### PR TITLE
take 'original' hash from preset, not from editbuffer. So, a locked g…

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/parameters/ParameterEditor.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/parameters/ParameterEditor.java
@@ -45,8 +45,6 @@ public class ParameterEditor extends LayoutResizingVertical {
 	private String loadedPreset = "";
 	private PlayControls playControls;
 	private boolean m_isModified = false;
-	private PlayControlsArea playControlsArea;
-	private SynthParameters synthParamsArea;
 	private static ParameterEditor theEditor = null;
 	private HashMap<String, String> attributes = new HashMap<String, String>();
 	private String hash = "";
@@ -194,10 +192,10 @@ public class ParameterEditor extends LayoutResizingVertical {
 			}
 		});
 
-		playControlsArea = addChild(new PlayControlsArea(this));
+		addChild(new PlayControlsArea(this));
 		addChild(new SpacerLarge(this));
 		addChild(new SpacerLarge(this));
-		synthParamsArea = addChild(new SynthParameters(this));
+		addChild(new SynthParameters(this));
 	}
 
 	public Control onKey(final KeyDownEvent event) {

--- a/playground/src/presets/EditBuffer.cpp
+++ b/playground/src/presets/EditBuffer.cpp
@@ -38,7 +38,13 @@ EditBuffer::~EditBuffer()
 
 void EditBuffer::resetModifiedIndicator(UNDO::Scope::tTransactionPtr transaction)
 {
-  auto swap = UNDO::createSwapData(false, getHash());
+  resetModifiedIndicator(transaction, getHash());
+
+}
+
+void EditBuffer::resetModifiedIndicator(UNDO::Scope::tTransactionPtr transaction, size_t hash)
+{
+  auto swap = UNDO::createSwapData(false, hash);
 
   transaction->addSimpleCommand([=](UNDO::Command::State)
   {
@@ -317,13 +323,13 @@ void EditBuffer::undoableLoad(UNDO::Scope::tTransactionPtr transaction, shared_p
   }
 
   lpc->toggleSuppressParameterChanges(transaction);
-  resetModifiedIndicator(transaction);
+  resetModifiedIndicator(transaction, preset->getHash());
 }
 
 void EditBuffer::copyFrom(UNDO::Scope::tTransactionPtr transaction, Preset *other, bool ignoreUUIDs)
 {
   super::copyFrom(transaction, other, ignoreUUIDs);
-  resetModifiedIndicator(transaction);
+  resetModifiedIndicator(transaction, other->getHash());
 }
 
 void EditBuffer::undoableSetLoadedPresetInfo(UNDO::Scope::tTransactionPtr transaction, Preset *preset)

--- a/playground/src/presets/EditBuffer.h
+++ b/playground/src/presets/EditBuffer.h
@@ -48,6 +48,8 @@ class EditBuffer : public Preset
     const PresetManager *getParent () const;
 
     void resetModifiedIndicator (UNDO::Scope::tTransactionPtr transaction);
+    void resetModifiedIndicator(UNDO::Scope::tTransactionPtr transaction, size_t hash);
+
     virtual void copyFrom (UNDO::Scope::tTransactionPtr transaction, Preset *other, bool ignoreUUIDs) override;
 
     virtual tUpdateID onChange (uint64_t flags = UpdateDocumentContributor::ChangeFlags::Generic) override;


### PR DESCRIPTION
…roup will

always result in a 'star' indicating that the preset != editbuffer