### PR TITLE
Big Pedal Changes

### DIFF
--- a/playground/src/parameters/PedalParameter.cpp
+++ b/playground/src/parameters/PedalParameter.cpp
@@ -276,7 +276,7 @@ void PedalParameter::loadDefault(UNDO::Scope::tTransactionPtr transaction)
 }
 
 void PedalParameter::loadFromPreset (UNDO::Scope::tTransactionPtr transaction, const tControlPositionValue &value) {
-  setCpValue(transaction, Initiator::INDIRECT, value, true);
+  setCpValue(transaction, Initiator::EXPLICIT_OTHER, value, true);
 }
 
 

--- a/playground/src/parameters/PedalParameter.cpp
+++ b/playground/src/parameters/PedalParameter.cpp
@@ -275,6 +275,11 @@ void PedalParameter::loadDefault(UNDO::Scope::tTransactionPtr transaction)
   undoableSetPedalMode(transaction, PedalModes::STAY);
 }
 
+void PedalParameter::loadFromPreset (UNDO::Scope::tTransactionPtr transaction, const tControlPositionValue &value) {
+  setCpValue(transaction, Initiator::INDIRECT, value, true);
+}
+
+
 size_t PedalParameter::getHash() const
 {
   size_t hash = super::getHash();

--- a/playground/src/parameters/PedalParameter.h
+++ b/playground/src/parameters/PedalParameter.h
@@ -27,6 +27,7 @@ class PedalParameter : public PhysicalControlParameter
     virtual ReturnMode getReturnMode() const override;
     virtual void copyFrom (UNDO::Scope::tTransactionPtr transaction, Parameter * other) override;
     virtual void loadDefault (UNDO::Scope::tTransactionPtr transaction) override;
+    virtual void loadFromPreset (UNDO::Scope::tTransactionPtr transaction, const tControlPositionValue &value) override;
 
     shared_ptr<PedalType> getAssociatedPedalTypeSetting() const;
 


### PR DESCRIPTION
HW Pedal Values are being overwritten by presetload -> saved positon is being loaded now

that also fixes:
Bug: Pedal und Ribbon wirken auf denselben MC, Pedal bewegen (Ribbon zeigt neue Position), Preset neu aufrufen, Undo drücken: Ribbon-Position ist falsch, weil unverändert.