### PR TITLE
Fixed "Deadlocked" state if certain files were not readable when listing importable files

### DIFF
--- a/playground/src/tools/FileTools.h
+++ b/playground/src/tools/FileTools.h
@@ -42,20 +42,25 @@ namespace FileTools
 
     while (it != fs::recursive_directory_iterator())
     {
-			try {
-				Glib::ustring name(it->path().string());
-				DebugLevel::warning(__FILE__, name);
-				if (fs::is_directory(it->path()) && name.find("/.") != Glib::ustring::npos) {
-					DebugLevel::warning(__FILE__, name);
-					it.disable_recursion_pending();
-				} else if (!fs::is_directory(it->path()) && !filter(*it)) {
-					list.emplace_back(*it);
-				}
-			} catch(Glib::Error err) {
-				DebugLevel::error(err.what(), err.code());
-			} catch (...) {
-				DebugLevel::error("non Glib::Error while traversing Thumbdrive!");
-			}
+	try 
+	{
+		Glib::ustring name(it->path().string());
+		DebugLevel::warning(__FILE__, name);
+		if (fs::is_directory(it->path()) && name.find("/.") != Glib::ustring::npos) 
+		{
+			DebugLevel::warning(__FILE__, name);
+			it.disable_recursion_pending();
+		} else if (!fs::is_directory(it->path()) && !filter(*it)) 
+		{
+			list.emplace_back(*it);
+		}
+	} catch(Glib::Error err) 
+	{
+		DebugLevel::error(err.what(), err.code());
+	} catch (...) 
+	{
+		DebugLevel::error("non Glib::Error while traversing Thumbdrive!");
+	}
       ++it;
     }
 

--- a/playground/src/tools/FileTools.h
+++ b/playground/src/tools/FileTools.h
@@ -42,17 +42,20 @@ namespace FileTools
 
     while (it != fs::recursive_directory_iterator())
     {
-      Glib::ustring name(it->path().string());
-      DebugLevel::warning(__FILE__, name);
-      if (fs::is_directory(it->path()) && name.find("/.") != Glib::ustring::npos)
-      {
-        DebugLevel::warning(__FILE__, name);
-        it.disable_recursion_pending();
-      }
-      else if (!fs::is_directory(it->path()) && !filter(*it))
-      {
-        list.emplace_back(*it);
-      }
+			try {
+				Glib::ustring name(it->path().string());
+				DebugLevel::warning(__FILE__, name);
+				if (fs::is_directory(it->path()) && name.find("/.") != Glib::ustring::npos) {
+					DebugLevel::warning(__FILE__, name);
+					it.disable_recursion_pending();
+				} else if (!fs::is_directory(it->path()) && !filter(*it)) {
+					list.emplace_back(*it);
+				}
+			} catch(Glib::Error err) {
+				DebugLevel::error(err.what(), err.code());
+			} catch (...) {
+				DebugLevel::error("non Glib::Error while traversing Thumbdrive!");
+			}
       ++it;
     }
 

--- a/playground/src/xml/FileOutStream.cpp
+++ b/playground/src/xml/FileOutStream.cpp
@@ -95,8 +95,12 @@ void FileOutStream::commit ()
 
     auto oldName = getTmpFileName ();
 
-    if (g_rename (oldName.c_str (), m_filename.c_str ()))
-      DebugLevel::error ("FileOutStream: Could not rename tmp file", oldName, "to target file", m_filename, ":", g_strerror (errno));
+    if (g_rename (oldName.c_str (), m_filename.c_str ())) {
+      DebugLevel::error("FileOutStream: Could not rename tmp file", oldName, "to target file", m_filename, ":",
+                        g_strerror(errno), " trying with backup option! (FileTools::rename)");
+
+      FileTools::rename(oldName, m_filename);
+    }
   }
 }
 

--- a/playground/src/xml/FileOutStream.cpp
+++ b/playground/src/xml/FileOutStream.cpp
@@ -95,7 +95,8 @@ void FileOutStream::commit ()
 
     auto oldName = getTmpFileName ();
 
-    if (g_rename (oldName.c_str (), m_filename.c_str ())) {
+    if (g_rename (oldName.c_str (), m_filename.c_str ())) 
+    {
       DebugLevel::error("FileOutStream: Could not rename tmp file", oldName, "to target file", m_filename, ":",
                         g_strerror(errno), " trying with backup option! (FileTools::rename)");
 


### PR DESCRIPTION
GLib could throw an exception which was not caught. Resulting in a not responding UI. 
Fixed with catching the exception and ignoring said file.