### PR TITLE
Add systemd services as part of the project

### DIFF
--- a/NonMaps/CMakeLists.txt
+++ b/NonMaps/CMakeLists.txt
@@ -8,9 +8,9 @@ set(OBJDIR ${CMAKE_CURRENT_BINARY_DIR}/obj)
 set(ONLINEHELPDIR ${NONMAPS_ROOT}/online-help)
 set(OUTFILE ${CMAKE_CURRENT_BINARY_DIR}/war/nonmaps/compilation-mappings.txt)
 
-file(GLOB_RECURSE SOURCE_FILES 
+file(GLOB_RECURSE SOURCE_FILES
   ${NONMAPS_ROOT}/src/*.java)
-  
+
 file (GLOB IMAGES ${NONMAPS_ROOT}/src/com/nonlinearlabs/NonMaps/client/world/overlay/images/*)
 file (COPY ${IMAGES} DESTINATION ./war/images)
 
@@ -25,42 +25,42 @@ add_custom_command(OUTPUT ${OUTFILE}
 add_custom_target(NonMaps ALL
   SOURCES ${OUTFILE}
   )
-  
+
 file(WRITE ${OBJDIR}/nonmaps-version.txt ${PLAYGROUND_VERSION})
-  
+
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/war
-  DESTINATION NonMaps
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps
   )
 
 install(DIRECTORY ${NONMAPS_ROOT}/war
-  DESTINATION NonMaps
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps
   )
 
 install(DIRECTORY ${NONMAPS_ROOT}/src/war
-  DESTINATION NonMaps
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps
   )
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/war/nonmaps
-  DESTINATION NonMaps/war
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps/war
   )
 
 install(DIRECTORY ${ONLINEHELPDIR}
-  DESTINATION NonMaps/war
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps/war
   )
 
 install(FILES ${IMAGES}
-  DESTINATION NonMaps/war/images
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps/war/images
   )
-  
+
 install(FILES ${MAPS_IMAGES}
-  DESTINATION NonMaps/war/images
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps/war/images
   )
 
 install(DIRECTORY war
-  DESTINATION NonMaps
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps
   )
-  
+
 install(FILES ${OBJDIR}/nonmaps-version.txt
-  DESTINATION NonMaps/war
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/NonMaps/war
   )
 

--- a/bbbb/CMakeLists.txt
+++ b/bbbb/CMakeLists.txt
@@ -37,9 +37,13 @@ IF(DEV_PC)
   set(LIBS ${LIBS} gtkmm-3.0 gdkmm-3.0)
 ENDIF(DEV_PC)
 
+IF(NOT DEFINED SYSTEMD_CONFIGURATION_FILES_DIR)
+  set(SYSTEMD_CONFIGURATION_FILES_DIR "${CMAKE_INSTALL_PREFIX}/etc/systemd/system")
+ENDIF()
+
 function(addLib name)
   pkg_check_modules(${name} REQUIRED ${name})
-  include_directories(${${name}_INCLUDE_DIRS}) 
+  include_directories(${${name}_INCLUDE_DIRS})
   link_directories(${${name}_LIBRARY_DIRS})
 endfunction(addLib)
 
@@ -53,7 +57,7 @@ endforeach(lib)
 include_directories(src)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wdouble-promotion")
-  
+
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
     IF(DEV_PC)
         ELSE()
@@ -74,8 +78,15 @@ foreach(lib ${LIBS})
   linkLib(${lib})
 endforeach(lib)
 
+configure_file(${PROJECT_SOURCE_DIR}/systemd/bbbb.service.in
+	${PROJECT_BINARY_DIR}/systemd/bbbb.service @ONLY)
+
+install(FILES ${PROJECT_BINARY_DIR}/systemd/bbbb.service
+  DESTINATION ${SYSTEMD_CONFIGURATION_FILES_DIR} COMPONENT init
+  )
+
 install(TARGETS bbbb
-  DESTINATION ./
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground
   )
 
 ADD_CUSTOM_TARGET(

--- a/bbbb/systemd/bbbb.service.in
+++ b/bbbb/systemd/bbbb.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nonlinear-Labs BeagleBoneBlackBridge
+After=syslog.target network.target systemd-modules-load.service
+
+[Service]
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/nonlinear/playground/bbbb
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ ${HOST_DIR}/usr/bin/cmake \
 	-DBUILD_TESTING=OFF \
 	-DBUILD_SHARED_LIBS=ON \
 	-DCMAKE_BUILD_TYPE=Release \
-	-DCMAKE_INSTALL_PREFIX="${TARGET_DIR}/nonlinear/playground" \
+	-DCMAKE_INSTALL_PREFIX="${TARGET_DIR}" \
 	-DJARSDIR="${GWT_COMPILER_DIR}" \
 	.. && \
 make -j8 && \

--- a/playground/CMakeLists.txt
+++ b/playground/CMakeLists.txt
@@ -13,7 +13,7 @@ set(LIBS
   avahi-gobject
   avahi-core
   avahi-client
-  freetype2 
+  freetype2
   )
 
 OPTION(DEV_PC
@@ -24,6 +24,9 @@ OPTION(PROFILING
   "Enable built in profiler"
   OFF)
 
+IF(NOT DEFINED SYSTEMD_CONFIGURATION_FILES_DIR)
+  set(SYSTEMD_CONFIGURATION_FILES_DIR "${CMAKE_INSTALL_PREFIX}/etc/systemd/system")
+ENDIF()
 
 IF(DEV_PC)
   ADD_DEFINITIONS(-D_DEVELOPMENT_PC -D_TESTS)
@@ -37,7 +40,7 @@ ENDIF(PROFILING)
 
 function(addLib name)
   pkg_check_modules(${name} REQUIRED ${name})
-  include_directories(${${name}_INCLUDE_DIRS}) 
+  include_directories(${${name}_INCLUDE_DIRS})
   link_directories(${${name}_LIBRARY_DIRS})
 endfunction(addLib)
 
@@ -58,8 +61,8 @@ ADD_CUSTOM_TARGET(
 	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_SOURCE_DIR}/src/device-info/SoftwareVersion.cpp
 )
 
-file(GLOB_RECURSE SOURCE_FILES src/*.cpp) 
-  
+file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
+
 add_executable(playground ${SOURCE_FILES})
 
 TARGET_LINK_LIBRARIES(playground pthread)
@@ -128,24 +131,32 @@ set_property(
   "-DHEAD_REF=\"${HEAD_REF}\" -DCOMMIT_COUNT=\"${COMMIT_COUNT}\" -DBRANCH_NAME=\"${BRANCH_NAME}\" -DLAST_COMMIT_TIME=\"${PLAYGROUND_VERSION}\""
 )
 
+configure_file(${CMAKE_SOURCE_DIR}/playground/systemd/playground.service.in
+	${PROJECT_BINARY_DIR}/systemd/playground.service @ONLY
+	)
+
 file(GLOB PARAMETER_DESCRIPTIONS src/parameters/descriptions/*.txt)
 file(GLOB VERSION_INFOS resources/version-infos/*)
 
+install(FILES ${PROJECT_BINARY_DIR}/systemd/playground.service
+  DESTINATION ${SYSTEMD_CONFIGURATION_FILES_DIR} COMPONENT init
+  )
+
 install(FILES ${PARAMETER_DESCRIPTIONS}
-  DESTINATION resources/parameter-descriptions
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/resources/parameter-descriptions
   )
 
 install(FILES ${VERSION_INFOS}
-        DESTINATION resources/version-infos
-        )
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground/resources/version-infos
+  )
 
 install(DIRECTORY resources
   USE_SOURCE_PERMISSIONS
-  DESTINATION ./
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground
   )
 
 install(TARGETS playground
-  DESTINATION ./
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/nonlinear/playground
   )
 
 ADD_CUSTOM_TARGET(

--- a/playground/systemd/playground.service.in
+++ b/playground/systemd/playground.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nonlinear-Labs Playground
+After=syslog.target network.target systemd-modules-load.service
+
+[Service]
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/nonlinear/playground/playground
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/playground/systemd/playground.service.in
+++ b/playground/systemd/playground.service.in
@@ -3,7 +3,7 @@ Description=Nonlinear-Labs Playground
 After=syslog.target network.target systemd-modules-load.service
 
 [Service]
-ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/nonlinear/playground/playground
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/nonlinear/playground/playground --bbbb=192.168.8.2
 Restart=on-failure
 RestartSec=1
 


### PR DESCRIPTION
Systemd services belong to the project and not to the build environment.

This adds all necessary changes in order to have *.service files installed
with the project. Also installation target nonlinear/playground is part
of the project, rather than set by a command line argument.

Removed some unnecessary whitespaces.