### PR TITLE
feature-make-about-textinputfieldarea-different-color-because-it-is-not-allowed-to-be-edited-and-it-gives-a-wrong-impression-that-it-might-be

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/setup/AboutList.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/setup/AboutList.java
@@ -20,10 +20,8 @@ public class AboutList extends OverlayControl {
 
 	@Override
 	public void draw(Context2d ctx, int invalidationMask) {
-		getPixRect().drawRoundedArea(ctx, Millimeter.toPixels(1), Millimeter.toPixels(0.25), new Gray(19),
-				Gray.floatingWindowHeaderBorder());
 
-		Rect r = getPixRect().getReducedBy(Millimeter.toPixels(2));
+		Rect r = getPixRect();
 
 		double lineHeight = Millimeter.toPixels(4);
 		double fontHeight = lineHeight * 0.8;


### PR DESCRIPTION
removed the broder around the text so that it appears more better and nicer for the eyes and the brain because that helps understand its not editable but read only

name says it all. pretty self explanatory 