### PR TITLE
Crash-Fix: removed doCallback in destructor of PresetListEntry 

### DIFF
--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AppendOverwriteInsertButtonMenu.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/AppendOverwriteInsertButtonMenu.cpp
@@ -56,7 +56,7 @@ size_t AppendOverwriteInsertButtonMenu::enumToIndex(PresetStoreModeSettings i) c
 bool AppendOverwriteInsertButtonMenu::animate()
 {
   return m_parent.animateSelectedPreset(
-      [=]() { Application::get().getHWUI()->undoableSetFocusAndMode(UIMode::Select); });
+      []() { Application::get().getHWUI()->undoableSetFocusAndMode(UIMode::Select); });
 }
 
 void AppendOverwriteInsertButtonMenu::executeAction()

--- a/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListEntry.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListEntry.cpp
@@ -24,7 +24,6 @@ PresetListEntry::PresetListEntry(const Rect &pos)
 
 PresetListEntry::~PresetListEntry()
 {
-  doAnimationCallback();
   m_animationConnection.disconnect();
   m_presetConnection.disconnect();
 }


### PR DESCRIPTION
removed callback (on animation finish) in destructor of PresetListEntry, prevents crash if layout is changed and object is in destruction

currently the only purpose of animation and the whole system is to display the "Schulz-🚆" now the callback will not be called if preset list goes out of scope before / while the animation is playing -> also that would not be the thing we want, because it only gets destructed if we change the focus, manually setting the focus to preset-edit is unwanted 
#568 