### PR TITLE
is mustn't a word? Changed Click behaviour for presets in maps

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
@@ -212,11 +212,22 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 			invalidate(INVALIDATION_FLAG_UI_CHANGED);
 			return this;
 		}
+		
+		if (isInStoreSelectMode())
+			return this;
 
+		if (isInMultiplePresetSelectionMode())
+			return this;
+
+		wasSelectedAtMouseDown = isSelected();
+
+		if (!wasSelectedAtMouseDown)
+			selectPreset();
+		
 		if (wasSelectedAtMouseDown) {
 			load();
 		}
-
+		
 		return this;
 	}
 
@@ -243,22 +254,6 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 
 		}
 		invalidate(INVALIDATION_FLAG_UI_CHANGED);
-	}
-
-	@Override
-	public Control mouseDown(Position eventPoint) {
-		if (isInStoreSelectMode())
-			return this;
-
-		if (isInMultiplePresetSelectionMode())
-			return this;
-
-		wasSelectedAtMouseDown = isSelected();
-
-		if (!wasSelectedAtMouseDown)
-			selectPreset();
-
-		return this;
 	}
 
 	private boolean isInMultiplePresetSelectionMode() {

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
@@ -200,34 +200,19 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 
 	@Override
 	public Control click(Position point) {
-		if (isInStoreSelectMode()) {
+		wasSelectedAtMouseDown = isSelected();
+		
+		if (isInStoreSelectMode() || !wasSelectedAtMouseDown) {
 			selectPreset();
-			return this;
 		} else if (isInMultiplePresetSelectionMode()) {
 			getParent().getParent().getMultiSelection().toggle(this);
 			invalidate(INVALIDATION_FLAG_UI_CHANGED);
-			return this;
 		} else if (NonMaps.get().getNonLinearWorld().isShiftDown()) {
 			getParent().getParent().startMultiSelection(this);
 			invalidate(INVALIDATION_FLAG_UI_CHANGED);
-			return this;
-		}
-		
-		if (isInStoreSelectMode())
-			return this;
-
-		if (isInMultiplePresetSelectionMode())
-			return this;
-
-		wasSelectedAtMouseDown = isSelected();
-
-		if (!wasSelectedAtMouseDown)
-			selectPreset();
-		
-		if (wasSelectedAtMouseDown) {
+		} else if(wasSelectedAtMouseDown) {
 			load();
-		}
-		
+		}		
 		return this;
 	}
 

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
@@ -41,9 +41,6 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 
 	private FilterState filterSate = FilterState.NO_FILTER;
 
-	private boolean wasSelectedAtMouseDown = false;
-	private boolean mouseCaptured = false;
-
 	public Preset(Bank parent) {
 		super(parent);
 
@@ -157,7 +154,7 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 				colorFill = new RGB(77, 77, 77);
 		}
 
-		if (mouseCaptured)
+		if (isDraggingControl())
 			colorFill = colorFill.brighter(40);
 
 		Rect r = getPixRect().copy();
@@ -200,9 +197,7 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 
 	@Override
 	public Control click(Position point) {
-		wasSelectedAtMouseDown = isSelected();
-		
-		if (isInStoreSelectMode() || !wasSelectedAtMouseDown) {
+		if (isInStoreSelectMode() || !isSelected()) {
 			selectPreset();
 		} else if (isInMultiplePresetSelectionMode()) {
 			getParent().getParent().getMultiSelection().toggle(this);
@@ -210,9 +205,9 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 		} else if (NonMaps.get().getNonLinearWorld().isShiftDown()) {
 			getParent().getParent().startMultiSelection(this);
 			invalidate(INVALIDATION_FLAG_UI_CHANGED);
-		} else if(wasSelectedAtMouseDown) {
+		} else if (isSelected()) {
 			load();
-		}		
+		}
 		return this;
 	}
 
@@ -316,16 +311,6 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 	@Override
 	public double getXMargin() {
 		return 3;
-	}
-
-	public void onMouseLost() {
-		mouseCaptured = false;
-		invalidate(INVALIDATION_FLAG_UI_CHANGED);
-	}
-
-	public void onMouseCaptured() {
-		mouseCaptured = true;
-		invalidate(INVALIDATION_FLAG_UI_CHANGED);
 	}
 
 	public void select() {


### PR DESCRIPTION
moved selecting out of mouse down into click that a dragged preset mustn't be selected while being dragged, that helps with moving from one bank into a different bank in the belt