### PR TITLE
introduce 'overlay' for enum settings that report a value on Setting:…

### DIFF
--- a/playground/src/device-settings/EnumSetting.h
+++ b/playground/src/device-settings/EnumSetting.h
@@ -37,6 +37,9 @@ template<typename TEnum>
 
       tEnum get () const
       {
+        if(auto overlay = m_overlay.lock())
+          return *overlay;
+
         return m_mode;
       }
 
@@ -93,10 +96,18 @@ template<typename TEnum>
       virtual const vector<Glib::ustring> &enumToString () const = 0;
       virtual const vector<Glib::ustring> &enumToDisplayString () const = 0;
 
+      std::shared_ptr<tEnum> scopedOverlay(tEnum value)
+      {
+        auto ret = std::make_shared<tEnum>(value);
+        m_overlay = ret;
+        return ret;
+      }
+
     private:
       EnumSetting (const EnumSetting& other);
       EnumSetting& operator= (const EnumSetting&);
 
       tEnum m_mode;
+      std::weak_ptr<tEnum> m_overlay;
   };
 

--- a/playground/src/presets/PresetManagerActions.cpp
+++ b/playground/src/presets/PresetManagerActions.cpp
@@ -19,6 +19,8 @@
 #include <xml/XmlWriter.h>
 #include <boost/algorithm/string.hpp>
 #include <tools/StringTools.h>
+#include <device-settings/Settings.h>
+#include <device-settings/AutoLoadSelectedPreset.h>
 
 PresetManagerActions::PresetManagerActions(PresetManager &presetManager) :
     RPCActionManager("/presets/"),
@@ -150,7 +152,10 @@ PresetManagerActions::PresetManagerActions(PresetManager &presetManager) :
 
       if(auto preset = m_presetManager.findPreset(editBuffer->getUuid()))
       {
+        auto scopedLock = Application::get().getSettings()->getSetting<AutoLoadSelectedPreset>()->scopedOverlay(BooleanSettings::BOOLEAN_SETTING_FALSE);
         editBuffer->undoableSetLoadedPresetInfo(transaction, preset.get());
+        preset->undoableSelect(transaction);
+        presetManager.undoableSelectBank(transaction, preset->getBank()->getUuid());
       }
 
       editBuffer->sendToLPC();


### PR DESCRIPTION
…:get as long as the returned object lives