### PR TITLE
the 'setup' call after setting focus and mode ist just useless.

### DIFF
--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
@@ -234,8 +234,6 @@ bool PresetManagerLayout::onButton(int i, bool down, ButtonModifiers modifiers)
           hwui->undoableSetFocusAndMode(UIMode::Select);
         else
           hwui->undoableSetFocusAndMode(UIMode::Edit);
-
-        setup();
         break;
 
       case BUTTON_PRESET:

--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.cpp
@@ -10,6 +10,7 @@ AnyParameterLockedIndicator::AnyParameterLockedIndicator(const Rect &pos) :
     m_calcHasLocks(1, std::bind(&AnyParameterLockedIndicator::calcHasLocks, this))
 {
   setFontColor (FrameBuffer::C43);
+  setVisible(false);
   Application::get().getPresetManager()->getEditBuffer()->onLocksChanged(sigc::mem_fun(this, &AnyParameterLockedIndicator::update));
   update();
 }


### PR DESCRIPTION
The initial state of the locked-label should be invisible.