### PR TITLE
Fix export

### DIFF
--- a/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
@@ -72,13 +72,13 @@ void ExportBackupEditor::exportBanks ()
 {
   Application::get ().stopWatchDog ();
   writeBackupFileXML ();
-  const auto humanDate = StringTools::replaceAll(
+  const auto humanDate = StringTools::replaceAll(StringTools::replaceAll(
           std::to_string(
                   TimeTools::getDisplayStringFromStamp(
                           std::chrono::duration_cast<std::chrono::seconds>(
                                   std::chrono::system_clock::now().time_since_epoch()
                           ).count())
-          ), " ", "-");
+          ), " ", "-"), ":", "-");
 
   auto targetNameWithStamp(std::string("/mnt/usb-stick/") + humanDate.c_str() + c_backupTargetFile);
 

--- a/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
@@ -12,8 +12,11 @@
 #include <tools/SpawnCommandLine.h>
 #include <tools/TimeTools.h>
 #include <algorithm>
+#include <experimental/filesystem>
 #include <tools/StringTools.h>
 #include "USBStickAvailableView.h"
+#include <device-settings/DebugLevel.h>
+#include <experimental/bits/fs_ops.h>
 
 static const Rect c_fullRightSidePosition (129, 16, 126, 48);
 static constexpr const char c_tempBackupFile[] = "/nonlinear/nonlinear-c15-banks.xml.tar.gz";
@@ -23,7 +26,7 @@ ExportBackupEditor::ExportBackupEditor () :
     ControlWithChildren (Rect (0, 0, 0, 0))
 {
   if (USBStickAvailableView::usbIsReady())
-  installState (Initial);
+    installState (Initial);
   else
     installState (NotReady);
 }
@@ -69,17 +72,25 @@ void ExportBackupEditor::exportBanks ()
 {
   Application::get ().stopWatchDog ();
   writeBackupFileXML ();
-
-  auto timeStamp = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-
-  auto humanDate = std::to_string(TimeTools::getDisplayStringFromStamp(timeStamp));
-
-  humanDate = StringTools::replaceAll(humanDate, " ", "-");
+  const auto humanDate = StringTools::replaceAll(
+          std::to_string(
+                  TimeTools::getDisplayStringFromStamp(
+                          std::chrono::duration_cast<std::chrono::seconds>(
+                                  std::chrono::system_clock::now().time_since_epoch()
+                          ).count())
+          ), " ", "-");
 
   auto targetNameWithStamp(std::string("/mnt/usb-stick/") + humanDate.c_str() + c_backupTargetFile);
 
-  auto moveCommand(std::string("mv ") + c_tempBackupFile + " " + targetNameWithStamp);
-  SpawnCommandLine cmd(moveCommand);
+  auto from = std::experimental::filesystem::path(c_tempBackupFile);
+  auto to = std::experimental::filesystem::path(targetNameWithStamp.c_str());
+
+  try {
+    std::experimental::filesystem::copy(from, to);
+    std::experimental::filesystem::remove(from);
+  } catch (std::experimental::filesystem::filesystem_error& e) {
+    std::cout << e.what() << '\n';
+  }
 
   Application::get ().runWatchDog ();
   installState (Finished);


### PR DESCRIPTION
Changed resulting filename because std::fs::copy has a problem with any ':' in filename. 
removed Homegrown solution for moving file and replaced by std::filesystem
it copies and removes original file because it has to do work across different file systems.  

FIXES: #237 