### PR TITLE
removed redundant code according to Review 1.56

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/ae_soundgenerator.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_soundgenerator.cpp
@@ -86,7 +86,6 @@ void ae_soundgenerator::resetPhase(float _phase)
 {
    m_oscA_phase = _phase;
    m_oscB_phase = _phase;
-#if test_phase_reset == 1
    /* */
    m_oscA_selfmix = 0.f;
    m_oscA_crossmix = 0.f;
@@ -97,7 +96,6 @@ void ae_soundgenerator::resetPhase(float _phase)
    m_chiB_stateVar = 0.f;
    /* */
    m_feedback_phase = 0.f;
-#endif
 }
 
 

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -1737,7 +1737,6 @@ void dsp_host::resetDSP()
 *******************************************************************************/
 void dsp_host::flushDSP()
 {
-#if test_flushModeFlag == 1
   // reset: audio engine poly section (full flush included)
   for(uint32_t v = 0; v < m_voices; v++)
   {
@@ -1754,21 +1753,6 @@ void dsp_host::flushDSP()
   m_gapfilter.resetDSP();
   m_echo.resetDSP();
   m_reverb.resetDSP();
-#else
-  for(uint32_t v = 0; v < m_voices; v++)
-  {
-    std::fill(m_combfilter[v].m_buffer.begin(), m_combfilter[v].m_buffer.end(), 0.f);
-  }
-
-  std::fill(m_flanger.m_buffer_L.begin(), m_flanger.m_buffer_L.end(), 0.f);
-  std::fill(m_flanger.m_buffer_R.begin(), m_flanger.m_buffer_R.end(), 0.f);
-  std::fill(m_echo.m_buffer_L.begin(), m_echo.m_buffer_L.end(), 0.f);
-  std::fill(m_echo.m_buffer_R.begin(), m_echo.m_buffer_R.end(), 0.f);
-
-  std::fill(m_reverb.m_buffer_L.begin(), m_reverb.m_buffer_L.end(), 0.f);
-  std::fill(m_reverb.m_buffer_R.begin(), m_reverb.m_buffer_R.end(), 0.f);
-
-#endif
 }
 
 /******************************************************************************/
@@ -1778,18 +1762,7 @@ void dsp_host::flushDSP()
 /* */
 void dsp_host::resetEnv()
 {
-  // if present, reset old envelopes
-#if test_whichEnvelope == 0
-  uint32_t e;
-  // reset old envelopes (A, B, C, G, F) -- not tested yet!
-  for(e = 0; e < sig_number_of_env_items; e++)
-  {
-    m_params.m_envelopes.m_body[e].m_index = 0;
-    m_params.m_envelopes.m_body[e].m_signal = 0.f;
-    m_params.m_envelopes.m_body[e].m_start = 0.f;
-  }
-#elif test_whichEnvelope == 1
-  // if present, reset new envelopes
+  // reset new envelopes
   // iterate voices
   uint32_t v;
 
@@ -1826,7 +1799,6 @@ void dsp_host::resetEnv()
   m_params.m_new_envelopes.m_env_f.m_body[0].m_x = 0.f;
   m_params.m_new_envelopes.m_env_f.m_body[0].m_signal_magnitude = 0.f;
   m_params.m_new_envelopes.m_env_f.m_body[0].m_start_magnitude = 0.f;
-#endif
 }
 
 void dsp_host::muteOsc(uint32_t _oscId, uint32_t _state)

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.h
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.h
@@ -15,13 +15,7 @@
 #include "pe_defines_params.h"
 #include "pe_exponentiator.h"
 #include "pe_defines_config.h"
-
-#if test_whichEnvelope == 0
-#include "pe_env_engine.h"
-#elif test_whichEnvelope == 1
 #include "pe_env_engine2.h"
-#endif
-
 #include "pe_key_event.h"
 #include "pe_lfo_engine.h"
 #include "pe_utilities.h"
@@ -92,11 +86,7 @@ struct paramengine
     exponentiator m_convert;
     param_utility m_utilities[sig_number_of_utilities];
     float m_env_c_clipFactor[dsp_number_of_voices];
-#if test_whichEnvelope == 0
-    env_engine m_envelopes;
-#elif test_whichEnvelope == 1
     env_engine2 m_new_envelopes;
-#endif
     poly_key_event m_event;
 #if test_comb_decay_gate_mode == 1
     float m_comb_decay_times[2];
@@ -140,19 +130,11 @@ struct paramengine
     void keyUp(const uint32_t _voiceId, float _velocity);                                   // key events: key up (note off) mechanism
     void keyApply(const uint32_t _voiceId);                                                 // key events: apply key event
     void keyApplyMono();                                                                    // key events: apply mono event
-#if test_whichEnvelope == 0
-    /* OLD envelope updates */
-    void envUpdateStart(const uint32_t _voiceId, const uint32_t _envId, const float _pitch, const float _velocity, const float _retriggerHardness);
-    void envUpdateStop(const uint32_t _voiceId, const uint32_t _envId, const float _pitch, const float _velocity);
-    void envUpdateTimes(const uint32_t _voiceId, const uint32_t _envId);
-    void envUpdateLevels(const uint32_t _voiceId, const uint32_t _envId);
-#elif test_whichEnvelope == 1
     /* NEW envelopes updates */
     void newEnvUpdateStart(const uint32_t _voiceId, const float _pitch, const float _velocity);
     void newEnvUpdateStop(const uint32_t _voiceId, const float _pitch, const float _velocity);
     void newEnvUpdateTimes(const uint32_t _voiceId);
     void newEnvUpdateLevels(const uint32_t _voiceId);
-#endif
     /* simplified polyphonic post processing approach (one function per clock) */
     void postProcessPoly_slow(float *_signal, const uint32_t _voiceId);                         // poly slow post processing (distribution, copy, env c event signal!)
     void postProcessPoly_fast(float *_signal, const uint32_t _voiceId);                         // poly fast post processing (distribution, copy)

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
@@ -20,8 +20,6 @@
       // - 155 (internal unison handling, echo/reverb sends),                                                          \
       // - 156 (simplified TCD key sequence by new KeyVoice command, automatic internal unison loop)
 
-#define test_key_update_pan 1  // (should pan values be updated on key? (probably yes)
-
 #define test_tone_initial_freq 500.0f  // Test Tone initial Frequency
 #define test_tone_initial_gain -6.0f   // Test Tone initial Gain (in decibel)
 #define test_tone_initial_state 0      // Test Tone initial State (0: disabled, 1: enabled)
@@ -31,16 +29,12 @@
 #define test_svf_types 1        // 0: SVF first Proto NAN, 1: SVF noFIR, 2: SVF FIR, 3: SVF Original Primary (later)
 #define test_svf_fm_limit 1.5f  // SVF fm clipping maximum
 
-#define test_fast_fold_asym 1  // 0: slow clock (producing audible artifacts), 1: fast clock (recommended)
 #define test_preload_update 1  // 0: non-optimized preload update, 1: optimized preload update (recommended)
-#define test_flushModeFlag 1   // 0: flushes ONLY Buffers, 1: flushes Buffers AND Filter State Variables
 #define test_inputModeFlag 0   // 0: receive TCD MIDI, 1: receive Remote MIDI (and produce TCD internally)
-#define test_whichEnvelope 1   // specify which env engine should be used: old (0) or new (1)
 
 #define test_reverbParams 1    // 0: fast rendering (like Reaktor), 1: slow rendering (experimental)
 #define test_reverbSmoother 1  // 0: no internal smoothers (experimental), 1: internal smoothers (like Reaktor)
 
-#define test_phase_reset 1  // 0: reset phase only, 1: reset phase, self- & cross-mix and feedback, chirp state var
 #define test_flanger_phs 1  // 0: slow (default, artifacts), 1: fast (seems okay), 2: audio (optimum)
 #define test_flanger_env 2  // 0: slow (default, artifacts), 1: fast (artifacts), 2: audio (recommended)
 #define test_flanger_env_legato 1  // 0: retriggering flanger env, 1: legato (only trigger if no key is pressed)

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
@@ -103,13 +103,8 @@ const float param_definition[sig_number_of_params][10] = {
     //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
     {        71,     2,      0,      200,    10,     0.18f,  -1,     0,      0,      10000  },         // 66  SHP_A_DRIVE
     {        73,     3,      0,      16000,  0,      0,      -1,     0,      0,      16000  },         // 67  SHP_A_DRIVE_ENV_A (later maybe fast type)
-#if test_fast_fold_asym == 0
-    {        74,     3,      0,      16000,  0,      0,      17,     1,      0,      16000  },         // 68  SHP_A_FOLD (later maybe fast type)
-    {        75,     3,      0,      16000,  0,      0,      18,     1,      0,      16000  },         // 69  SHP_A_ASYMETRY (later maybe fast type)
-#elif test_fast_fold_asym == 1
     {        74,     2,      0,      16000,  0,      0,      17,     1,      0,      16000  },         // 68  SHP_A_FOLD (later maybe fast type)
     {        75,     2,      0,      16000,  0,      0,      18,     1,      0,      16000  },         // 69  SHP_A_ASYMETRY (later maybe fast type)
-#endif
     {        76,     2,      0,      8000,   0,      0,      19,     1,      1,      8000   },         // 70  SHP_A_MIX
     {        78,     2,      0,      16000,  5,      0,      20,     1,      0,      16000  },         // 71  SHP_A_FEEDBACK_MIX
     {        80,     3,      0,      16000,  0,      0,      -1,     1,      0,      16000  },         // 72  SHP_A_FEEDBACK_ENV_C
@@ -137,13 +132,8 @@ const float param_definition[sig_number_of_params][10] = {
     //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
     {        101,    2,      0,      200,    10,     0.18f,  -1,     0,      0,      10000  },         // 89  SHP_B_DRIVE
     {        103,    3,      0,      16000,  0,      0,      -1,     0,      0,      16000  },         // 90  SHP_B_DRIVE_ENV_B (later maybe fast type)
-#if test_fast_fold_asym == 0
-    {        104,    3,      0,      16000,  0,      0,      33,     1,      0,      16000  },         // 91  SHP_B_FOLD (later maybe fast type)
-    {        105,    3,      0,      16000,  0,      0,      34,     1,      0,      16000  },         // 92  SHP_B_ASYMETRY (later maybe fast type)
-#elif test_fast_fold_asym == 1
     {        104,    2,      0,      16000,  0,      0,      33,     1,      0,      16000  },         // 91  SHP_B_FOLD (later maybe fast type)
     {        105,    2,      0,      16000,  0,      0,      34,     1,      0,      16000  },         // 92  SHP_B_ASYMETRY (later maybe fast type)
-#endif
     {        106,    2,      0,      8000,   0,      0,      35,     1,      1,      8000   },         // 93  SHP_B_MIX
     {        108,    2,      0,      16000,  5,      0,      36,     1,      0,      16000  },         // 94  SHP_B_FEEDBACK_MIX
     {        110,    3,      0,      16000,  0,      0,      -1,     1,      0,      16000  },         // 95  SHP_B_FEEDBACK_ENV_C
@@ -191,13 +181,8 @@ const float param_definition[sig_number_of_params][10] = {
     {        160,    2,      0,      8000,   3,      0,      65,     1,      1,      8000   },         // 128 FBM_EFFECTS_MIX
     {        162,    2,      0,      16000,  0,      0,      66,     0,      0,      16000  },         // 129 FBM_REVERB_MIX
     {        164,    2,      0,      200,    11,     2.5f,   67,     1,      0,      10000  },         // 130 FBM_DRIVE
-#if test_fast_fold_asym == 0
-    {        166,    3,      0,      16000,  0,      0,      68,     1,      0,      16000  },         // 131 FBM_FOLD
-    {        167,    3,      0,      16000,  0,      0,      69,     1,      0,      16000  },         // 132 FBM_ASYM
-#elif test_fast_fold_asym == 1
     {        166,    2,      0,      16000,  0,      0,      68,     1,      0,      16000  },         // 131 FBM_FOLD
     {        167,    2,      0,      16000,  0,      0,      69,     1,      0,      16000  },         // 132 FBM_ASYM
-#endif
     {        168,    3,      0,      8000,   0,      0,      -1,     1,      1,      8000   },         // 133 FBM_LEVEL_KT
     {        299,    2,      0,      16000,  4,      4,      -1,     1,      0,      16000  },         // 134 FBM_LEVEL
 
@@ -212,26 +197,16 @@ const float param_definition[sig_number_of_params][10] = {
     {        178,    2,      0,      4000,   0,      0,      -1,     0,      1,      8000   },         // 141 OUT_SVF_LEVEL
     {        180,    2,      0,      16000,  0,      0.5f,   -1,     0,      1,      8000   },         // 142 OUT_SVF_PAN
     {        181,    2,      0,      200,    11,     0.25f,  80,     1,      0,      10000  },         // 143 OUT_DRIVE
-#if test_fast_fold_asym == 0
-    {        183,    3,      0,      16000,  0,      0,      81,     1,      0,      16000  },         // 144 OUT_FOLD (later maybe fast type)
-    {        184,    3,      0,      16000,  0,      0,      82,     1,      0,      16000  },         // 145 OUT_ASYMETRY (later maybe fast type)
-#elif test_fast_fold_asym == 1
     {        183,    2,      0,      16000,  0,      0,      81,     1,      0,      16000  },         // 144 OUT_FOLD (later maybe fast type)
     {        184,    2,      0,      16000,  0,      0,      82,     1,      0,      16000  },         // 145 OUT_ASYMETRY (later maybe fast type)
-#endif
     {        185,    2,      0,      16000,  4,      2.56f,  83,     0,      0,      16000  },         // 146 OUT_LEVEL
     {        187,    2,      0,      960000, 0,      0,      -1,     0,      0,      16000  },         // 147 OUT_KEY_PAN
 
     // - - - CABINET  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
     {        188,    2,      0,      200,    12,     0,      84,     0,      0,      10000  },         // 148 CABINET_DRIVE
-#if test_fast_fold_asym == 0
-    {        190,    3,      0,      16000,  0,      0,      85,     0,      0,      16000  },         // 149 CABINET_FOLD (later maybe fast type)
-    {        191,    3,      0,      16000,  0,      0,      86,     0,      0,      16000  },         // 150 CABINET_ASYMETRY (later maybe fast type)
-#elif test_fast_fold_asym == 1
     {        190,    2,      0,      16000,  0,      0,      85,     0,      0,      16000  },         // 149 CABINET_FOLD (later maybe fast type)
     {        191,    2,      0,      16000,  0,      0,      86,     0,      0,      16000  },         // 150 CABINET_ASYMETRY (later maybe fast type)
-#endif
     {        192,    2,      0,      80,     0,      0,      -1,     0,      1,      8000   },         // 151 CABINET_TILT (implement fast and slow handling)
     {        194,    3,      0,      200,    9,      60,     -1,     0,      0,      16000  },         // 152 CABINET_HI_CUT
     {        196,    3,      0,      200,    9,      20,     -1,     0,      0,      16000  },         // 153 CABINET_LOW_CUT


### PR DESCRIPTION
removed defines and corresponding code for:
- test_key_update_pan
- test_fast_fold_asym
- test_flushModeFlag
- test_whichEnvelope
- test_phase_reset
(see on google drive: Nonlinear Labs > Linux Engine > Linux Engine 1.56 Status :: Review 1.56)