### PR TITLE
overload to_string(Bank::AttachmentDirection dir) was unknown

### DIFF
--- a/playground/src/presets/Bank.cpp
+++ b/playground/src/presets/Bank.cpp
@@ -7,6 +7,8 @@
 #include <tools/TimeTools.h>
 #include <device-settings/DebugLevel.h>
 
+string to_string(Bank::AttachmentDirection dir);
+
 EditBuffer *getEditBuffer()
 {
   return Application::get().getPresetManager()->getEditBuffer();
@@ -359,7 +361,16 @@ void Bank::setAttachedToBank(UNDO::Transaction *transaction, const Uuid &uuid)
 
 void Bank::setAttachedDirection(UNDO::Transaction *transaction, const string &direction)
 {
-  transaction->addUndoSwap(this, m_attachDirection, direction);
+  try
+  {
+    int i = stoi(direction);
+    Bank::AttachmentDirection dir = static_cast<Bank::AttachmentDirection>(i);
+    transaction->addUndoSwap(this, m_attachDirection, to_string(dir));
+  }
+  catch(...)
+  {
+    transaction->addUndoSwap(this, m_attachDirection, direction);
+  }
 }
 
 void Bank::setX(UNDO::Transaction *transaction, const string &x)

--- a/playground/src/presets/Bank.cpp
+++ b/playground/src/presets/Bank.cpp
@@ -363,8 +363,8 @@ void Bank::setAttachedDirection(UNDO::Transaction *transaction, const string &di
 {
   try
   {
-    int i = stoi(direction);
-    Bank::AttachmentDirection dir = static_cast<Bank::AttachmentDirection>(i);
+    auto i = stoi(direction);
+    auto dir = static_cast<Bank::AttachmentDirection>(i);
     transaction->addUndoSwap(this, m_attachDirection, to_string(dir));
   }
   catch(...)


### PR DESCRIPTION
at the place where it was needed, so default 'to_string' for enums
was utilised, turning the values into numbers.
The load code now tries to interpret the string as number and converts
it into a string afterwards. If it fails, it uses the string as is.

fixes #746