### PR TITLE
changed using getNumChilds to using the real number of items because …

### DIFF
--- a/playground/src/proxies/hwui/controls/ButtonMenu.cpp
+++ b/playground/src/proxies/hwui/controls/ButtonMenu.cpp
@@ -193,4 +193,8 @@ void ButtonMenu::setItemTitle(size_t i, const Glib::ustring &caption)
   }
 }
 
+const size_t ButtonMenu::getItemCount() const {
+  return m_items.size();
+}
+
 

--- a/playground/src/proxies/hwui/controls/ButtonMenu.h
+++ b/playground/src/proxies/hwui/controls/ButtonMenu.h
@@ -30,7 +30,7 @@ class ButtonMenu : public ControlWithChildren
   protected:
     void clearActions();
     void setItemTitle(size_t i, const Glib::ustring &caption);
-
+    const size_t getItemCount() const;
   private:
     void bruteForce ();
     size_t getItemToShowAtPlace(size_t place) const;

--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankEditButtonMenu.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankEditButtonMenu.cpp
@@ -245,7 +245,7 @@ void BankEditButtonMenu::moveRight()
 
 void BankEditButtonMenu::correctMenuSelection()
 {
-  if(s_lastSelectedButton >= getNumChildren())
+  if(s_lastSelectedButton >= getItemCount())
     s_lastSelectedButton = 0;
 }
 


### PR DESCRIPTION
…only 5 children would be present at any time in a button menu
#280 