### PR TITLE
changed scaleconverter of hi-cut comb to use a different denominator …

### DIFF
--- a/playground/src/parameters/scale-converters/Linear40To140StScaleConverter.cpp
+++ b/playground/src/parameters/scale-converters/Linear40To140StScaleConverter.cpp
@@ -1,8 +1,8 @@
+#include <parameters/scale-converters/dimension/PitchDimensionCoarse.h>
 #include "Linear40To140StScaleConverter.h"
-#include "dimension/PitchDimension.h"
 
 Linear40To140StScaleConverter::Linear40To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(40, 140), PitchDimension::get())
+    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(40, 140), PitchDimensionCoarse::get())
 {
 }
 


### PR DESCRIPTION
…-> now using coarse to get rid of the verbose second number after the comma

#608 