### PR TITLE
added functionality to insert bank in clusters

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/ServerProxy.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/ServerProxy.java
@@ -510,7 +510,14 @@ public class ServerProxy {
 		return n.getAttributes().getNamedItem("changed").getNodeValue().equals("1");
 	}
 
-	public interface DownloadHandler {
+    public void insertBankInCluster(Bank other, Orientation orientation, Bank parent) {
+		StaticURI.Path path = new StaticURI.Path("presets", "banks", "insert-bank-in-cluster");
+		StaticURI uri = new StaticURI(path, new StaticURI.KeyValue("bank-to-insert", other.getUUID()), new StaticURI.KeyValue("bank-inserted-at",
+				parent.getUUID()), new StaticURI.KeyValue("orientation", orientation.name()));
+		queueJob(uri, false);
+    }
+
+    public interface DownloadHandler {
 		void onFileDownloaded(String text);
 
 		void onError();

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/Bank.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/Bank.java
@@ -63,6 +63,7 @@ public class Bank extends LayoutResizingVertical implements Renameable, IBank {
 	}
 
 	private Tape tapes[] = new Tape[4];
+	private InsertTape insertTapes[] = new InsertTape[4];
 	private PresetList presetList = null;
 
 	public Bank(PresetManager parent, String uuid) {
@@ -76,11 +77,30 @@ public class Bank extends LayoutResizingVertical implements Renameable, IBank {
 		tapes[Tape.Orientation.South.ordinal()] = addChild(new Tape(this, Tape.Orientation.South));
 		tapes[Tape.Orientation.East.ordinal()] = addChild(new Tape(this, Tape.Orientation.East));
 		tapes[Tape.Orientation.West.ordinal()] = addChild(new Tape(this, Tape.Orientation.West));
+		insertTapes[Orientation.North.ordinal()] = addChild(new InsertTape(this, Orientation.North));
+		insertTapes[Orientation.South.ordinal()] = addChild(new InsertTape(this, Orientation.South));
+		insertTapes[Orientation.East.ordinal()] = addChild(new InsertTape(this, Orientation.East));
+		insertTapes[Orientation.West.ordinal()] = addChild(new InsertTape(this, Orientation.West));
+
+	}
+
+	public boolean hasSlaveInDirection(Orientation orientation) {
+		switch(orientation) {
+			case North:
+				return getMasterTop() != null;
+			case South:
+				return getBottomSlave() != null;
+			case East:
+				return getRightSlave() != null;
+			case West:
+				return getMasterLeft() != null;
+		}
+		return false;
 	}
 
 	@Override
 	public boolean skipChildOnLayout(MapsControl c) {
-		return c instanceof Tape;
+		return c instanceof Tape || c instanceof InsertTape;
 	}
 
 	public Tape getTape(Tape.Orientation o) {
@@ -103,16 +123,24 @@ public class Bank extends LayoutResizingVertical implements Renameable, IBank {
 		}
 
 		getTape(Tape.Orientation.North).setNonSize(new NonDimension(oldDim.getWidth(), tapeWidth));
-		getTape(Tape.Orientation.North).moveTo(new NonPosition(tapeWidth, 0));
-
 		getTape(Tape.Orientation.South).setNonSize(new NonDimension(oldDim.getWidth(), tapeWidth));
-		getTape(Tape.Orientation.South).moveTo(new NonPosition(tapeWidth, oldDim.getHeight() + tapeWidth));
-
 		getTape(Tape.Orientation.West).setNonSize(new NonDimension(tapeWidth, oldDim.getHeight()));
-		getTape(Tape.Orientation.West).moveTo(new NonPosition(0, tapeWidth));
-
 		getTape(Tape.Orientation.East).setNonSize(new NonDimension(tapeWidth, oldDim.getHeight()));
+
+		getTape(Tape.Orientation.North).moveTo(new NonPosition(tapeWidth, 0));
+		getTape(Tape.Orientation.South).moveTo(new NonPosition(tapeWidth, oldDim.getHeight() + tapeWidth));
+		getTape(Tape.Orientation.West).moveTo(new NonPosition(0, tapeWidth));
 		getTape(Tape.Orientation.East).moveTo(new NonPosition(oldDim.getWidth() + tapeWidth, tapeWidth));
+
+		insertTapes[Orientation.North.ordinal()].setNonSize(new NonDimension(oldDim.getWidth(), tapeWidth * 1.05));
+		insertTapes[Orientation.South.ordinal()].setNonSize(new NonDimension(oldDim.getWidth(), tapeWidth * 1.05));
+		insertTapes[Orientation.East.ordinal()].setNonSize(new NonDimension(tapeWidth * 1.05, oldDim.getHeight()));
+		insertTapes[Orientation.West.ordinal()].setNonSize(new NonDimension(tapeWidth * 1.05, oldDim.getHeight()));
+
+		insertTapes[Orientation.North.ordinal()].moveTo(new NonPosition(tapeWidth, 0));
+		insertTapes[Orientation.South.ordinal()].moveTo(new NonPosition(tapeWidth, oldDim.getHeight() + tapeWidth));
+		insertTapes[Orientation.East.ordinal()].moveTo(new NonPosition(oldDim.getWidth() + tapeWidth, tapeWidth));
+		insertTapes[Orientation.West.ordinal()].moveTo(new NonPosition(0, tapeWidth));
 
 		setNonSize(oldDim.getWidth() + tapeWidth * 2, oldDim.getHeight() + tapeWidth * 2);
 	}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/InsertTape.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/maps/presets/bank/InsertTape.java
@@ -1,0 +1,124 @@
+package com.nonlinearlabs.NonMaps.client.world.maps.presets.bank;
+
+import com.google.gwt.canvas.dom.client.Context2d;
+import com.nonlinearlabs.NonMaps.client.NonMaps;
+import com.nonlinearlabs.NonMaps.client.world.*;
+import com.nonlinearlabs.NonMaps.client.world.maps.MapsControl;
+import com.nonlinearlabs.NonMaps.client.world.maps.NonDimension;
+import com.nonlinearlabs.NonMaps.client.world.maps.presets.PresetManager;
+import com.nonlinearlabs.NonMaps.client.world.overlay.DragProxy;
+import com.nonlinearlabs.NonMaps.client.world.overlay.Overlay;
+
+public class InsertTape extends MapsControl {
+
+
+    private boolean inserting;
+    private Bank prospectBank;
+    private Tape.Orientation orientation;
+
+    public InsertTape(Bank parent, Tape.Orientation orientation) {
+        super(parent);
+        this.setOrientation(orientation);
+    }
+
+    @Override
+    public void doFirstLayoutPass(double levelOfDetail) {
+
+    }
+
+    @Override
+    public Bank getParent() {
+        return (Bank) super.getParent();
+    }
+
+    @Override
+    public boolean isVisible() {
+
+        Overlay o = getNonMaps().getNonLinearWorld().getViewport().getOverlay();
+
+        for (DragProxy d : o.getDragProxies()) {
+            Control r = d.getCurrentReceiver();
+            if (r != null) {
+                if (r instanceof PresetManager || r instanceof InsertTape || r instanceof Tape) {
+                    return getParent().hasSlaveInDirection(getOrientation());
+                }
+            }
+        }
+
+        return false;
+
+    }
+
+    public Tape.Orientation getOrientation() {
+        return orientation;
+    }
+
+    public void setOrientation(Tape.Orientation orientation) {
+        this.orientation = orientation;
+    }
+
+    @Override
+    public void draw(Context2d ctx, int invalidationMask) {
+        super.draw(ctx, invalidationMask);
+        if(inserting)
+            getPixRect().fill(ctx, new RGB(250, 250, 250));
+        else
+            getPixRect().fill(ctx, new RGB(130,130,130));
+
+        setShouldInsert(null, false);
+    }
+
+    public boolean fitsTo(Bank other) {
+        if (getParent().isClusteredWith(other))
+            return false;
+
+        if (!isVisible())
+            return false;
+
+        return other.isVisible();
+    }
+
+    private void setShouldInsert(Bank b, boolean insert) {
+        prospectBank = b;
+        inserting = insert;
+    }
+
+    private boolean shouldInsert(Bank b) {
+        return b == prospectBank && inserting;
+    }
+
+    @Override
+    public Control drag(Rect pos, DragProxy dragProxy) {
+        if (isVisible() && !getParent().isDraggingControl()) {
+            if (dragProxy.getOrigin() instanceof Bank) {
+                Bank other = (Bank) dragProxy.getOrigin();
+                Position mouse = dragProxy.getMousePosition();
+
+                if(getPixRect().contains(mouse)) {
+                    if (getParent() != other) {
+                        if (fitsTo(other)) {
+                            //Display attaching!
+                            setShouldInsert(other, true);
+                            return this;
+                        }
+                    }
+                }
+                setShouldInsert(other, false);
+            }
+        }
+        return super.drag(pos, dragProxy);
+    }
+
+    @Override
+    public Control drop(Position pos, DragProxy dragProxy) {
+        if (dragProxy.getOrigin() instanceof Bank) {
+            Bank other = (Bank) dragProxy.getOrigin();
+            if(shouldInsert(other)) {
+                NonMaps.get().getServerProxy().insertBankInCluster(other, orientation, this.getParent());
+                requestLayout();
+            }
+            return this;
+        }
+        return super.drop(pos, dragProxy);
+    }
+}

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/DragProxy.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/DragProxy.java
@@ -21,7 +21,13 @@ import com.nonlinearlabs.NonMaps.client.world.Rect;
 
 public class DragProxy extends OverlayControl {
 
-	class FoundControl {
+	private Position lastMousePos;
+
+    public Position getMousePosition() {
+    	return lastMousePos;
+    }
+
+    class FoundControl {
 		public FoundControl(DragProxy proxy, Control ctrl, int ranking) {
 			this.proxy = proxy;
 			this.ctrl = ctrl;
@@ -108,6 +114,7 @@ public class DragProxy extends OverlayControl {
 
 	@Override
 	public Control mouseDrag(Position oldPoint, final Position newPoint, boolean fine) {
+		lastMousePos = newPoint;
 		doAutoScrolling(newPoint);
 
 		double xDiff = newPoint.getX() - oldPoint.getX();

--- a/playground/src/presets/BankActions.cpp
+++ b/playground/src/presets/BankActions.cpp
@@ -885,6 +885,18 @@ BankActions::BankActions(PresetManager &presetManager) :
     }
   });
 
+  addAction("insert-bank-in-cluster", [&](shared_ptr<NetworkRequest> request)mutable {
+      const auto insertedUUID = request->get("bank-to-insert");
+      const auto insertedAtUUID = request->get("bank-inserted-at");
+      const auto orientation = request->get("orientation");
+
+      if(auto bankToInsert = m_presetManager.findBank(insertedUUID)) {
+          if(auto bankAtInsertPosition = m_presetManager.findBank(insertedAtUUID)) {
+              insertBankInCluster(bankToInsert, bankAtInsertPosition, orientation);
+          }
+      }
+  });
+
   addAction("dock-banks",
       [&] (shared_ptr<NetworkRequest> request) mutable
       {
@@ -1149,4 +1161,34 @@ Glib::ustring BankActions::guessNameBasedOnEditBuffer() const
     return m_presetManager.createPresetNameBasedOn (ebName);
 
   return ebName;
+}
+
+void BankActions::insertBankInCluster(BankActions::tBankPtr bankToInsert, BankActions::tBankPtr bankAtInsert,
+                                      const ustring directionSeenFromBankInCluster) {
+    auto scope = m_presetManager.getUndoScope().startTransaction("Insert Bank %0 into Cluster", bankToInsert->getName(true));
+    auto transaction = scope->getTransaction();
+    if(directionSeenFromBankInCluster == "North") {
+        if(auto topMaster = bankAtInsert->getMasterTop()) {
+            bankToInsert->undoableAttachBank(transaction, topMaster->getUuid(), PresetBank::AttachmentDirection::top);
+        }
+        bankAtInsert->undoableAttachBank(transaction, bankToInsert->getUuid(), PresetBank::AttachmentDirection::top);
+    }
+    else if(directionSeenFromBankInCluster == "South") {
+        if(auto bottomSlave = bankAtInsert->getSlaveBottom()) {
+            bottomSlave->undoableAttachBank(transaction, bankToInsert->getUuid(), PresetBank::AttachmentDirection::top);
+        }
+        bankToInsert->undoableAttachBank(transaction, bankAtInsert->getUuid(), PresetBank::AttachmentDirection::top);
+    }
+    else if(directionSeenFromBankInCluster == "East") {
+        if(auto rightSlave = bankAtInsert->getSlaveRight()) {
+            rightSlave->undoableAttachBank(transaction, bankToInsert->getUuid(), PresetBank::AttachmentDirection::left);
+        }
+        bankToInsert->undoableAttachBank(transaction, bankAtInsert->getUuid(), PresetBank::AttachmentDirection::left);
+    }
+    else if(directionSeenFromBankInCluster == "West") {
+        if(auto leftMaster = bankAtInsert->getMasterLeft()) {
+            bankToInsert->undoableAttachBank(transaction, leftMaster->getUuid(), PresetBank::AttachmentDirection::left);
+        }
+        bankAtInsert->undoableAttachBank(transaction, bankToInsert->getUuid(), PresetBank::AttachmentDirection::left);
+    }
 }

--- a/playground/src/presets/BankActions.h
+++ b/playground/src/presets/BankActions.h
@@ -30,5 +30,7 @@ class BankActions : public RPCActionManager
     Glib::ustring guessNameBasedOnEditBuffer() const;
 
     PresetManager &m_presetManager;
+
+    void insertBankInCluster(tBankPtr bankToInsert, tBankPtr bankAtInsert, const ustring directionSeenFromBankInCluster);
 };
 

--- a/playground/src/presets/PresetBank.cpp
+++ b/playground/src/presets/PresetBank.cpp
@@ -946,3 +946,35 @@ PresetBank *PresetBank::getClusterMaster()
 
   return this;
 }
+
+PresetBank *PresetBank::getMasterTop() {
+    if(getAttached().direction == AttachmentDirection::top) {
+        return getParent()->findBank(getAttached().uuid).get();
+    }
+    return nullptr;
+}
+
+PresetBank *PresetBank::getMasterLeft() {
+    if(getAttached().direction == AttachmentDirection::left) {
+        return getParent()->findBank(getAttached().uuid).get();
+    }
+    return nullptr;
+}
+
+PresetBank *PresetBank::getSlaveRight() {
+    for(auto bank: getParent()->getBanks()) {
+        if(auto masterLeft = bank->getMasterLeft())
+            if(masterLeft == this)
+                return bank.get();
+    }
+    return nullptr;
+}
+
+PresetBank *PresetBank::getSlaveBottom() {
+    for(auto bank: getParent()->getBanks()) {
+        if(auto masterLeft = bank->getMasterTop())
+            if(masterLeft == this)
+                return bank.get();
+    }
+    return nullptr;
+}

--- a/playground/src/presets/PresetBank.h
+++ b/playground/src/presets/PresetBank.h
@@ -112,6 +112,10 @@ class PresetBank : public UpdateDocumentContributor,
     bool resolveCyclicAttachments(std::vector<PresetBank*> stackedBanks, UNDO::Scope::tTransactionPtr transaction);
 
     PresetBank *getClusterMaster();
+    PresetBank *getMasterTop();
+    PresetBank *getMasterLeft();
+    PresetBank *getSlaveRight();
+    PresetBank *getSlaveBottom();
 
     virtual tUpdateID onChange(uint64_t flags = UpdateDocumentContributor::ChangeFlags::Generic) override;
 


### PR DESCRIPTION
We have a problem making this feature look good. Because we still snap to the (way too fine) grid, banks are in weird positions if clustered. That would call for a more sophisticated algorithm to determine the width and height of "InsertTapes".