### PR TITLE
Backup Proposals

### DIFF
--- a/playground/src/presets/PresetManagerActions.cpp
+++ b/playground/src/presets/PresetManagerActions.cpp
@@ -23,6 +23,7 @@
 #include <device-settings/AutoLoadSelectedPreset.h>
 #include <proxies/lpc/LPCProxy.h>
 #include <proxies/lpc/LPCParameterChangeSurpressor.h>
+#include <tools/TimeTools.h>
 
 PresetManagerActions::PresetManagerActions(PresetManager &presetManager) :
     RPCActionManager("/presets/"),
@@ -261,8 +262,12 @@ bool PresetManagerActions::handleRequest(const Glib::ustring &path, shared_ptr<N
       auto &boled = Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled();
       boled.setOverlay(new SplashLayout());
 
+
+      const auto time = TimeTools::getDisplayStringFromStamp(TimeTools::getAdjustedTimestamp());
+      const auto timeWithoutWhitespaces = StringTools::replaceAll(time, " ", "-");
+      const auto timeSanitized = StringTools::replaceAll(timeWithoutWhitespaces, ":", "-");
       auto stream = request->createStream("application/zip", true);
-      httpRequest->setHeader("Content-Disposition", "attachment; filename=\"nonlinear-c15-banks.xml.tar.gz\"");
+      httpRequest->setHeader("Content-Disposition", "attachment; filename=\""+ timeSanitized +"-nonlinear-c15-banks.xml.tar.gz\"");
       XmlWriter writer(stream);
       auto pm = Application::get().getPresetManager();
       PresetManagerSerializer serializer(*pm.get());

--- a/playground/src/proxies/hwui/panel-unit/boled/setup/ImportBackupEditor.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/setup/ImportBackupEditor.cpp
@@ -89,7 +89,7 @@ bool ImportBackupEditor::filterApplicableFileNames(std::experimental::filesystem
 {
   auto fileName = term.path().filename().string();
   string endA = ".xml.zip";
-  string endB = ".tar.gz";
+  string endB = ".xml.tar.gz";
   return !(std::equal(endA.rbegin(), endA.rend(), fileName.rbegin()) ||  std::equal(endB.rbegin(), endB.rend(), fileName.rbegin()));
 }
 

--- a/playground/src/proxies/hwui/panel-unit/boled/setup/ImportBackupEditor.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/setup/ImportBackupEditor.cpp
@@ -89,7 +89,7 @@ bool ImportBackupEditor::filterApplicableFileNames(std::experimental::filesystem
 {
   auto fileName = term.path().filename().string();
   string endA = ".xml.zip";
-  string endB = ".xml.tar.gz";
+  string endB = ".tar.gz";
   return !(std::equal(endA.rbegin(), endA.rend(), fileName.rbegin()) ||  std::equal(endB.rbegin(), endB.rend(), fileName.rbegin()));
 }
 


### PR DESCRIPTION
to counter backup interchange problems I changed the name generation of webui-backups to include a sanitzed time string also changed boled backup filter to counter teh browser feature of adding a (1) or (2) to already downloaded files after .xml -> (.xml (1).tar.gz is a common file which is not found by boled backup) I believe that removing the .xml qualifier will not hurt the robustness of the feature but add more value to the user by easing the backup process

adresses both points made in #278 