### PR TITLE
Prameter to Store no longer "swallows" Store UIFocus

### DIFF
--- a/playground/src/proxies/hwui/HWUI.cpp
+++ b/playground/src/proxies/hwui/HWUI.cpp
@@ -516,14 +516,9 @@ FocusAndMode HWUI::restrictFocusAndMode(FocusAndMode in) const
   bool switchFromParameterToPresetManager = (isCurrentParameter && isDesiredPresetManager);
   bool switchFromPresetManagerToParameter = (isCurrentPresetManager && isDesiredParameter);
 
-  if(switchFromParameterToPresetManager || switchFromPresetManagerToParameter)
-  {
+  if(switchFromPresetManagerToParameter)
     if(m_focusAndMode.mode == UIMode::Edit)
-    {
-      // ticket: BOLED: "Edit"-Mode (immer) beenden, wenn zwischen  Preset/Bank-Screen und Parameter-Screen gewechselt wird.
       in.mode = UIMode::Select;
-    }
-  }
 
   if(isDesiredPresetManager)
     if(in.mode == UIMode::Store && Application::get().getPresetManager()->getNumBanks() == 0)

--- a/playground/src/proxies/hwui/HWUI.cpp
+++ b/playground/src/proxies/hwui/HWUI.cpp
@@ -513,7 +513,6 @@ FocusAndMode HWUI::restrictFocusAndMode(FocusAndMode in) const
   bool isCurrentParameter = (m_focusAndMode.focus == UIFocus::Parameters);
   bool isDesiredParameter = (in.focus == UIFocus::Parameters);
 
-  bool switchFromParameterToPresetManager = (isCurrentParameter && isDesiredPresetManager);
   bool switchFromPresetManagerToParameter = (isCurrentPresetManager && isDesiredParameter);
 
   if(switchFromPresetManagerToParameter)


### PR DESCRIPTION
changed logic in HWUI to meet the 2 criteria: bank to Parameter -> remove Edit and Parameter to Store -> keep Store Focus