### PR TITLE
parameter renderers now running continuously

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -108,13 +108,13 @@ void dsp_host::tickMain()
     for(const auto &it : m_params.m_parameters.getClockIds(PARAM_SLOW, PARAM_MONO))
     {
         auto i = m_params.getHead(it).m_index;
-        m_params.tickItem(i);
+        m_params.getBody(i).tick();
     }
 #else
     auto end = m_params.m_parameters.end(PARAM_SLOW, PARAM_MONO);
     for(param_body* it = m_params.m_parameters.begin(PARAM_SLOW, PARAM_MONO); it != end; it++)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
     m_params.postProcessMono_slow(m_parameters.bindToVoice(0));
@@ -125,13 +125,13 @@ void dsp_host::tickMain()
       for(const auto &it : m_params.m_parameters.getClockIds(PARAM_SLOW, PARAM_POLY))
       {
           auto i = m_params.getHead(it).m_index + v;
-          m_params.tickItem(i);
+          m_params.getBody(i).tick();
       }
 #else
     end = m_params.m_parameters.end(PARAM_SLOW, PARAM_POLY, v);
     for(param_body* it = m_params.m_parameters.begin(PARAM_SLOW, PARAM_POLY, v); it != end; it += m_voices)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
       m_params.postProcessPoly_slow(m_parameters.bindToVoice(v), v);
@@ -149,13 +149,13 @@ void dsp_host::tickMain()
     for(auto &it : m_params.m_parameters.getClockIds(PARAM_FAST, PARAM_MONO))
     {
         auto i = m_params.getHead(it).m_index;
-        m_params.tickItem(i);
+        m_params.getBody(i).tick();
     }
 #else
     auto end = m_params.m_parameters.end(PARAM_FAST, PARAM_MONO);
     for(param_body* it = m_params.m_parameters.begin(PARAM_FAST, PARAM_MONO); it != end; it++)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
     m_params.postProcessMono_fast(m_parameters.bindToVoice(0));
@@ -166,13 +166,13 @@ void dsp_host::tickMain()
       for(auto &it : m_params.m_parameters.getClockIds(PARAM_FAST, PARAM_POLY))
       {
           auto i = m_params.getHead(it).m_index + v;
-          m_params.tickItem(i);
+          m_params.getBody(i).tick();
       }
 #else
     end = m_params.m_parameters.end(PARAM_FAST, PARAM_POLY, v);
     for(param_body* it = m_params.m_parameters.begin(PARAM_FAST, PARAM_POLY, v); it != end; it += m_voices)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
       m_params.postProcessPoly_fast(m_parameters.bindToVoice(v), v);
@@ -185,13 +185,13 @@ void dsp_host::tickMain()
   for(auto &it : m_params.m_parameters.getClockIds(PARAM_AUDIO, PARAM_MONO))
   {
       auto i = m_params.getHead(it).m_index;
-      m_params.tickItem(i);
+      m_params.getBody(i).tick();
   }
 #else
     auto end = m_params.m_parameters.end(PARAM_AUDIO, PARAM_MONO);
     for(param_body* it = m_params.m_parameters.begin(PARAM_AUDIO, PARAM_MONO); it != end; it++)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
   m_params.postProcessMono_audio(m_parameters.bindToVoice(0));
@@ -207,13 +207,13 @@ void dsp_host::tickMain()
     for(auto &it : m_params.m_parameters.getClockIds(PARAM_AUDIO, PARAM_POLY))
     {
         auto i = m_params.getHead(it).m_index + v;
-        m_params.tickItem(i);
+        m_params.getBody(i).tick();
     }
 #else
     end = m_params.m_parameters.end(PARAM_AUDIO, PARAM_POLY, v);
     for(param_body* it = m_params.m_parameters.begin(PARAM_AUDIO, PARAM_POLY, v); it != end; it += m_voices)
     {
-        m_params.newTickItem(it);
+        it->tick();
     }
 #endif
     /* post processing and envelope rendering */

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
@@ -17,6 +17,14 @@ std::ostream& operator<<(std::ostream& lhs, const param_body& rhs)
   return lhs;
 }
 
+// continuous load rendeing (at any time)
+void param_body::tick()
+{
+    m_x = std::min(m_x, 1.f);
+    m_signal = m_start + (m_diff * m_x);
+    m_x += m_dx[1];
+}
+
 /* proper init */
 void paramengine::init(uint32_t _sampleRate, uint32_t _voices)
 {
@@ -347,26 +355,6 @@ void paramengine::applySync(const uint32_t _index)
 {
   /* just update signal, no reference for one-liner */
   getBody(_index).m_signal = getBody(_index).m_dest;
-}
-
-/* parameter rendering */
-void paramengine::tickItem(const uint32_t _index)
-{
-  /* provide (rendering) item reference */
-  param_body* item = &getBody(_index);
-  /* render when state is true */
-  if(item->m_state == 1)
-  {
-    /* stop on final sample */
-    if(item->m_x >= 1)
-    {
-      item->m_x = 1;
-      item->m_state = 0;
-    }
-    /* update signal (and x) */
-    item->m_signal = item->m_start + (item->m_diff * item->m_x);
-    item->m_x += item->m_dx[1];
-  }
 }
 
 /* TCD Key Events - keyDown */

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.h
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.h
@@ -52,6 +52,7 @@ struct param_body
   float m_start = 0.f;
   float m_diff = 0.f;
   float m_dest = 0.f;
+  void tick();
 };
 
 /* */
@@ -182,24 +183,6 @@ struct paramengine
   {
     return m_parameters.getSignal(paramId, voice);
   }
-#if PARAM_ITERATOR == 1
-  inline void newTickItem(param_body* item)
-  {
-      /* render when state is true */
-      if(item->m_state == 1)
-      {
-        /* stop on final sample */
-        if(item->m_x >= 1)
-        {
-          item->m_x = 1;
-          item->m_state = 0;
-        }
-        /* update signal (and x) */
-        item->m_signal = item->m_start + (item->m_diff * item->m_x);
-        item->m_x += item->m_dx[1];
-      }
-  }
-#endif
   /* local variables */
   uint32_t m_samplerate;
   uint32_t m_preload = 0;
@@ -254,8 +237,6 @@ struct paramengine
   void applyPreloaded(const uint32_t _voiceId, const uint32_t _paramId);         // param apply preloaded
   void applyDest(const uint32_t _index);                                         // param apply dest (non-sync types)
   void applySync(const uint32_t _index);                                         // param apply dest (sync types)
-  /* rendering */
-  void tickItem(const uint32_t _index);  // parameter rendering
   /* key events */
   void keyDown(const uint32_t _voiceId, float _velocity);  // key events: key down (note on) mechanism
   void keyUp(const uint32_t _voiceId, float _velocity);    // key events: key up (note off) mechanism

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 /* Param Interface Testing */
-#define PARAM_ITERATOR 1 // 0: render param bodies by clockIds; 1: render param bodies by direct iteration
+#define PARAM_ITERATOR 1 // 0: render param bodies by clockIds; 1: render param bodies by direct iteration (default)
 
 /* Test Flags                                       THINGS TO DEFINE, testing candidates and new functionalities */
 


### PR DESCRIPTION
- rendering can perform in two modes: by clockId or by direct param_body iteration (default)
- both modes produce pretty similar performance results, although the iterator seems to variate a little more