### PR TITLE
For the upcomming yocto builds, we need to change the filename

### DIFF
--- a/playground/src/device-settings/HostAPDSetting.cpp
+++ b/playground/src/device-settings/HostAPDSetting.cpp
@@ -14,7 +14,7 @@
 #if _DEVELOPMENT_PC
 static const char *c_fileName = "/home/hhoegelo/development/nl/playground/hostapd.conf";
 #else
-static const char *c_fileName = "/etc/hostapd.conf";
+static const char *c_fileName = "/etc/hostapd.nonlinear.conf";
 #endif
 
 HostAPDSetting::HostAPDSetting (Settings &parent, const std::string &pattern) :


### PR DESCRIPTION
For yocto builds:

hostapd.conf -> hostapt.nonlinear.conf