### PR TITLE
fix preset file delete

### DIFF
--- a/playground/src/presets/PresetBank.cpp
+++ b/playground/src/presets/PresetBank.cpp
@@ -86,7 +86,9 @@ void PresetBank::deleteOldPresetFiles(RefPtr<Gio::File> bankFolder)
       {
         if(!getPreset(withoutExtension))
         {
-          bankFolder->get_child(withoutExtension)->remove();
+          auto presetFile = bankFolder->get_child(fileName);
+          if(presetFile)
+            presetFile->remove();
         }
       }
     }


### PR DESCRIPTION
now it does not crash anymore -> which led to deleting the bank
(Still dont think that behavior is acceptable (deleteting a bank if a error occurs) but i left it in)