### PR TITLE
Removed Undo::Recurse

### DIFF
--- a/playground/src/libundo/undo/Scope.cpp
+++ b/playground/src/libundo/undo/Scope.cpp
@@ -311,7 +311,7 @@ namespace UNDO
 
         writer.writeTextElement("redo", StringTools::buildString(getRedoTransaction().get()));
 
-        getRootTransaction()->recurse([&](const Transaction *p) mutable { p->writeDocument(writer, knownRevision); });
+        getRootTransaction()->traverse([&](const Transaction *p) mutable { p->writeDocument(writer, knownRevision); });
       });
     }
   }

--- a/playground/src/libundo/undo/Transaction.h
+++ b/playground/src/libundo/undo/Transaction.h
@@ -9,7 +9,7 @@ namespace UNDO
 {
   class Scope;
 
-  class Transaction : public Command, public UpdateDocumentContributor
+class Transaction : public Command, public UpdateDocumentContributor, public std::enable_shared_from_this<Transaction>
   {
    public:
     typedef std::shared_ptr<Transaction> tTransactionPtr;

--- a/playground/src/libundo/undo/Transaction.h
+++ b/playground/src/libundo/undo/Transaction.h
@@ -9,7 +9,7 @@ namespace UNDO
 {
   class Scope;
 
-class Transaction : public Command, public UpdateDocumentContributor, public std::enable_shared_from_this<Transaction>
+  class Transaction : public Command, public UpdateDocumentContributor, public std::enable_shared_from_this<Transaction>
   {
    public:
     typedef std::shared_ptr<Transaction> tTransactionPtr;
@@ -58,14 +58,15 @@ class Transaction : public Command, public UpdateDocumentContributor, public std
 
     void addPostfixCommand(ActionCommand::tAction doRedoUndo);
 
-    virtual void writeDocument(Writer &writer, tUpdateID knownRevision) const override;
+    void writeDocument(Writer &writer, tUpdateID knownRevision) const override;
 
-    void recurse(function<void(const Transaction *)> cb) const;
+    long traverseTree() const;
+    void traverse(function<void(const Transaction *)> cb) const;
 
    protected:
-    virtual void implDoAction() const override;
-    virtual void implUndoAction() const override;
-    virtual void implRedoAction() const override;
+    void implDoAction() const override;
+    void implUndoAction() const override;
+    void implRedoAction() const override;
 
     virtual void onImplUndoActionStart() const;
     virtual void onImplRedoActionFinished() const;

--- a/playground/src/libundo/undo/Transaction.h
+++ b/playground/src/libundo/undo/Transaction.h
@@ -9,7 +9,7 @@ namespace UNDO
 {
   class Scope;
 
-  class Transaction : public Command, public UpdateDocumentContributor, public std::enable_shared_from_this<Transaction>
+  class Transaction : public Command, public UpdateDocumentContributor
   {
    public:
     typedef std::shared_ptr<Transaction> tTransactionPtr;

--- a/playground/src/presets/PresetManager.h
+++ b/playground/src/presets/PresetManager.h
@@ -45,6 +45,7 @@ class PresetManager : public ContentSection
 
   void init();
   void stress(int numTransactions);
+  void stressBlocking(int numTransactions);
   void stressLoad(int numTransactions);
   void reload();
 

--- a/playground/src/proxies/hwui/HWUI.cpp
+++ b/playground/src/proxies/hwui/HWUI.cpp
@@ -158,9 +158,17 @@ void HWUI::onKeyboardLineRead(Glib::RefPtr<Gio::AsyncResult> &res)
         onButtonPressed(BUTTON_UNDO, false);
         onButtonPressed(BUTTON_REDO, false);
       }
-      else if(line == "stress-undo")
+      else if(line == "stress-undo-s")
       {
         Application::get().getPresetManager()->stress(1000);
+      }
+      else if(line == "stress-undo-m")
+      {
+        Application::get().getPresetManager()->stress(10000);
+      }
+      else if(line == "stress-undo-l")
+      {
+        Application::get().getPresetManager()->stress(100000);
       }
       else if(line == "stress-pm")
       {

--- a/playground/src/proxies/hwui/HWUI.cpp
+++ b/playground/src/proxies/hwui/HWUI.cpp
@@ -23,6 +23,7 @@
 #include <xml/FileOutStream.h>
 #include <groups/HardwareSourcesGroup.h>
 #include <io/network/WebSocketSession.h>
+#include <tools/PerformanceTimer.h>
 
 HWUI::HWUI()
     : m_blinkCount(0)
@@ -173,6 +174,25 @@ void HWUI::onKeyboardLineRead(Glib::RefPtr<Gio::AsyncResult> &res)
       else if(line == "stress-pm")
       {
         Application::get().getPresetManager()->stressLoad(1000);
+      }
+      else if(line == "undo-performance-compare")
+      {
+        Application::get().stopWatchDog();
+
+
+        for(int steps = 0; steps < 50; steps++) {
+          unsigned long long totalTraverse = 0;
+          long avgusTraverse = 0;
+          for(int i = 1; i < 101; i++)
+          {
+            auto traverse = Application::get().getPresetManager()->getUndoScope().getRootTransaction()->traverseTree();
+            totalTraverse += traverse;
+          }
+          avgusTraverse = static_cast<long>(totalTraverse / 100);
+          DebugLevel::warning("Count: ~",steps*1000,"Transactions Traverse avg:", avgusTraverse / 1000, "\bms");
+          Application::get().getPresetManager()->stressBlocking(1000);
+        }
+        Application::get().runWatchDog();
       }
       else if(line.at(0) == '!')
       {


### PR DESCRIPTION
Was used in "Write-document" to write all Undo Transactions.
Removed it with a Breadth-First algorithm that collects all child nodes while calling the callback on current node.
It is faster and does not crash at an tree size of around 66750 (on my machine) compared to the prior implementation.

Iterator Invalidation is not a problem as long as the vector does not change the order of elements.
I also played around with reserving the space needed but it was counter intuitive and made the runs slower that now.

Some Benchmarks:
![speed comparison _ match](https://user-images.githubusercontent.com/15381257/49447199-350e6d00-f7d6-11e8-9b6e-c299d3791119.png)
Data from when recurse crashed until I felt like it was enough:
![speed comparison _ all avail](https://user-images.githubusercontent.com/15381257/49447198-350e6d00-f7d6-11e8-949f-244d9f7c84ca.png)

The other Changes in Transaction are clang-tidy Warnings that i fixed.

#565 