### PR TITLE
subscribed lockedindicator to locks changed signal

### DIFF
--- a/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/LockedIndicator.h
+++ b/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/LockedIndicator.h
@@ -20,7 +20,8 @@ class LockedIndicator : public Label
     virtual int getFontHeight () const override;
 
     void onParameterSelected (Parameter * newOne);
-    void onParameterGroupChanged ();
+
+  virtual void onParameterGroupChanged ();
 
     sigc::connection m_groupConnection;
 };

--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.cpp
@@ -7,14 +7,11 @@
 
 AnyParameterLockedIndicator::AnyParameterLockedIndicator(const Rect &pos) : LockedIndicator(Rect(pos.getX(), pos.getY(), pos.getWidth(), pos.getHeight()))
 {
-}
+  Application::get().getPresetManager()->getEditBuffer()->onLocksChanged(
+      sigc::mem_fun(this, &AnyParameterLockedIndicator::onParameterGroupChanged)
+  );
 
-void AnyParameterLockedIndicator::onParameterSelected(Parameter * newOne)
-{
-    if(newOne) {
-        m_groupConnection.disconnect();
-        m_groupConnection = newOne->getParentGroup()->onGroupChanged(sigc::mem_fun(this, &AnyParameterLockedIndicator::onParameterGroupChanged));
-    }
+  onParameterGroupChanged();
 }
 
 void AnyParameterLockedIndicator::onParameterGroupChanged() {

--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.h
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AnyParameterLockedIndicator.h
@@ -10,15 +10,11 @@ class Parameter;
 class AnyParameterLockedIndicator : public LockedIndicator
 {
   public:
-    AnyParameterLockedIndicator (const Rect &pos);
-    virtual ~AnyParameterLockedIndicator () = default;
+  explicit AnyParameterLockedIndicator (const Rect &pos);
+
+  ~AnyParameterLockedIndicator () override = default;
 
   private:
-    void onParameterSelected(Parameter * newOne);
     void onParameterGroupChanged();
-
-
-    sigc::connection m_groupConnection;
-
 };
 


### PR DESCRIPTION
Fixes: Presetmanager lock symbol not showing locksymbol if last selected parameter was not locked, but some parameter was locked. 