### PR TITLE
Enter on Preset always loads, no matter what the playground thinks about being modified or not

### DIFF
--- a/playground/src/presets/EditBuffer.cpp
+++ b/playground/src/presets/EditBuffer.cpp
@@ -290,24 +290,9 @@ void EditBuffer::undoableLoadSelectedPreset()
   {
     if(auto preset = bank->getPreset(bank->getSelectedPreset()))
     {
-      if(!isSelectedPresetLoadedAndUnModified())
-      {
-        undoableLoad(preset);
-      }
+      undoableLoad(preset);
     }
   }
-}
-
-bool EditBuffer::isSelectedPresetLoadedAndUnModified()
-{
-  if(auto bank = getParent()->getSelectedBank())
-  {
-    if(auto preset = bank->getPreset(bank->getSelectedPreset()))
-    {
-      return getUUIDOfLastLoadedPreset() == preset->getUuid() && !isModified();
-    }
-  }
-  return false;
 }
 
 void EditBuffer::undoableLoad(shared_ptr<Preset> preset)

--- a/playground/src/presets/EditBuffer.h
+++ b/playground/src/presets/EditBuffer.h
@@ -69,8 +69,8 @@ class EditBuffer : public Preset
   Glib::ustring exportReaktorPreset();
   bool isModified() const;
   void sendToLPC();
-  bool isSelectedPresetLoadedAndUnModified();
-  std::shared_ptr<Preset> getPreset() const;
+
+    std::shared_ptr<Preset> getPreset() const;
 
  private:
   Parameter *searchForAnyParameterWithLock() const;


### PR DESCRIPTION
removed check if selected Preset was Loaded and Not Modified, now it does not care about being modified
#586 