### PR TITLE
fixed apparent typo

### DIFF
--- a/playground/src/clipboard/Clipboard.cpp
+++ b/playground/src/clipboard/Clipboard.cpp
@@ -269,7 +269,7 @@ void Clipboard::pastePresetOnPreset (const Glib::ustring &presetUuid)
   {
     if (auto targetBank = targetPreset->getBank ())
     {
-      auto scope = getUndoScope ().startTransaction ("Paste Bank");
+      auto scope = getUndoScope ().startTransaction ("Paste Preset");
       auto transaction = scope->getTransaction ();
 
       auto insertPos = targetBank->getPresetPosition (presetUuid) + 1;


### PR DESCRIPTION
Paste Preset now creates correctly named transaction