### PR TITLE
Repaired Recall and Compare with Init-Sound

### DIFF
--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/ParameterCompareButton.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/ParameterCompareButton.java
@@ -18,7 +18,6 @@ public class ParameterCompareButton extends SVGImage {
 	
 	private boolean setupChange(int id) {
 		EditBufferModel.get().findParameter(id).value.onChange(e -> {
-			//inCompare = false;
 			return true;
 		});
 		return true;

--- a/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/ParameterCompareButton.java
+++ b/NonMaps/src/com/nonlinearlabs/NonMaps/client/world/overlay/belt/ParameterCompareButton.java
@@ -1,6 +1,5 @@
 package com.nonlinearlabs.NonMaps.client.world.overlay.belt;
 
-import com.nonlinearlabs.NonMaps.client.NonMaps;
 import com.nonlinearlabs.NonMaps.client.dataModel.editBuffer.EditBufferModel;
 import com.nonlinearlabs.NonMaps.client.world.Control;
 import com.nonlinearlabs.NonMaps.client.world.Position;
@@ -10,17 +9,6 @@ public class ParameterCompareButton extends SVGImage {
 
 	public ParameterCompareButton(Control parent) {
 		super(parent, "PreRecall_B_Enabled.svg", "PreRecall_B_Active.svg", "PreRecall_B_Disabled.svg");
-				
-		EditBufferModel.get().selectedParameter.onChange(id -> setupChange(id));
-		
-		setupChange(EditBufferModel.get().selectedParameter.getValue());
-	}
-	
-	private boolean setupChange(int id) {
-		EditBufferModel.get().findParameter(id).value.onChange(e -> {
-			return true;
-		});
-		return true;
 	}
 	
 	public static boolean inCompare = false;

--- a/playground/src/parameters/Parameter.cpp
+++ b/playground/src/parameters/Parameter.cpp
@@ -235,13 +235,11 @@ bool Parameter::isChangedFromLoaded() const
 
   if(auto originalParameter = getOriginalParameter())
   {
-    const auto rawOld = originalParameter->getValue();
-    return std::fabs(rawOld - rawNow) > epsilon;
+    return std::fabs(originalParameter->getValue() - rawNow) > epsilon;
   }
   else
   {
-    const auto rawOld = getDefaultValue();
-    return std::fabs(rawOld - rawNow) > epsilon;
+    return std::fabs(getDefaultValue() - rawNow) > epsilon;
   }
 }
 

--- a/playground/src/parameters/Parameter.cpp
+++ b/playground/src/parameters/Parameter.cpp
@@ -229,15 +229,20 @@ PresetParameter *Parameter::getOriginalParameter() const
 
 bool Parameter::isChangedFromLoaded() const
 {
+  const auto rawNow = getControlPositionValue();
+  const auto epsilon = 0.5 / getValue().getFineDenominator();
+  DebugLevel::warning("Using", epsilon, "as epsilon for Parameter::isChangedFromLoaded!", getLongName());
+
   if(auto originalParameter = getOriginalParameter())
   {
     const auto rawOld = originalParameter->getValue();
-    const auto rawNow = getControlPositionValue();
-    const auto epsilon = 0.5 / getValue().getFineDenominator();
-    DebugLevel::warning("Using", epsilon, "as epsilon for Parameter::isChangedFromLoaded!", getLongName());
     return std::fabs(rawOld - rawNow) > epsilon;
   }
-  return false;
+  else
+  {
+    const auto rawOld = getDefaultValue();
+    return std::fabs(rawOld - rawNow) > epsilon;
+  }
 }
 
 bool Parameter::isBiPolar() const
@@ -338,9 +343,9 @@ void Parameter::writeDocProperties(Writer &writer, tUpdateID knownRevision) cons
   writer.writeTextElement("default", to_string(m_value.getDefaultValue()));
 
   if(auto ogParam = getOriginalParameter())
-  {
     writer.writeTextElement("og-value", to_string(ogParam->getValue()));
-  }
+  else
+    writer.writeTextElement("og-value", to_string(getDefaultValue()));
 
   if(shouldWriteDocProperties(knownRevision))
   {
@@ -526,10 +531,12 @@ void Parameter::check()
 void Parameter::undoableRecallFromPreset()
 {
   auto &scope = Application::get().getPresetManager()->getUndoScope();
-  auto transactionScope = scope.startTransaction("Recall %0 value from Preset", getLongName());
+  auto original = getOriginalParameter();
+  auto origin = original ? "Preset" : "Init-Sound";
+  auto transactionScope = scope.startTransaction("Recall %0 value from %1", getLongName(), origin);
   auto transaction = transactionScope->getTransaction();
-  if(auto original = getOriginalParameter())
-  {
+  if(original)
     setCPFromHwui(transaction, original->getValue());
-  }
+  else
+    setDefaultFromHwui(transaction);
 }

--- a/playground/src/parameters/Parameter.cpp
+++ b/playground/src/parameters/Parameter.cpp
@@ -231,7 +231,7 @@ bool Parameter::isChangedFromLoaded() const
 {
   const auto rawNow = getControlPositionValue();
   const auto epsilon = 0.5 / getValue().getFineDenominator();
-  DebugLevel::warning("Using", epsilon, "as epsilon for Parameter::isChangedFromLoaded!", getLongName());
+  DebugLevel::gassy("Using", epsilon, "as epsilon for Parameter::isChangedFromLoaded!", getLongName());
 
   if(auto originalParameter = getOriginalParameter())
   {

--- a/playground/src/presets/EditBuffer.cpp
+++ b/playground/src/presets/EditBuffer.cpp
@@ -420,6 +420,7 @@ void EditBuffer::undoableInitSound(UNDO::Transaction *transaction)
 
   setName(transaction, "Init Sound");
   transaction->addSimpleCommand(sendEditBuffer, UNDO::ActionCommand::tAction());
+
 }
 
 void EditBuffer::undoableSetDefaultValues(UNDO::Transaction *transaction, Preset *other)

--- a/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
+++ b/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
@@ -246,23 +246,23 @@ ParameterRecallLayout2::ParameterRecallLayout2()
 
   if(auto p = getCurrentParameter())
   {
-    if(auto originalParam = p->getOriginalParameter())
-    {
-      if(p->getVisualizationStyle() == Parameter::VisualizationStyle::Dot)
-        m_slider = addControl(new StaticKnubbelSlider(originalParam->getValue(), p->isBiPolar(),
-                                                      Rect(BIG_SLIDER_X, 24, BIG_SLIDER_WIDTH, 6)));
-      else
-        m_slider = addControl(new StaticBarSlider(originalParam->getValue(), p->isBiPolar(),
-                                                  Rect(BIG_SLIDER_X, 24, BIG_SLIDER_WIDTH, 6)));
+    auto originalParam = p->getOriginalParameter();
+    auto originalValue = originalParam ? originalParam->getValue() : p->getDefaultValue();
 
-      m_leftValue = addControl(new Label(p->getDisplayString(), Rect(67, 35, 58, 11)));
+    if(p->getVisualizationStyle() == Parameter::VisualizationStyle::Dot)
+      m_slider = addControl(
+          new StaticKnubbelSlider(originalValue, p->isBiPolar(), Rect(BIG_SLIDER_X, 24, BIG_SLIDER_WIDTH, 6)));
+    else
+      m_slider
+          = addControl(new StaticBarSlider(originalValue, p->isBiPolar(), Rect(BIG_SLIDER_X, 24, BIG_SLIDER_WIDTH, 6)));
 
-      auto sc = p->getValue().getScaleConverter();
-      auto displayValue = sc->controlPositionToDisplay(originalParam->getValue());
-      auto displayString = sc->getDimension().stringize(displayValue);
+    m_leftValue = addControl(new Label(p->getDisplayString(), Rect(67, 35, 58, 11)));
 
-      m_rightValue = addControl(new Label(displayString, Rect(131, 35, 58, 11)));
-    }
+    auto sc = p->getValue().getScaleConverter();
+    auto displayValue = sc->controlPositionToDisplay(originalValue);
+    auto displayString = sc->getDimension().stringize(displayValue);
+
+    m_rightValue = addControl(new Label(displayString, Rect(131, 35, 58, 11)));
   }
 
   m_recallValue = getCurrentParameter()->getControlPositionValue();
@@ -347,31 +347,30 @@ void ParameterRecallLayout2::updateUI(bool paramLikeInPreset)
 
   if(auto p = getCurrentParameter())
   {
-    if(auto originalParam = p->getOriginalParameter())
+    if(paramLikeInPreset)
     {
-      if(paramLikeInPreset)
-      {
-        m_leftValue->setText(p->getDisplayString());
-        m_rightValue->setText(m_recallString);
-        m_slider->setValue(p->getControlPositionValue(), p->isBiPolar());
-        m_rightValue->setHighlight(false);
-        m_leftValue->setHighlight(true);
-        m_buttonB->setText("");
-        m_buttonC->setText("Recall");
-      }
-      else
-      {
-        auto sc = p->getValue().getScaleConverter();
-        auto displayValue = sc->controlPositionToDisplay(originalParam->getValue());
-        auto displayString = sc->getDimension().stringize(displayValue);
-        m_leftValue->setText(displayString);
-        m_rightValue->setText(p->getDisplayString());
-        m_slider->setValue(m_recallValue, p->isBiPolar());
-        m_leftValue->setHighlight(false);
-        m_rightValue->setHighlight(true);
-        m_buttonC->setText("");
-        m_buttonB->setText("Recall");
-      }
+      m_leftValue->setText(p->getDisplayString());
+      m_rightValue->setText(m_recallString);
+      m_slider->setValue(p->getControlPositionValue(), p->isBiPolar());
+      m_rightValue->setHighlight(false);
+      m_leftValue->setHighlight(true);
+      m_buttonB->setText("");
+      m_buttonC->setText("Recall");
+    }
+    else
+    {
+      auto sc = p->getValue().getScaleConverter();
+      auto originalParam = p->getOriginalParameter();
+      auto originalValue = originalParam ? originalParam->getValue() : p->getDefaultValue();
+      auto displayValue = sc->controlPositionToDisplay(originalValue);
+      auto displayString = sc->getDimension().stringize(displayValue);
+      m_leftValue->setText(displayString);
+      m_rightValue->setText(p->getDisplayString());
+      m_slider->setValue(m_recallValue, p->isBiPolar());
+      m_leftValue->setHighlight(false);
+      m_rightValue->setHighlight(true);
+      m_buttonC->setText("");
+      m_buttonB->setText("Recall");
     }
   }
 }


### PR DESCRIPTION
cleanup code paths in compare / recall for the case that no original preset exists -> init sound, now if no original preset exists the value with which current value is being compared is the default value. if no previous preset exists and editbuffer parameter is different than default -> current parameter changed