### PR TITLE
#844

### DIFF
--- a/playground/src/parameters/ModulateableParameter.cpp
+++ b/playground/src/parameters/ModulateableParameter.cpp
@@ -306,14 +306,8 @@ Glib::ustring ModulateableParameter::stringizeModulationAmount() const
 
 Glib::ustring ModulateableParameter::stringizeModulationAmount(tControlPositionValue amount) const
 {
-  auto converter = getValue().getScaleConverter();
-  if(!converter->isBiPolar())
-  {
-    DebugLevel::warning("Using LinearBipolar100PercentScaleConverter For Parameter:", getLongName(), "because ValueScaleConverter is not bipolar");
-    converter = ScaleConverter::get<LinearBipolar100PercentScaleConverter>();
-  }
-
-  return converter->getDimension().stringize(converter->controlPositionToDisplay(amount));
+  LinearBipolar100PercentScaleConverter converter;
+  return converter.getDimension().stringize(converter.controlPositionToDisplay(amount));
 }
 
 DFBLayout *ModulateableParameter::createLayout(FocusAndMode focusAndMode) const

--- a/playground/src/parameters/ModulateableParameter.cpp
+++ b/playground/src/parameters/ModulateableParameter.cpp
@@ -306,8 +306,14 @@ Glib::ustring ModulateableParameter::stringizeModulationAmount() const
 
 Glib::ustring ModulateableParameter::stringizeModulationAmount(tControlPositionValue amount) const
 {
-  return getValue().getScaleConverter()->getDimension().stringize(
-      getValue().getScaleConverter()->controlPositionToDisplay(amount));
+  auto converter = getValue().getScaleConverter();
+  if(!converter->isBiPolar())
+  {
+    DebugLevel::warning("Using LinearBipolar100PercentScaleConverter For Parameter:", getLongName(), "because ValueScaleConverter is not bipolar");
+    converter = ScaleConverter::get<LinearBipolar100PercentScaleConverter>();
+  }
+
+  return converter->getDimension().stringize(converter->controlPositionToDisplay(amount));
 }
 
 DFBLayout *ModulateableParameter::createLayout(FocusAndMode focusAndMode) const

--- a/playground/src/parameters/ModulateableParameterWithUnusualModUnit.cpp
+++ b/playground/src/parameters/ModulateableParameterWithUnusualModUnit.cpp
@@ -46,9 +46,6 @@ double ModulateableParameterWithUnusualModUnit::getModulationAmountCoarseDenomin
 }
 
 Glib::ustring ModulateableParameterWithUnusualModUnit::stringizeModulationAmount(tControlPositionValue amount) const {
-    if(!m_modAmountScaling->isBiPolar())
-        DebugLevel::warning("Explicit Mod-Amount scaling not BiPolar!");
-
     return m_modAmountScaling->getDimension().stringize(
             m_modAmountScaling->controlPositionToDisplay(amount));
 }

--- a/playground/src/parameters/ModulateableParameterWithUnusualModUnit.cpp
+++ b/playground/src/parameters/ModulateableParameterWithUnusualModUnit.cpp
@@ -1,6 +1,7 @@
 #include "ModulateableParameterWithUnusualModUnit.h"
 #include <xml/Writer.h>
 #include <math.h>
+#include <device-settings/DebugLevel.h>
 
 ModulateableParameterWithUnusualModUnit::ModulateableParameterWithUnusualModUnit(
     ParameterGroup *group, uint16_t id, const ScaleConverter *scaling, const ScaleConverter *modAmountScaling,
@@ -45,6 +46,9 @@ double ModulateableParameterWithUnusualModUnit::getModulationAmountCoarseDenomin
 }
 
 Glib::ustring ModulateableParameterWithUnusualModUnit::stringizeModulationAmount(tControlPositionValue amount) const {
+    if(!m_modAmountScaling->isBiPolar())
+        DebugLevel::warning("Explicit Mod-Amount scaling not BiPolar!");
+
     return m_modAmountScaling->getDimension().stringize(
             m_modAmountScaling->controlPositionToDisplay(amount));
 }


### PR DESCRIPTION
requesting input from @hhoegelo, bug seems clear for me, but not sure how to advance from that
#844 
modulate able parameters who are uni polar, and not of type ModulateableParameterWithUnusualModUnit
have this bug, if mod-amount is negative the parameter value scale converter will not be able to stringize the mod-amount
Is the correct solution to instantiate all offending Parameters with their fitting ModAmountConverter?