### PR TITLE
1) drag start should respect the 'old' mouse position - where draggin…

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/Header.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/Header.java
@@ -205,9 +205,9 @@ public class Header extends Label {
 
 		for (Bank bank : getBanksThatMoveWhenMovingBank(getParent())) {
 			if (bank == getParent()) {
-				ret = getNonMaps().getNonLinearWorld().getViewport().getOverlay().addDragProxy(bank, bank.getPixRect().getPosition());
+				ret = getNonMaps().getNonLinearWorld().getViewport().getOverlay().addDragProxy(bank);
 			} else {
-				getNonMaps().getNonLinearWorld().getViewport().getOverlay().addDragProxy(bank, bank.getPixRect().getPosition());
+				getNonMaps().getNonLinearWorld().getViewport().getOverlay().addDragProxy(bank);
 			}
 		}
 

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/preset/Preset.java
@@ -246,13 +246,18 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 	}
 
 	@Override
+	public Control mouseDown(Position eventPoint) {
+		return this;
+	}
+
+	@Override
 	public Control startDragging(Position pos) {
 		if (getNonMaps().getNonLinearWorld().getViewport().getOverlay().getSetup().getPresetDragDropSetting().isEnabled()) {
 			if (isInMultiplePresetSelectionMode()) {
 				return startMultipleSelectionDrag(pos);
 			}
 
-			return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(this, getPixRect().getPosition());
+			return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(this);
 		}
 
 		return super.startDragging(pos);
@@ -274,7 +279,7 @@ public class Preset extends LayoutResizingHorizontal implements Renameable, IPre
 		for (String uuid : selection.getSelectedPresets()) {
 			Preset p = pm.findPreset(uuid);
 			if (p != null) {
-				DragProxy a = world.getViewport().getOverlay().addDragProxy(p, p.getPixRect().getPosition());
+				DragProxy a = world.getViewport().getOverlay().addDragProxy(p);
 				if (p == this)
 					ret = a;
 

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/settings/SetupHeader.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/settings/SetupHeader.java
@@ -57,7 +57,7 @@ class SetupHeader extends Label {
 
 	@Override
 	public Control startDragging(Position pos) {
-		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(getParent(), getPixRect().getPosition());
+		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(getParent());
 	}
 
 	@Override

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/DragProxy.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/DragProxy.java
@@ -46,12 +46,11 @@ public class DragProxy extends OverlayControl {
 	AutoScrollDirection currentAutoScrollDirection = AutoScrollDirection.None;
 	private DragProxy triggeredProxy;
 
-	public DragProxy(Overlay parent, Control origin, Position point) {
+	public DragProxy(Overlay parent, Control origin) {
 		super(parent);
 		this.origin = origin;
 
-		getRelativePosition().getPosition().set(point);
-		getRelativePosition().getDimension().set(origin.getPixRect().getDimension());
+		getRelativePosition().set(origin.getPixRect());
 	}
 
 	@Override

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/Overlay.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/Overlay.java
@@ -46,7 +46,7 @@ public class Overlay extends OverlayLayout {
 		// has to be the last one to add as it refers to previously added
 		// members
 		addChild(globalMenu = new GlobalMenu(this));
-		
+
 		compareDialogs = new ArrayList<CompareDialog>();
 	}
 
@@ -221,13 +221,13 @@ public class Overlay extends OverlayLayout {
 		return ColorTable.getColorIndicator();
 	}
 
-	public DragProxy createDragProxy(Control origin, Position point) {
+	public DragProxy createDragProxy(Control origin) {
 		removeDragProxies();
-		return addDragProxy(origin, point);
+		return addDragProxy(origin);
 	}
 
-	public DragProxy addDragProxy(Control origin, Position point) {
-		return addChild(new DragProxy(this, origin, point));
+	public DragProxy addDragProxy(Control origin) {
+		return addChild(new DragProxy(this, origin));
 	}
 
 	boolean removeDragProxies() {
@@ -418,11 +418,11 @@ public class Overlay extends OverlayLayout {
 	public void addCompareDialog(CompareDialog d) {
 		compareDialogs.add(d);
 	}
-	
+
 	public void removeCompareDialog(CompareDialog d) {
 		compareDialogs.remove(d);
 	}
-	
+
 	public List<CompareDialog> getCompareDialogs() {
 		return compareDialogs;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/presets/BeltPreset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/presets/BeltPreset.java
@@ -127,7 +127,7 @@ public class BeltPreset extends OverlayLayout implements IPreset {
 
 	@Override
 	public Control startDragging(Position pos) {
-		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(this, getPixRect().getPosition());
+		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(this);
 	}
 
 	@Override

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/presets/StorePreset.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/presets/StorePreset.java
@@ -80,7 +80,7 @@ class StorePreset extends SVGImage {
 
 	@Override
 	public Control startDragging(Position eventPoint) {
-		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(getPhase(1), getPixRect().getPosition());
+		return getNonMaps().getNonLinearWorld().getViewport().getOverlay().createDragProxy(getPhase(1));
 	}
 
 	@Override

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/Drag.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/Drag.java
@@ -5,18 +5,28 @@ import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class Drag extends Gesture implements Gesture.NeedsFocus, Gesture.HasPosition {
 
-	private Position pos;
+	private Position to;
+	private Position from;
 	private boolean fine = false;
 
-	public Drag(Gesture predecessor, Position to, boolean fine) {
+	public Drag(Gesture predecessor, Position from, Position to, boolean fine) {
 		super(predecessor);
-		this.pos = to.copy();
+		this.from = from;
+		this.to = to.copy();
 		this.fine = fine;
 	}
 
 	@Override
 	public Position getPosition() {
-		return pos;
+		return to;
+	}
+
+	public Position getStartPosition() {
+		return from;
+	}
+
+	public Position getEndPosition() {
+		return to;
 	}
 
 	@Override

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDown.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDown.java
@@ -18,7 +18,7 @@ class LeftDown extends Down {
 	@Override
 	public Gesture move(boolean fine) {
 		if (getDistance(getPosition(), PointerState.get().getPosition()) > getDragHysteresis())
-			return new LeftDragStart(this, PointerState.get().getPosition(), fine);
+			return new LeftDragStart(this, getPosition(), PointerState.get().getPosition(), fine);
 
 		return this;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDrag.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDrag.java
@@ -4,8 +4,8 @@ import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class LeftDrag extends Drag {
 
-	LeftDrag(Gesture predecessor, Position to, boolean fine) {
-		super(predecessor, to, fine);
+	LeftDrag(Gesture predecessor, Position from, Position to, boolean fine) {
+		super(predecessor, from, to, fine);
 	}
 
 	@Override
@@ -15,7 +15,7 @@ class LeftDrag extends Drag {
 
 	@Override
 	public Gesture move(boolean fine) {
-		return new LeftDrag(this, PointerState.get().getPosition(), fine);
+		return new LeftDrag(this, getPosition(), PointerState.get().getPosition(), fine);
 	}
 
 }

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDragStart.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftDragStart.java
@@ -5,13 +5,13 @@ import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class LeftDragStart extends LeftDrag {
 
-	LeftDragStart(Gesture predecessor, Position to, boolean fine) {
-		super(predecessor, to, fine);
+	LeftDragStart(Gesture predecessor, Position from, Position to, boolean fine) {
+		super(predecessor, from, to, fine);
 	}
 
 	@Override
 	public Control applyTo(Control receiver) {
-		Control ret = receiver.startDragging(getPosition());
+		Control ret = receiver.startDragging(getStartPosition());
 
 		if (ret != null) {
 			setReceiver(receiver);

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftLongPress.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/LeftLongPress.java
@@ -16,7 +16,7 @@ class LeftLongPress extends LongPress {
 	@Override
 	public Gesture move(boolean fine) {
 		if (getDistance(getPosition(), PointerState.get().getPosition()) > getDragHysteresis())
-			return new LeftDragStart(this, PointerState.get().getPosition(), fine);
+			return new LeftDragStart(this, getPosition(), PointerState.get().getPosition(), fine);
 
 		return this;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDown.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDown.java
@@ -16,7 +16,7 @@ class RightDown extends Down {
 	public Gesture move(boolean fine) {
 
 		if (getDistance(getPosition(), PointerState.get().getPosition()) > getDragHysteresis())
-			return new RightDragStart(this, PointerState.get().getPosition(), fine);
+			return new RightDragStart(this, getPosition(), PointerState.get().getPosition(), fine);
 
 		return this;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDrag.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDrag.java
@@ -4,8 +4,8 @@ import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class RightDrag extends Drag implements Gesture.NeedsFocus, Gesture.HasPosition {
 
-	RightDrag(Gesture predecessor, Position to, boolean fine) {
-		super(predecessor, to, fine);
+	RightDrag(Gesture predecessor, Position from, Position to, boolean fine) {
+		super(predecessor, from, to, fine);
 	}
 
 	@Override
@@ -15,7 +15,7 @@ class RightDrag extends Drag implements Gesture.NeedsFocus, Gesture.HasPosition 
 
 	@Override
 	public Gesture move(boolean fine) {
-		return new RightDrag(this, PointerState.get().getPosition(), fine);
+		return new RightDrag(this, getPosition(), PointerState.get().getPosition(), fine);
 	}
 
 }

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDragStart.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightDragStart.java
@@ -5,13 +5,13 @@ import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class RightDragStart extends RightDrag {
 
-	RightDragStart(Gesture predecessor, Position to, boolean fine) {
-		super(predecessor, to, fine);
+	RightDragStart(Gesture predecessor, Position from, Position to, boolean fine) {
+		super(predecessor, from, to, fine);
 	}
 
 	@Override
 	public Control applyTo(Control receiver) {
-		Control ret = receiver.startDragging(getPosition());
+		Control ret = receiver.startDragging(getStartPosition());
 
 		if (ret != null) {
 			setReceiver(receiver);

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightLongPress.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/RightLongPress.java
@@ -16,7 +16,7 @@ class RightLongPress extends LongPress {
 	@Override
 	public Gesture move(boolean fine) {
 		if (getDistance(getPosition(), PointerState.get().getPosition()) > getDragHysteresis())
-			return new RightDragStart(this, PointerState.get().getPosition(), fine);
+			return new RightDragStart(this, getPosition(), PointerState.get().getPosition(), fine);
 
 		return this;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchDown.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchDown.java
@@ -33,7 +33,7 @@ class TouchDown extends Down {
 	public Gesture onTouchMove(JsArray<Touch> touches) {
 		if (touches.length() == 1) {
 			if (getDistance(this.touches.get(0), new Position(touches.get(0))) > Millimeter.toPixels(5)) {
-				return new TouchMoveStart(this, touches);
+				return new TouchMoveStart(this, this.touches.get(0), touches);
 			}
 
 			return this;

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchLongPress.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchLongPress.java
@@ -21,7 +21,7 @@ class TouchLongPress extends LongPress {
 	@Override
 	public Gesture onTouchMove(JsArray<Touch> touches) {
 		if (getDistance(getPosition(), PointerState.get().getPosition()) > getDragHysteresis())
-			return new TouchMoveStart(this, touches);
+			return new TouchMoveStart(this, getPosition(), touches);
 
 		return this;
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchMove.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchMove.java
@@ -13,8 +13,8 @@ class TouchMove extends Drag implements NeedsFocus, HasPosition {
 
 	private ArrayList<Position> touches;
 
-	TouchMove(Gesture predecessor, JsArray<Touch> touches) {
-		super(predecessor, new Position(touches.get(0)), false);
+	TouchMove(Gesture predecessor, Position from, JsArray<Touch> touches) {
+		super(predecessor, from, new Position(touches.get(0)), false);
 		this.touches = new ArrayList<Position>();
 
 		for (int i = 0; i < touches.length(); i++) {
@@ -31,7 +31,7 @@ class TouchMove extends Drag implements NeedsFocus, HasPosition {
 	@Override
 	public Gesture onTouchMove(JsArray<Touch> touches) {
 		if (touches.length() == 1) {
-			return new TouchMove(this, touches);
+			return new TouchMove(this, getPosition(), touches);
 		} else if (touches.length() == 2) {
 			return new TouchPinchStart(this, touches);
 		}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchMoveStart.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchMoveStart.java
@@ -5,13 +5,14 @@ import com.google.gwt.dom.client.Touch;
 import com.google.gwt.user.client.Timer;
 import com.nonlinearlabs.NonMaps.client.NonMaps;
 import com.nonlinearlabs.NonMaps.client.world.Control;
+import com.nonlinearlabs.NonMaps.client.world.Position;
 
 class TouchMoveStart extends TouchMove {
 
 	private Timer longPressTimer;
 
-	TouchMoveStart(Gesture predecessor, JsArray<Touch> touches) {
-		super(predecessor, touches);
+	TouchMoveStart(Gesture predecessor, Position from, JsArray<Touch> touches) {
+		super(predecessor, from, touches);
 
 		NonMaps.theMaps.captureMouse();
 
@@ -25,7 +26,7 @@ class TouchMoveStart extends TouchMove {
 
 	@Override
 	public Gesture onTouchMove(JsArray<Touch> touches) {
-		return new TouchMove(this, touches);
+		return new TouchMove(this, getPosition(), touches);
 	}
 
 	public Gesture onLongPress() {
@@ -42,7 +43,7 @@ class TouchMoveStart extends TouchMove {
 
 	@Override
 	public Control applyTo(Control receiver) {
-		Control ret = receiver.startDragging(getPosition());
+		Control ret = receiver.startDragging(getStartPosition());
 
 		if (ret != null) {
 			setReceiver(receiver);

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchPinch.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/pointer/TouchPinch.java
@@ -30,7 +30,7 @@ public class TouchPinch extends Gesture implements HasPosition {
 	@Override
 	public Gesture onTouchMove(JsArray<Touch> touches) {
 		if (touches.length() == 1) {
-			return new TouchMoveStart(this, touches);
+			return new TouchMoveStart(this, getPosition(), touches);
 		} else if (touches.length() == 2) {
 			return new TouchPinch(this, touches);
 		}


### PR DESCRIPTION
…g actually started

2) creating a drag proxy is not interested in mouse position, just always use origins pix rect
3) Preset::mouseDown() has to return 'this' so mouse gets captured and succeeding mouse events will arrive at according preset