### PR TITLE
Code quality only. This patch should not change programs behavior in any way.

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/SignalStorage.h
+++ b/audio-engine/src/synth/c15-audio-engine/SignalStorage.h
@@ -16,7 +16,7 @@ class SignalStorage
     return *this;
   }
 
-  inline const float &get(SignalLabel param) const
+  inline const float &get(Signals param) const
   {
     return m_boundVoice[static_cast<uint32_t>(param)];
   }
@@ -26,12 +26,12 @@ class SignalStorage
     return m_paramsignaldata[voice][param];
   }
 
-  inline void set(SignalLabel param, float value)
+  inline void set(Signals param, float value)
   {
     m_boundVoice[static_cast<uint32_t>(param)] = value;
   }
 
-  inline void set(SignalLabel param, uint32_t voice, float value)
+  inline void set(Signals param, uint32_t voice, float value)
   {
     m_paramsignaldata[voice][static_cast<uint32_t>(param)] = value;
   }

--- a/audio-engine/src/synth/c15-audio-engine/SignalStorage.h
+++ b/audio-engine/src/synth/c15-audio-engine/SignalStorage.h
@@ -12,31 +12,31 @@ class SignalStorage
 
   inline SignalStorage &bindToVoice(uint32_t v)
   {
-    m_boundVoice = m_paramsignaldata[v];
+    m_boundVoice = m_sigIdsignaldata[v];
     return *this;
   }
 
-  inline const float &get(Signals param) const
+  inline const float &get(Signals sigId) const
   {
-    return m_boundVoice[static_cast<uint32_t>(param)];
+    return m_boundVoice[static_cast<uint32_t>(sigId)];
   }
 
-  inline const float &get(uint32_t voice, uint32_t param) const
+  inline const float &get(uint32_t voice, uint32_t sigId) const
   {
-    return m_paramsignaldata[voice][param];
+    return m_sigIdsignaldata[voice][sigId];
   }
 
-  inline void set(Signals param, float value)
+  inline void set(Signals sigId, float value)
   {
-    m_boundVoice[static_cast<uint32_t>(param)] = value;
+    m_boundVoice[static_cast<uint32_t>(sigId)] = value;
   }
 
-  inline void set(Signals param, uint32_t voice, float value)
+  inline void set(Signals sigId, uint32_t voice, float value)
   {
-    m_paramsignaldata[voice][static_cast<uint32_t>(param)] = value;
+    m_sigIdsignaldata[voice][static_cast<uint32_t>(sigId)] = value;
   }
 
  private:
-  float m_paramsignaldata[dsp_number_of_voices][sig_number_of_signal_items] = {};
-  float *m_boundVoice = m_paramsignaldata[0];
+  float m_sigIdsignaldata[dsp_number_of_voices][sig_number_of_signal_items] = {};
+  float *m_boundVoice = m_sigIdsignaldata[0];
 };

--- a/audio-engine/src/synth/c15-audio-engine/ae_cabinet.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_cabinet.cpp
@@ -126,7 +126,7 @@ void ae_cabinet::set(SignalStorage &signals)
   float tmpVar;
 
   //*************************** Biquad Highpass ****************************//
-  float frequency = signals.get(SignalLabel::CAB_HPF);
+  float frequency = signals.get(Signals::CAB_HPF);
   frequency = std::clamp(frequency, m_freqClip_min, m_freqClip_max);
   frequency *= m_warpConst_2PI;
 
@@ -147,7 +147,7 @@ void ae_cabinet::set(SignalStorage &signals)
   m_hp_b1 = m_hp_b1 / tmpVar;
 
   //*************************** Biquad Lowpass 1 ***************************//
-  frequency = signals.get(SignalLabel::CAB_LPF);
+  frequency = signals.get(Signals::CAB_LPF);
   frequency = std::clamp(frequency, m_freqClip_min, m_freqClip_max);
   frequency *= m_warpConst_2PI;
 
@@ -168,7 +168,7 @@ void ae_cabinet::set(SignalStorage &signals)
   m_lp1_b1 = m_lp1_b1 / tmpVar;
 
   //*************************** Biquad Lowpass 2 ***************************//
-  frequency = signals.get(SignalLabel::CAB_LPF) * 1.333f;
+  frequency = signals.get(Signals::CAB_LPF) * 1.333f;
   frequency = std::clamp(frequency, m_freqClip_min, m_freqClip_max);
   frequency *= m_warpConst_2PI;
   tmpVar = NlToolbox::Math::cos(frequency);
@@ -188,7 +188,7 @@ void ae_cabinet::set(SignalStorage &signals)
   m_lp2_b1 = m_lp2_b1 / tmpVar;
 
   //**************************** Tilt Lowshelves ***************************//
-  float tilt = std::pow(10.f, signals.get(SignalLabel::CAB_TILT) * 0.025f);
+  float tilt = std::pow(10.f, signals.get(Signals::CAB_TILT) * 0.025f);
   //    float tilt = std::pow(1.059192f, signals.get(SignalLabel::CAB_TILT));       // alternative to pow(10.f, signals.get(SignalLabel::CAB_TILT) / 40.f)
 
   tmpVar = tilt + 1.f / tilt + 2.f;
@@ -207,7 +207,7 @@ void ae_cabinet::set(SignalStorage &signals)
   m_ls1_b1 = m_ls1_b1 / coeff;
   m_ls1_b2 = m_ls1_b2 / coeff;
 
-  tilt = std::pow(10.f, signals.get(SignalLabel::CAB_TILT) * -0.025f);
+  tilt = std::pow(10.f, signals.get(Signals::CAB_TILT) * -0.025f);
   //    tilt = std::pow(1.059192f, signals.get(SignalLabel::CAB_TILT) * -1.f);          // alternative to pow(10.f, signals.get(SignalLabel::CAB_TILT) / 40.f * -1.f)
 
   tmpVar = tilt + 1.f / tilt + 2.f;
@@ -236,8 +236,8 @@ void ae_cabinet::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
   float tmpVar;
 
   //********************************* Drive ********************************//
-  float sample_L = _rawSample_L * signals.get(SignalLabel::CAB_DRV);
-  float sample_R = _rawSample_R * signals.get(SignalLabel::CAB_DRV);
+  float sample_L = _rawSample_L * signals.get(Signals::CAB_DRV);
+  float sample_R = _rawSample_R * signals.get(Signals::CAB_DRV);
 
   //************************** Biquad Highpass L ***************************//
   tmpVar = m_hp_b0 * sample_L;
@@ -296,30 +296,30 @@ void ae_cabinet::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
   sample_R = tmpVar;
 
   //******************************* Shaper L *******************************//
-  sample_L *= signals.get(SignalLabel::CAB_PRESAT);
+  sample_L *= signals.get(Signals::CAB_PRESAT);
   tmpVar = sample_L;
 
   sample_L = NlToolbox::Math::sinP3_wrap(sample_L);
-  sample_L = NlToolbox::Others::threeRanges(sample_L, tmpVar, signals.get(SignalLabel::CAB_FLD));
+  sample_L = NlToolbox::Others::threeRanges(sample_L, tmpVar, signals.get(Signals::CAB_FLD));
 
   tmpVar = sample_L * sample_L - m_hp30_stateVar_L;
   m_hp30_stateVar_L = tmpVar * m_hp30_b0 + m_hp30_stateVar_L + DNC_const;
 
-  sample_L = NlToolbox::Others::parAsym(sample_L, tmpVar, signals.get(SignalLabel::CAB_ASM));
-  sample_L *= signals.get(SignalLabel::CAB_SAT);
+  sample_L = NlToolbox::Others::parAsym(sample_L, tmpVar, signals.get(Signals::CAB_ASM));
+  sample_L *= signals.get(Signals::CAB_SAT);
 
   //******************************* Shaper R *******************************//
-  sample_R *= signals.get(SignalLabel::CAB_PRESAT);
+  sample_R *= signals.get(Signals::CAB_PRESAT);
   tmpVar = sample_R;
 
   sample_R = NlToolbox::Math::sinP3_wrap(sample_R);
-  sample_R = NlToolbox::Others::threeRanges(sample_R, tmpVar, signals.get(SignalLabel::CAB_FLD));
+  sample_R = NlToolbox::Others::threeRanges(sample_R, tmpVar, signals.get(Signals::CAB_FLD));
 
   tmpVar = sample_R * sample_R - m_hp30_stateVar_R;
   m_hp30_stateVar_R = tmpVar * m_hp30_b0 + m_hp30_stateVar_R + DNC_const;
 
-  sample_R = NlToolbox::Others::parAsym(sample_R, tmpVar, signals.get(SignalLabel::CAB_ASM));
-  sample_R *= signals.get(SignalLabel::CAB_SAT);
+  sample_R = NlToolbox::Others::parAsym(sample_R, tmpVar, signals.get(Signals::CAB_ASM));
+  sample_R *= signals.get(Signals::CAB_SAT);
 
   //*************************** Tilt Lowshelf L2 ***************************//
   tmpVar = m_ls2_b0 * sample_L;
@@ -404,10 +404,10 @@ void ae_cabinet::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
   sample_R = tmpVar;
 
   //******************************* Crossfade ******************************//
-  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, sample_L, signals.get(SignalLabel::CAB_DRY),
-                                             signals.get(SignalLabel::CAB_WET));
-  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, sample_R, signals.get(SignalLabel::CAB_DRY),
-                                             signals.get(SignalLabel::CAB_WET));
+  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, sample_L, signals.get(Signals::CAB_DRY),
+                                             signals.get(Signals::CAB_WET));
+  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, sample_R, signals.get(Signals::CAB_DRY),
+                                             signals.get(Signals::CAB_WET));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_combfilter.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_combfilter.cpp
@@ -77,13 +77,13 @@ void ae_combfilter::apply(float _sampleA, float _sampleB, SignalStorage &signals
   float tmpVar;
 
   //**************************** AB Sample Mix ****************************//
-  tmpVar = signals.get(SignalLabel::CMB_AB);  // AB Mix is inverted, so crossfade mix is as well (currently)
+  tmpVar = signals.get(Signals::CMB_AB);  // AB Mix is inverted, so crossfade mix is as well (currently)
   m_out = _sampleB * (1.f - tmpVar) + _sampleA * tmpVar;
 
   //****************** AB Ssample Phase Mdulation Mix ********************//
-  tmpVar = signals.get(SignalLabel::CMB_PMAB);
+  tmpVar = signals.get(Signals::CMB_PMAB);
   float phaseMod = _sampleA * (1.f - tmpVar) + _sampleB * tmpVar;
-  phaseMod *= signals.get(SignalLabel::CMB_PM);
+  phaseMod *= signals.get(Signals::CMB_PM);
 
   //************************** 1-Pole Highpass ****************************//
   tmpVar = m_hpCoeff_b0 * m_out;
@@ -158,7 +158,7 @@ void ae_combfilter::apply(float _sampleA, float _sampleB, SignalStorage &signals
 
   m_delayStateVar = tmpVar;
 
-  tmpVar *= signals.get(SignalLabel::CMB_FEC);
+  tmpVar *= signals.get(Signals::CMB_FEC);
   tmpVar += (phaseMod * tmpVar);
 
   //******************************* Delay ********************************//
@@ -195,7 +195,7 @@ void ae_combfilter::apply(float _sampleA, float _sampleB, SignalStorage &signals
 
   m_buffer_indx = (m_buffer_indx + 1) & m_buffer_sz_m1;
 
-  tmpVar = signals.get(SignalLabel::CMB_BYP);  // Bypass
+  tmpVar = signals.get(Signals::CMB_BYP);  // Bypass
   m_out = tmpVar * holdsample + (1.f - tmpVar) * m_out;
 
   //****************************** Decay ********************************//
@@ -209,7 +209,7 @@ void ae_combfilter::apply(float _sampleA, float _sampleB, SignalStorage &signals
 void ae_combfilter::set(SignalStorage &signals, float _samplerate)
 {
   //********************** Highpass Coefficients *************************//
-  float frequency = signals.get(SignalLabel::CMB_FRQ);
+  float frequency = signals.get(Signals::CMB_FRQ);
   frequency *= 0.125f;
   frequency = std::clamp(frequency, m_freqClip_24576, m_freqClip_2);
 
@@ -221,7 +221,7 @@ void ae_combfilter::set(SignalStorage &signals, float _samplerate)
   m_hpCoeff_b1 = m_hpCoeff_b0 * -1.f;
 
   //*********************** Lowpass Coefficient **************************//
-  frequency = signals.get(SignalLabel::CMB_LPF);
+  frequency = signals.get(Signals::CMB_LPF);
   frequency = std::clamp(frequency, m_freqClip_24576, m_freqClip_4);
   frequency *= m_warpConst_PI;
 
@@ -234,11 +234,11 @@ void ae_combfilter::set(SignalStorage &signals, float _samplerate)
   m_lpCoeff = (1.f - frequency) / (1.f + frequency);
 
   //********************** Allpass Coefficients **************************//
-  frequency = signals.get(SignalLabel::CMB_APF);
+  frequency = signals.get(Signals::CMB_APF);
   frequency = std::clamp(frequency, m_freqClip_24576, m_freqClip_2);
   frequency *= m_warpConst_2PI;
 
-  float resonance = signals.get(SignalLabel::CMB_APR) * 1.99f - 1.f;
+  float resonance = signals.get(Signals::CMB_APR) * 1.99f - 1.f;
   resonance = NlToolbox::Math::sin(frequency) * (1.f - resonance);
 
   float tmpVar = 1.f / (1.f + resonance);
@@ -247,7 +247,7 @@ void ae_combfilter::set(SignalStorage &signals, float _samplerate)
   m_apCoeff_2 = (1.f - resonance) * tmpVar;
 
   //*************************** Delaytime ********************************//
-  frequency = signals.get(SignalLabel::CMB_FRQ);
+  frequency = signals.get(Signals::CMB_FRQ);
 
   if(frequency < m_delayFreqClip)
   {
@@ -319,8 +319,8 @@ void ae_combfilter::set(SignalStorage &signals, float _samplerate)
   m_delaySamples = m_delaySamples * tmpVar + m_delaySamples;
 
   //**************************** Decay Gain ******************************//
-  tmpVar = signals.get(SignalLabel::CMB_DEC);
-  frequency = signals.get(SignalLabel::CMB_FRQ) * std::abs(tmpVar);
+  tmpVar = signals.get(Signals::CMB_DEC);
+  frequency = signals.get(Signals::CMB_FRQ) * std::abs(tmpVar);
 
   frequency = std::max(frequency, DNC_const);
   frequency = (1.f / frequency) * -6.28318f;

--- a/audio-engine/src/synth/c15-audio-engine/ae_echo.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_echo.cpp
@@ -76,7 +76,7 @@ void ae_echo::init(float _samplerate, uint32_t _upsampleFactor)
 *******************************************************************************/
 void ae_echo::set(SignalStorage &signals)
 {
-  float omega = std::clamp(signals.get(SignalLabel::DLY_LPF), m_freqClip_min, m_freqClip_max);
+  float omega = std::clamp(signals.get(Signals::DLY_LPF), m_freqClip_min, m_freqClip_max);
   omega = NlToolbox::Math::tan(omega * m_warpConst_PI);
 
   m_lp_a1 = (1.f - omega) / (1.f + omega);
@@ -93,12 +93,12 @@ void ae_echo::apply(float _rawSample_L, float _rawSample_R, SignalStorage &signa
   float tmpVar;
 
   //***************************** Left Channel *****************************//
-  tmpVar = (_rawSample_L * signals.get(SignalLabel::DLY_SND)) + (m_stateVar_L * signals.get(SignalLabel::DLY_FB_LOC))
-      + (m_stateVar_R * signals.get(SignalLabel::DLY_FB_CR));
+  tmpVar = (_rawSample_L * signals.get(Signals::DLY_SND)) + (m_stateVar_L * signals.get(Signals::DLY_FB_LOC))
+      + (m_stateVar_R * signals.get(Signals::DLY_FB_CR));
 
   m_buffer_L[m_buffer_indx] = tmpVar;
 
-  tmpVar = signals.get(SignalLabel::DLY_TL) - m_lp2hz_stateVar_L;  // 2Hz LP
+  tmpVar = signals.get(Signals::DLY_TL) - m_lp2hz_stateVar_L;  // 2Hz LP
   tmpVar = tmpVar * m_lp2hz_b0 + m_lp2hz_stateVar_L;
 
   m_lp2hz_stateVar_L = tmpVar + DNC_const;
@@ -139,16 +139,16 @@ void ae_echo::apply(float _rawSample_L, float _rawSample_R, SignalStorage &signa
 
   m_stateVar_L += DNC_const;
 
-  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, m_out_L, signals.get(SignalLabel::DLY_DRY),
-                                             signals.get(SignalLabel::DLY_WET));
+  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, m_out_L, signals.get(Signals::DLY_DRY),
+                                             signals.get(Signals::DLY_WET));
 
   //**************************** Right Channel *****************************//
-  tmpVar = (_rawSample_R * signals.get(SignalLabel::DLY_SND)) + (m_stateVar_R * signals.get(SignalLabel::DLY_FB_LOC))
-      + (m_stateVar_L * signals.get(SignalLabel::DLY_FB_CR));
+  tmpVar = (_rawSample_R * signals.get(Signals::DLY_SND)) + (m_stateVar_R * signals.get(Signals::DLY_FB_LOC))
+      + (m_stateVar_L * signals.get(Signals::DLY_FB_CR));
 
   m_buffer_R[m_buffer_indx] = tmpVar;
 
-  tmpVar = signals.get(SignalLabel::DLY_TR) - m_lp2hz_stateVar_R;  // 2Hz LP
+  tmpVar = signals.get(Signals::DLY_TR) - m_lp2hz_stateVar_R;  // 2Hz LP
   tmpVar = tmpVar * m_lp2hz_b0 + m_lp2hz_stateVar_R;
 
   m_lp2hz_stateVar_R = tmpVar + DNC_const;
@@ -189,8 +189,8 @@ void ae_echo::apply(float _rawSample_L, float _rawSample_R, SignalStorage &signa
 
   m_stateVar_R += DNC_const;  /// Brauchen wir das wirklich?
 
-  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, m_out_R, signals.get(SignalLabel::DLY_DRY),
-                                             signals.get(SignalLabel::DLY_WET));
+  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, m_out_R, signals.get(Signals::DLY_DRY),
+                                             signals.get(Signals::DLY_WET));
 
   m_buffer_indx = (m_buffer_indx + 1) & m_buffer_sz_m1;
 }

--- a/audio-engine/src/synth/c15-audio-engine/ae_feedbackmixer.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_feedbackmixer.cpp
@@ -50,7 +50,7 @@ void ae_feedbackmixer::init(float _samplerate)
 
 void ae_feedbackmixer::set(SignalStorage &signals)
 {
-  float omega = std::clamp(signals.get(SignalLabel::FBM_HPF), m_freqClip_min, m_freqClip_max);
+  float omega = std::clamp(signals.get(Signals::FBM_HPF), m_freqClip_min, m_freqClip_max);
   omega = NlToolbox::Math::tan(omega * m_warpConst_PI);
 
   m_hp_a1 = (1.f - omega) / (1.f + omega);
@@ -64,8 +64,8 @@ void ae_feedbackmixer::set(SignalStorage &signals)
 
 void ae_feedbackmixer::apply(float _sampleComb, float _sampleSVF, float _sampleFX, SignalStorage &signals)
 {
-  float tmpVar = _sampleFX * signals.get(SignalLabel::FBM_FX) + _sampleComb * signals.get(SignalLabel::FBM_CMB)
-      + _sampleSVF * signals.get(SignalLabel::FBM_SVF);
+  float tmpVar = _sampleFX * signals.get(Signals::FBM_FX) + _sampleComb * signals.get(Signals::FBM_CMB)
+      + _sampleSVF * signals.get(Signals::FBM_SVF);
 
   m_out = m_hp_b0 * tmpVar;  // HP
   m_out += m_hp_b1 * m_hp_stateVar_1;
@@ -74,19 +74,19 @@ void ae_feedbackmixer::apply(float _sampleComb, float _sampleSVF, float _sampleF
   m_hp_stateVar_1 = tmpVar + DNC_const;
   m_hp_stateVar_2 = m_out + DNC_const;
 
-  m_out *= signals.get(SignalLabel::FBM_DRV);
+  m_out *= signals.get(Signals::FBM_DRV);
 
   tmpVar = m_out;
   m_out = NlToolbox::Math::sinP3_wrap(m_out);
-  m_out = NlToolbox::Others::threeRanges(m_out, tmpVar, signals.get(SignalLabel::FBM_FLD));
+  m_out = NlToolbox::Others::threeRanges(m_out, tmpVar, signals.get(Signals::FBM_FLD));
 
   tmpVar = m_out * m_out;
   tmpVar -= m_hp30hz_stateVar;  // HP 30Hz
   m_hp30hz_stateVar = tmpVar * m_hp30hz_b0 + m_hp30hz_stateVar + NlToolbox::Constants::DNC_const;
 
-  m_out = NlToolbox::Others::parAsym(m_out, tmpVar, signals.get(SignalLabel::FBM_ASM));
+  m_out = NlToolbox::Others::parAsym(m_out, tmpVar, signals.get(Signals::FBM_ASM));
 
-  m_out = m_out * signals.get(SignalLabel::FBM_LVL);
+  m_out = m_out * signals.get(Signals::FBM_LVL);
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_flanger.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_flanger.cpp
@@ -105,7 +105,7 @@ void ae_flanger::init(float _samplerate, uint32_t _upsampleFactor)
 
 void ae_flanger::set_slow(SignalStorage &signals)
 {
-  float omega = std::clamp(signals.get(SignalLabel::FLA_LPF), m_freqClip_min, m_freqClip_max);
+  float omega = std::clamp(signals.get(Signals::FLA_LPF), m_freqClip_min, m_freqClip_max);
   omega = NlToolbox::Math::tan(omega * m_warpConst_PI);
 
   m_lp_a1 = (1.f - omega) / (1.f + omega);
@@ -119,7 +119,7 @@ void ae_flanger::set_slow(SignalStorage &signals)
 
 void ae_flanger::set_fast(SignalStorage &signals)
 {
-  float tmpVar = signals.get(SignalLabel::FLA_APF_L);  // AP L
+  float tmpVar = signals.get(Signals::FLA_APF_L);  // AP L
   tmpVar = std::clamp(tmpVar, m_freqClip_min, m_freqClip_max);
 
   tmpVar *= m_warpConst_2PI;
@@ -134,7 +134,7 @@ void ae_flanger::set_fast(SignalStorage &signals)
   m_ap_b1_L *= tmpVar;
   m_ap_b0_L *= tmpVar;
 
-  tmpVar = signals.get(SignalLabel::FLA_APF_R);  // AP R
+  tmpVar = signals.get(Signals::FLA_APF_R);  // AP R
   tmpVar = std::clamp(tmpVar, m_freqClip_min, m_freqClip_max);
 
   tmpVar *= m_warpConst_2PI;
@@ -158,14 +158,14 @@ void ae_flanger::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
 {
   float tmpVar_1, tmpVar_2;
 
-  float tmod = signals.get(SignalLabel::FLA_TMOD) - m_lp2hz_stateVar_D;  // 2Hz LP TMOD
+  float tmod = signals.get(Signals::FLA_TMOD) - m_lp2hz_stateVar_D;  // 2Hz LP TMOD
   tmod = tmod * m_lp2hz_b0 + m_lp2hz_stateVar_D;
 
   m_lp2hz_stateVar_D = tmod + DNC_const;
 
   //**************************** Left Channel *****************************//
-  tmpVar_1 = _rawSample_L + (m_stateVar_L * signals.get(SignalLabel::FLA_FB_LOC))
-      + (m_stateVar_R * signals.get(SignalLabel::FLA_FB_CR));
+  tmpVar_1 = _rawSample_L + (m_stateVar_L * signals.get(Signals::FLA_FB_LOC))
+      + (m_stateVar_R * signals.get(Signals::FLA_FB_CR));
 
   tmpVar_2 = m_lp_b0 * tmpVar_1;  // LP L
   tmpVar_2 += m_lp_b1 * m_lp_stateVar_L1;
@@ -176,12 +176,12 @@ void ae_flanger::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
 
   m_buffer_L[m_buffer_indx] = tmpVar_2;
 
-  tmpVar_1 = signals.get(SignalLabel::FLA_TL) - m_lp2hz_stateVar_TL;  // 2Hz LP TL
+  tmpVar_1 = signals.get(Signals::FLA_TL) - m_lp2hz_stateVar_TL;  // 2Hz LP TL
   tmpVar_1 = tmpVar_1 * m_lp2hz_b0 + m_lp2hz_stateVar_TL;
 
   m_lp2hz_stateVar_TL = tmpVar_1 + DNC_const;
 
-  tmpVar_1 = tmpVar_1 + tmpVar_1 * tmod * signals.get(SignalLabel::FLA_LFO_L);
+  tmpVar_1 = tmpVar_1 + tmpVar_1 * tmod * signals.get(Signals::FLA_LFO_L);
 
   int32_t ind_t0 = static_cast<int32_t>(std::round(tmpVar_1 - 0.5f));
   tmpVar_1 = tmpVar_1 - static_cast<float>(ind_t0);
@@ -237,12 +237,12 @@ void ae_flanger::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
 
   m_stateVar_L += DNC_const;
 
-  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, tmpVar_2, signals.get(SignalLabel::FLA_DRY),
-                                             signals.get(SignalLabel::FLA_WET));
+  m_out_L = NlToolbox::Crossfades::crossFade(_rawSample_L, tmpVar_2, signals.get(Signals::FLA_DRY),
+                                             signals.get(Signals::FLA_WET));
 
   //*************************** Right Channel *****************************//
-  tmpVar_1 = _rawSample_R + (m_stateVar_R * signals.get(SignalLabel::FLA_FB_LOC))
-      + (m_stateVar_L * signals.get(SignalLabel::FLA_FB_CR));
+  tmpVar_1 = _rawSample_R + (m_stateVar_R * signals.get(Signals::FLA_FB_LOC))
+      + (m_stateVar_L * signals.get(Signals::FLA_FB_CR));
 
   tmpVar_2 = m_lp_b0 * tmpVar_1;  // LP L
   tmpVar_2 += m_lp_b1 * m_lp_stateVar_R1;
@@ -253,12 +253,12 @@ void ae_flanger::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
 
   m_buffer_R[m_buffer_indx] = tmpVar_2;
 
-  tmpVar_1 = signals.get(SignalLabel::FLA_TR) - m_lp2hz_stateVar_TR;  // 2Hz LP TR
+  tmpVar_1 = signals.get(Signals::FLA_TR) - m_lp2hz_stateVar_TR;  // 2Hz LP TR
   tmpVar_1 = tmpVar_1 * m_lp2hz_b0 + m_lp2hz_stateVar_TR;
 
   m_lp2hz_stateVar_TR = tmpVar_1 + DNC_const;
 
-  tmpVar_1 = tmpVar_1 + tmpVar_1 * tmod * signals.get(SignalLabel::FLA_LFO_R);
+  tmpVar_1 = tmpVar_1 + tmpVar_1 * tmod * signals.get(Signals::FLA_LFO_R);
 
   ind_t0 = static_cast<int32_t>(std::round(tmpVar_1 - 0.5f));
   tmpVar_1 = tmpVar_1 - static_cast<float>(ind_t0);
@@ -314,8 +314,8 @@ void ae_flanger::apply(float _rawSample_L, float _rawSample_R, SignalStorage &si
 
   m_stateVar_R += DNC_const;
 
-  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, tmpVar_2, signals.get(SignalLabel::FLA_DRY),
-                                             signals.get(SignalLabel::FLA_WET));
+  m_out_R = NlToolbox::Crossfades::crossFade(_rawSample_R, tmpVar_2, signals.get(Signals::FLA_DRY),
+                                             signals.get(Signals::FLA_WET));
 
   m_buffer_indx = (m_buffer_indx + 1) & m_buffer_sz_m1;
 }

--- a/audio-engine/src/synth/c15-audio-engine/ae_gapfilter.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_gapfilter.cpp
@@ -125,11 +125,11 @@ void ae_gapfilter::set(SignalStorage &signals)
   float tmpVar_1, tmpVar_2;
 
   //************************** Biquad Highpass L ***************************//
-  float frequency = signals.get(SignalLabel::GAP_HFL);
+  float frequency = signals.get(Signals::GAP_HFL);
   tmpVar_1 = (frequency - m_freqScale_min) * (1.f / (m_freqScale_max - m_freqScale_min));
   tmpVar_1 = std::clamp(frequency, -1.f, 1.f);
 
-  float resonance = signals.get(SignalLabel::GAP_RES) * tmpVar_1;
+  float resonance = signals.get(Signals::GAP_RES) * tmpVar_1;
 
   tmpVar_1 = std::clamp(frequency, m_freqClip_min, m_freqClip_max);  // L1
   tmpVar_1 *= m_warpConst_2PI;
@@ -167,11 +167,11 @@ void ae_gapfilter::set(SignalStorage &signals)
   m_hp_l2_b1 = m_hp_l2_b1 / tmpVar_2;
 
   //************************** Biquad Highpass R ***************************//
-  frequency = signals.get(SignalLabel::GAP_HFR);
+  frequency = signals.get(Signals::GAP_HFR);
   tmpVar_1 = (frequency - m_freqScale_min) * (1.f / (m_freqScale_max - m_freqScale_min));
   tmpVar_1 = std::clamp(tmpVar_1, -1.f, 1.f);
 
-  resonance = signals.get(SignalLabel::GAP_RES) * tmpVar_1;
+  resonance = signals.get(Signals::GAP_RES) * tmpVar_1;
 
   tmpVar_1 = std::clamp(frequency, m_freqClip_min, m_freqClip_max);  // R1
   tmpVar_1 *= m_warpConst_2PI;
@@ -209,11 +209,11 @@ void ae_gapfilter::set(SignalStorage &signals)
   m_hp_r2_b1 = m_hp_r2_b1 / tmpVar_2;
 
   //*************************** Biquad Lowpass L ***************************//
-  frequency = signals.get(SignalLabel::GAP_LFL);
+  frequency = signals.get(Signals::GAP_LFL);
   tmpVar_1 = (frequency - m_freqScale_min) * (1.f / (m_freqScale_max - m_freqScale_min));
   tmpVar_1 = std::clamp(tmpVar_1, -1.f, 1.f);
 
-  resonance = signals.get(SignalLabel::GAP_RES) * tmpVar_1;
+  resonance = signals.get(Signals::GAP_RES) * tmpVar_1;
 
   tmpVar_1 = std::clamp(frequency, m_freqClip_min, m_freqClip_max);  // L1
   tmpVar_1 *= m_warpConst_2PI;
@@ -255,11 +255,11 @@ void ae_gapfilter::set(SignalStorage &signals)
   m_lp_l2_b1 = m_lp_l2_b1 / tmpVar_2;
 
   //*************************** Biquad Lowpass R ***************************//
-  frequency = signals.get(SignalLabel::GAP_LFR);
+  frequency = signals.get(Signals::GAP_LFR);
   tmpVar_1 = (frequency - m_freqScale_min) * (1.f / (m_freqScale_max - m_freqScale_min));
   tmpVar_1 = std::clamp(tmpVar_1, -1.f, 1.f);
 
-  resonance = signals.get(SignalLabel::GAP_RES) * tmpVar_1;
+  resonance = signals.get(Signals::GAP_RES) * tmpVar_1;
 
   tmpVar_1 = std::clamp(frequency, m_freqClip_min, m_freqClip_max);  // R1
   tmpVar_1 *= m_warpConst_2PI;
@@ -335,7 +335,7 @@ void ae_gapfilter::apply(float _rawSample_L, float _rawSample_R, SignalStorage &
   hp_sample = tmpVar;
 
   //****************************** Lowpass L ******************************//
-  tmpVar = hp_sample * signals.get(SignalLabel::GAP_HPLP) + _rawSample_L * signals.get(SignalLabel::GAP_INLP);
+  tmpVar = hp_sample * signals.get(Signals::GAP_HPLP) + _rawSample_L * signals.get(Signals::GAP_INLP);
 
   float lp_sample = m_lp_l1_b0 * tmpVar;  // L1
   lp_sample += m_lp_l1_b1 * m_lp_l1_stateVar_1;
@@ -359,9 +359,9 @@ void ae_gapfilter::apply(float _rawSample_L, float _rawSample_R, SignalStorage &
   m_lp_l2_stateVar_4 = m_lp_l2_stateVar_3 + NlToolbox::Constants::DNC_const;
   m_lp_l2_stateVar_3 = tmpVar + NlToolbox::Constants::DNC_const;
 
-  lp_sample = tmpVar * signals.get(SignalLabel::GAP_LPOUT);
-  hp_sample *= signals.get(SignalLabel::GAP_HPOUT);
-  m_out_L = hp_sample + lp_sample + (_rawSample_L * signals.get(SignalLabel::GAP_INOUT));
+  lp_sample = tmpVar * signals.get(Signals::GAP_LPOUT);
+  hp_sample *= signals.get(Signals::GAP_HPOUT);
+  m_out_L = hp_sample + lp_sample + (_rawSample_L * signals.get(Signals::GAP_INOUT));
 
   //***************************** Highpass R ******************************//
   hp_sample = m_hp_r1_b0 * _rawSample_R;  // R1
@@ -389,7 +389,7 @@ void ae_gapfilter::apply(float _rawSample_L, float _rawSample_R, SignalStorage &
   hp_sample = tmpVar;
 
   //****************************** Lowpass R ******************************//
-  tmpVar = hp_sample * signals.get(SignalLabel::GAP_HPLP) + _rawSample_R * signals.get(SignalLabel::GAP_INLP);
+  tmpVar = hp_sample * signals.get(Signals::GAP_HPLP) + _rawSample_R * signals.get(Signals::GAP_INLP);
 
   lp_sample = m_lp_r1_b0 * tmpVar;  // R1
   lp_sample += m_lp_r1_b1 * m_lp_r1_stateVar_1;
@@ -413,9 +413,9 @@ void ae_gapfilter::apply(float _rawSample_L, float _rawSample_R, SignalStorage &
   m_lp_r2_stateVar_4 = m_lp_r2_stateVar_3 + NlToolbox::Constants::DNC_const;
   m_lp_r2_stateVar_3 = tmpVar + NlToolbox::Constants::DNC_const;
 
-  lp_sample = tmpVar * signals.get(SignalLabel::GAP_LPOUT);
-  hp_sample *= signals.get(SignalLabel::GAP_HPOUT);
-  m_out_R = hp_sample + lp_sample + (_rawSample_R * signals.get(SignalLabel::GAP_INOUT));
+  lp_sample = tmpVar * signals.get(Signals::GAP_LPOUT);
+  hp_sample *= signals.get(Signals::GAP_HPOUT);
+  m_out_R = hp_sample + lp_sample + (_rawSample_R * signals.get(Signals::GAP_INOUT));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_outputmixer.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_outputmixer.cpp
@@ -57,40 +57,40 @@ void ae_outputmixer::combine(float _sampleA, float _sampleB, float _sampleComb, 
                              SignalStorage &signals, uint32_t _voiceID)
 {
   //******************************* Left Mix *******************************//
-  float mainSample = signals.get(SignalLabel::OUT_A_L) * _sampleA + signals.get(SignalLabel::OUT_B_L) * _sampleB
-      + signals.get(SignalLabel::OUT_CMB_L) * _sampleComb + signals.get(SignalLabel::OUT_SVF_L) * _sampleSVFilter;
+  float mainSample = signals.get(Signals::OUT_A_L) * _sampleA + signals.get(Signals::OUT_B_L) * _sampleB
+      + signals.get(Signals::OUT_CMB_L) * _sampleComb + signals.get(Signals::OUT_SVF_L) * _sampleSVFilter;
 
   //************************* Left Sample Shaper ***************************//
-  mainSample *= signals.get(SignalLabel::OUT_DRV);
+  mainSample *= signals.get(Signals::OUT_DRV);
   float tmpVar = mainSample;
 
   mainSample = NlToolbox::Math::sinP3_wrap(mainSample);
-  mainSample = NlToolbox::Others::threeRanges(mainSample, tmpVar, signals.get(SignalLabel::OUT_FLD));
+  mainSample = NlToolbox::Others::threeRanges(mainSample, tmpVar, signals.get(Signals::OUT_FLD));
 
   tmpVar = mainSample * mainSample;
   tmpVar = tmpVar - m_hp30hz_stateVar_L[_voiceID];
   m_hp30hz_stateVar_L[_voiceID] = tmpVar * m_hp30hz_b0 + m_hp30hz_stateVar_L[_voiceID] + DNC_const;
 
-  mainSample = NlToolbox::Others::parAsym(mainSample, tmpVar, signals.get(SignalLabel::OUT_ASM));
+  mainSample = NlToolbox::Others::parAsym(mainSample, tmpVar, signals.get(Signals::OUT_ASM));
 
   m_out_L += mainSample;
 
   //****************************** Right Mix *******************************//
-  mainSample = signals.get(SignalLabel::OUT_A_R) * _sampleA + signals.get(SignalLabel::OUT_B_R) * _sampleB
-      + signals.get(SignalLabel::OUT_CMB_R) * _sampleComb + signals.get(SignalLabel::OUT_SVF_R) * _sampleSVFilter;
+  mainSample = signals.get(Signals::OUT_A_R) * _sampleA + signals.get(Signals::OUT_B_R) * _sampleB
+      + signals.get(Signals::OUT_CMB_R) * _sampleComb + signals.get(Signals::OUT_SVF_R) * _sampleSVFilter;
 
   //************************ Right Sample Shaper ***************************//
-  mainSample *= signals.get(SignalLabel::OUT_DRV);
+  mainSample *= signals.get(Signals::OUT_DRV);
   tmpVar = mainSample;
 
   mainSample = NlToolbox::Math::sinP3_wrap(mainSample);
-  mainSample = NlToolbox::Others::threeRanges(mainSample, tmpVar, signals.get(SignalLabel::OUT_FLD));
+  mainSample = NlToolbox::Others::threeRanges(mainSample, tmpVar, signals.get(Signals::OUT_FLD));
 
   tmpVar = mainSample * mainSample;
   tmpVar = tmpVar - m_hp30hz_stateVar_R[_voiceID];
   m_hp30hz_stateVar_R[_voiceID] = tmpVar * m_hp30hz_b0 + m_hp30hz_stateVar_R[_voiceID] + DNC_const;
 
-  mainSample = NlToolbox::Others::parAsym(mainSample, tmpVar, signals.get(SignalLabel::OUT_ASM));
+  mainSample = NlToolbox::Others::parAsym(mainSample, tmpVar, signals.get(Signals::OUT_ASM));
 
   m_out_R += mainSample;
 }
@@ -115,8 +115,8 @@ void ae_outputmixer::filter_level(SignalStorage &signals)
   m_hp_stateVar_R1 = m_out_R + DNC_const;
   m_hp_stateVar_R2 = tmpVar + DNC_const;
 
-  m_out_L *= signals.get(SignalLabel::OUT_LVL);
-  m_out_R *= signals.get(SignalLabel::OUT_LVL);
+  m_out_L *= signals.get(Signals::OUT_LVL);
+  m_out_R *= signals.get(Signals::OUT_LVL);
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_reverb.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_reverb.cpp
@@ -132,7 +132,7 @@ void ae_reverb::set(SignalStorage &signals)
   float tmp_target;
 #if test_reverbSmoother == 1
 
-  tmpVar = signals.get(SignalLabel::REV_SIZE);
+  tmpVar = signals.get(Signals::REV_SIZE);
   //    tmp_target = signals.get(SignalLabel::REV_CHO) * (tmpVar * -200.f + 311.f);
   //    if (m_depth_target - tmp_target != 0.f)
   //    {
@@ -141,7 +141,7 @@ void ae_reverb::set(SignalStorage &signals)
   //        m_depth_diff = m_depth_target - m_depth_base;
   //        m_depth_ramp = 0.f;
   //    }
-  tmp_target = signals.get(SignalLabel::REV_CHO) * (tmpVar * -200.f + 311.f);
+  tmp_target = signals.get(Signals::REV_CHO) * (tmpVar * -200.f + 311.f);
   if(m_depth_target - tmp_target != 0.f)
   {
     m_depth_inc = (m_depth_target - m_depth) * m_smooth_inc;
@@ -156,7 +156,7 @@ void ae_reverb::set(SignalStorage &signals)
     m_size_ramp = 0.f;
   }
 
-  tmp_target = signals.get(SignalLabel::REV_BAL);
+  tmp_target = signals.get(Signals::REV_BAL);
   if(m_bal_target - tmp_target != 0.f)
   {
     m_bal_target = tmp_target;
@@ -165,7 +165,7 @@ void ae_reverb::set(SignalStorage &signals)
     m_bal_ramp = 0.f;
   }
 
-  tmpVar = signals.get(SignalLabel::REV_PRE);
+  tmpVar = signals.get(Signals::REV_PRE);
   tmp_target = std::round(tmpVar);
   if(m_preDel_L_target - tmp_target != 0.f)
   {
@@ -184,7 +184,7 @@ void ae_reverb::set(SignalStorage &signals)
     m_preDel_R_ramp = 0.f;
   }
 
-  tmp_target = std::clamp(signals.get(SignalLabel::REV_LPF), 0.1f, m_omegaClip_max);
+  tmp_target = std::clamp(signals.get(Signals::REV_LPF), 0.1f, m_omegaClip_max);
   tmp_target = NlToolbox::Math::tan(tmp_target * m_warpConst_PI);
   if(m_lp_omega_target - tmp_target != 0.f)
   {
@@ -194,7 +194,7 @@ void ae_reverb::set(SignalStorage &signals)
     m_lp_omega_ramp = 0.f;
   }
 
-  tmp_target = std::clamp(signals.get(SignalLabel::REV_HPF), 0.1f, m_omegaClip_max);
+  tmp_target = std::clamp(signals.get(Signals::REV_HPF), 0.1f, m_omegaClip_max);
   tmp_target = NlToolbox::Math::tan(tmp_target * m_warpConst_PI);
   if(m_hp_omega_target - tmp_target != 0.f)
   {
@@ -365,7 +365,7 @@ void ae_reverb::apply(float _rawSample_L, float _rawSample_R, SignalStorage &sig
 
   //************************************************************************//
   //**************************** Left Channel ******************************//
-  wetSample_L = _rawSample_L * signals.get(SignalLabel::REV_SND) * signals.get(SignalLabel::REV_FEED);
+  wetSample_L = _rawSample_L * signals.get(Signals::REV_SND) * signals.get(Signals::REV_FEED);
 
   //****************************** Asym 2 L ********************************//
   m_buffer_L[m_buffer_indx] = wetSample_L;
@@ -524,7 +524,7 @@ void ae_reverb::apply(float _rawSample_L, float _rawSample_R, SignalStorage &sig
 
   //************************************************************************//
   //*************************** Right Channel ******************************//
-  wetSample_R = _rawSample_R * signals.get(SignalLabel::REV_SND) * signals.get(SignalLabel::REV_FEED);
+  wetSample_R = _rawSample_R * signals.get(Signals::REV_SND) * signals.get(Signals::REV_FEED);
 
   //****************************** Asym 2 R ********************************//
   m_buffer_R[m_buffer_indx] = wetSample_R;
@@ -742,11 +742,11 @@ void ae_reverb::apply(float _rawSample_L, float _rawSample_R, SignalStorage &sig
   wetSample_L = wetSample_L * m_bal_full + wetSample_L2 * m_bal_half;
   wetSample_R = wetSample_R * m_bal_full + wetSample_R2 * m_bal_half;
 
-  m_out_L = _rawSample_L * signals.get(SignalLabel::REV_DRY) + wetSample_L * signals.get(SignalLabel::REV_WET);
-  m_out_R = _rawSample_R * signals.get(SignalLabel::REV_DRY) + wetSample_R * signals.get(SignalLabel::REV_WET);
+  m_out_L = _rawSample_L * signals.get(Signals::REV_DRY) + wetSample_L * signals.get(Signals::REV_WET);
+  m_out_R = _rawSample_R * signals.get(Signals::REV_DRY) + wetSample_R * signals.get(Signals::REV_WET);
 
-  m_out_FX = ((_rawSample_L + _rawSample_R) * (1.f - signals.get(SignalLabel::FBM_REV)))
-      + ((wetSample_L + wetSample_R) * signals.get(SignalLabel::FBM_REV));
+  m_out_FX = ((_rawSample_L + _rawSample_R) * (1.f - signals.get(Signals::FBM_REV)))
+      + ((wetSample_L + wetSample_R) * signals.get(Signals::FBM_REV));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_soundgenerator.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_soundgenerator.cpp
@@ -57,14 +57,14 @@ void ae_soundgenerator::init(float _samplerate, uint32_t _vn)
 void ae_soundgenerator::set(SignalStorage &signals)
 {
   //*************************** Chirp Filter A *****************************//
-  m_chiA_omega = signals.get(SignalLabel::OSC_A_CHI) * m_warpConst_PI;
+  m_chiA_omega = signals.get(Signals::OSC_A_CHI) * m_warpConst_PI;
   m_chiA_omega = NlToolbox::Math::tan(m_chiA_omega);
 
   m_chiA_a0 = 1.f / (m_chiA_omega + 1.f);
   m_chiA_a1 = m_chiA_omega - 1.f;
 
   //*************************** Chirp Filter B *****************************//
-  m_chiB_omega = signals.get(SignalLabel::OSC_B_CHI) * m_warpConst_PI;
+  m_chiB_omega = signals.get(Signals::OSC_B_CHI) * m_warpConst_PI;
   m_chiB_omega = NlToolbox::Math::tan(m_chiB_omega);
 
   m_chiB_a0 = 1.f / (m_chiB_omega + 1.f);
@@ -100,9 +100,9 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
   float tmpVar;
 
   //**************************** Modulation A ******************************//
-  float oscSampleA = m_oscA_selfmix * signals.get(SignalLabel::OSC_A_PMSEA);
-  oscSampleA = oscSampleA + m_oscB_crossmix * signals.get(SignalLabel::OSC_A_PMBEB);
-  oscSampleA = oscSampleA + m_feedback_phase * signals.get(SignalLabel::OSC_A_PMFEC);
+  float oscSampleA = m_oscA_selfmix * signals.get(Signals::OSC_A_PMSEA);
+  oscSampleA = oscSampleA + m_oscB_crossmix * signals.get(Signals::OSC_A_PMBEB);
+  oscSampleA = oscSampleA + m_feedback_phase * signals.get(Signals::OSC_A_PMFEC);
 
   //**************************** Oscillator A ******************************//
   oscSampleA -= (m_chiA_a1 * m_chiA_stateVar);  // Chirp IIR
@@ -115,7 +115,7 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
 
   oscSampleA += m_oscA_phase;
 
-  oscSampleA += signals.get(SignalLabel::OSC_A_PHS) + signals.get(SignalLabel::UN_PHS);  // NEW Phase Offset
+  oscSampleA += signals.get(Signals::OSC_A_PHS) + signals.get(Signals::UN_PHS);  // NEW Phase Offset
   oscSampleA += (-0.25f);                                                                // Wrap
   oscSampleA -= NlToolbox::Conversion::float2int(oscSampleA);
 
@@ -125,9 +125,9 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
     m_OscA_randVal_float = static_cast<float>(m_OscA_randVal_int) * 4.5657e-10f;
   }
 
-  float osc_freq = signals.get(SignalLabel::OSC_A_FRQ);
+  float osc_freq = signals.get(Signals::OSC_A_FRQ);
   m_oscA_phaseInc
-      = ((m_OscA_randVal_float * signals.get(SignalLabel::OSC_A_FLUEC) * osc_freq) + osc_freq) * m_sample_interval;
+      = ((m_OscA_randVal_float * signals.get(Signals::OSC_A_FLUEC) * osc_freq) + osc_freq) * m_sample_interval;
 
   m_oscA_phase_stateVar = oscSampleA;
 
@@ -137,9 +137,9 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
   oscSampleA = m_mute_state[m_OscA_mute] * NlToolbox::Math::sinP3_noWrap(oscSampleA);
 
   //**************************** Modulation B ******************************//
-  float oscSampleB = m_oscB_selfmix * signals.get(SignalLabel::OSC_B_PMSEB);
-  oscSampleB = oscSampleB + m_oscA_crossmix * signals.get(SignalLabel::OSC_B_PMAEA);
-  oscSampleB = oscSampleB + m_feedback_phase * signals.get(SignalLabel::OSC_B_PMFEC);
+  float oscSampleB = m_oscB_selfmix * signals.get(Signals::OSC_B_PMSEB);
+  oscSampleB = oscSampleB + m_oscA_crossmix * signals.get(Signals::OSC_B_PMAEA);
+  oscSampleB = oscSampleB + m_feedback_phase * signals.get(Signals::OSC_B_PMFEC);
 
   //**************************** Oscillator B ******************************//
   oscSampleB -= (m_chiB_a1 * m_chiB_stateVar);  // Chirp IIR
@@ -152,7 +152,7 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
 
   oscSampleB += m_oscB_phase;
 
-  oscSampleB += signals.get(SignalLabel::OSC_B_PHS) + signals.get(SignalLabel::UN_PHS);  // NEW Phase Offset
+  oscSampleB += signals.get(Signals::OSC_B_PHS) + signals.get(Signals::UN_PHS);  // NEW Phase Offset
   oscSampleB += (-0.25f);                                                                // Warp
   oscSampleB -= NlToolbox::Conversion::float2int(oscSampleB);
 
@@ -162,9 +162,9 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
     m_OscB_randVal_float = static_cast<float>(m_OscB_randVal_int) * 4.5657e-10f;
   }
 
-  osc_freq = signals.get(SignalLabel::OSC_B_FRQ);
+  osc_freq = signals.get(Signals::OSC_B_FRQ);
   m_oscB_phaseInc
-      = ((m_OscB_randVal_float * signals.get(SignalLabel::OSC_B_FLUEC) * osc_freq) + osc_freq) * m_sample_interval;
+      = ((m_OscB_randVal_float * signals.get(Signals::OSC_B_FLUEC) * osc_freq) + osc_freq) * m_sample_interval;
 
   m_oscB_phase_stateVar = oscSampleB;
 
@@ -174,57 +174,57 @@ void ae_soundgenerator::generate(float _feedbackSample, SignalStorage &signals)
   oscSampleB = m_mute_state[m_OscB_mute] * NlToolbox::Math::sinP3_noWrap(oscSampleB);
 
   //******************************* Shaper A *******************************//
-  float shaperSampleA = oscSampleA * signals.get(SignalLabel::SHP_A_DRVEA);
+  float shaperSampleA = oscSampleA * signals.get(Signals::SHP_A_DRVEA);
   tmpVar = shaperSampleA;
 
   shaperSampleA = NlToolbox::Math::sinP3_wrap(shaperSampleA);
-  shaperSampleA = NlToolbox::Others::threeRanges(shaperSampleA, tmpVar, signals.get(SignalLabel::SHP_A_FLD));
+  shaperSampleA = NlToolbox::Others::threeRanges(shaperSampleA, tmpVar, signals.get(Signals::SHP_A_FLD));
 
   tmpVar = shaperSampleA * shaperSampleA + (-0.5f);
 
-  shaperSampleA = NlToolbox::Others::parAsym(shaperSampleA, tmpVar, signals.get(SignalLabel::SHP_A_ASM));
+  shaperSampleA = NlToolbox::Others::parAsym(shaperSampleA, tmpVar, signals.get(Signals::SHP_A_ASM));
 
   //******************************* Shaper B *******************************//
-  float shaperSampleB = oscSampleB * signals.get(SignalLabel::SHP_B_DRVEB);
+  float shaperSampleB = oscSampleB * signals.get(Signals::SHP_B_DRVEB);
   tmpVar = shaperSampleB;
 
   shaperSampleB = NlToolbox::Math::sinP3_wrap(shaperSampleB);
-  shaperSampleB = NlToolbox::Others::threeRanges(shaperSampleB, tmpVar, signals.get(SignalLabel::SHP_B_FLD));
+  shaperSampleB = NlToolbox::Others::threeRanges(shaperSampleB, tmpVar, signals.get(Signals::SHP_B_FLD));
 
   tmpVar = shaperSampleB * shaperSampleB + (-0.5f);
 
-  shaperSampleB = NlToolbox::Others::parAsym(shaperSampleB, tmpVar, signals.get(SignalLabel::SHP_B_ASM));
+  shaperSampleB = NlToolbox::Others::parAsym(shaperSampleB, tmpVar, signals.get(Signals::SHP_B_ASM));
 
   //****************************** Crossfades ******************************//
   m_oscA_selfmix
-      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(SignalLabel::OSC_A_PMSSH));
+      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(Signals::OSC_A_PMSSH));
   m_oscA_crossmix
-      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(SignalLabel::OSC_B_PMASH));
+      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(Signals::OSC_B_PMASH));
 
   m_oscB_selfmix
-      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(SignalLabel::OSC_B_PMSSH));
+      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(Signals::OSC_B_PMSSH));
   m_oscB_crossmix
-      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(SignalLabel::OSC_A_PMBSH));
+      = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(Signals::OSC_A_PMBSH));
 
-  m_out_A = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(SignalLabel::SHP_A_MIX));
-  m_out_B = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(SignalLabel::SHP_B_MIX));
+  m_out_A = NlToolbox::Crossfades::bipolarCrossFade(oscSampleA, shaperSampleA, signals.get(Signals::SHP_A_MIX));
+  m_out_B = NlToolbox::Crossfades::bipolarCrossFade(oscSampleB, shaperSampleB, signals.get(Signals::SHP_B_MIX));
 
   //******************* Envelope Influence (Magnitudes) ********************//
-  m_out_A *= signals.get(SignalLabel::ENV_A_MAG);
-  m_out_B *= signals.get(SignalLabel::ENV_B_MAG);
+  m_out_A *= signals.get(Signals::ENV_A_MAG);
+  m_out_B *= signals.get(Signals::ENV_B_MAG);
 
   //**************************** Feedback Mix ******************************//
-  tmpVar = _feedbackSample * signals.get(SignalLabel::SHP_A_FBEC);
-  m_out_A = NlToolbox::Crossfades::unipolarCrossFade(m_out_A, tmpVar, signals.get(SignalLabel::SHP_A_FBM));
+  tmpVar = _feedbackSample * signals.get(Signals::SHP_A_FBEC);
+  m_out_A = NlToolbox::Crossfades::unipolarCrossFade(m_out_A, tmpVar, signals.get(Signals::SHP_A_FBM));
 
-  tmpVar = _feedbackSample * signals.get(SignalLabel::SHP_B_FBEC);
-  m_out_B = NlToolbox::Crossfades::unipolarCrossFade(m_out_B, tmpVar, signals.get(SignalLabel::SHP_B_FBM));
+  tmpVar = _feedbackSample * signals.get(Signals::SHP_B_FBEC);
+  m_out_B = NlToolbox::Crossfades::unipolarCrossFade(m_out_B, tmpVar, signals.get(Signals::SHP_B_FBM));
 
   //************************** Ring Modulation *****************************//
   tmpVar = m_out_A * m_out_B;
 
-  m_out_A = NlToolbox::Crossfades::unipolarCrossFade(m_out_A, tmpVar, signals.get(SignalLabel::SHP_A_RM));
-  m_out_B = NlToolbox::Crossfades::unipolarCrossFade(m_out_B, tmpVar, signals.get(SignalLabel::SHP_B_RM));
+  m_out_A = NlToolbox::Crossfades::unipolarCrossFade(m_out_A, tmpVar, signals.get(Signals::SHP_A_RM));
+  m_out_B = NlToolbox::Crossfades::unipolarCrossFade(m_out_B, tmpVar, signals.get(Signals::SHP_B_RM));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_svfilter.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_svfilter.cpp
@@ -44,21 +44,21 @@ void ae_svfilter::init(float _samplerate)
 
 void ae_svfilter::apply(float _sampleA, float _sampleB, float _sampleComb, SignalStorage &signals)
 {
-  float tmpRes = signals.get(SignalLabel::SVF_RES);
+  float tmpRes = signals.get(Signals::SVF_RES);
 
   //******************************** Sample Mix ****************************//
-  float tmpVar = signals.get(SignalLabel::SVF_AB);
+  float tmpVar = signals.get(Signals::SVF_AB);
   float mixSample = _sampleB * (1.f - tmpVar) + _sampleA * tmpVar;
-  tmpVar = signals.get(SignalLabel::SVF_CMIX);
+  tmpVar = signals.get(Signals::SVF_CMIX);
   mixSample = mixSample * (1.f - std::abs(tmpVar)) + _sampleComb * tmpVar;
 
   //************************** Frequency Modulation ************************//
-  float fmVar = _sampleA * signals.get(SignalLabel::SVF_FMAB) + _sampleB * (1.f - signals.get(SignalLabel::SVF_FMAB));
+  float fmVar = _sampleA * signals.get(Signals::SVF_FMAB) + _sampleB * (1.f - signals.get(Signals::SVF_FMAB));
 
   //************************** 1st Stage SV FILTER *************************//
   float inputSample = mixSample + (m_first_sat_stateVar * 0.1f);
 
-  float omega = (signals.get(SignalLabel::SVF_F1_CUT) + fmVar * signals.get(SignalLabel::SVF_F1_FM)) * m_warpConst_2PI;
+  float omega = (signals.get(Signals::SVF_F1_CUT) + fmVar * signals.get(Signals::SVF_F1_FM)) * m_warpConst_2PI;
   omega = std::clamp(omega, 0.f, test_svf_fm_limit);  /// initially 1.5f
 
   float attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
@@ -70,19 +70,19 @@ void ae_svfilter::apply(float _sampleA, float _sampleB, float _sampleComb, Signa
   m_first_int1_stateVar = bandpassOutput + DNC_const;
   m_first_int2_stateVar = lowpassOutput + DNC_const;
 
-  float outputSample_1 = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_1)), 0.f);
-  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_1))));
-  outputSample_1 += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_1), 0.f));
+  float outputSample_1 = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_1)), 0.f);
+  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_1))));
+  outputSample_1 += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_1), 0.f));
 
   //************************** 1st Stage Parabol Sat ***********************//
   m_first_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_first_sat_stateVar *= (1.f - std::abs(m_first_sat_stateVar) * 0.25f);
 
   //************************** 2nd Stage SV FILTER *************************//
-  inputSample = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_3)) + (mixSample * signals.get(SignalLabel::SVF_PAR_4))
+  inputSample = (outputSample_1 * signals.get(Signals::SVF_PAR_3)) + (mixSample * signals.get(Signals::SVF_PAR_4))
       + (m_second_sat_stateVar * 0.1f);
 
-  omega = (signals.get(SignalLabel::SVF_F2_CUT) + fmVar * signals.get(SignalLabel::SVF_F2_FM)) * m_warpConst_2PI;
+  omega = (signals.get(Signals::SVF_F2_CUT) + fmVar * signals.get(Signals::SVF_F2_FM)) * m_warpConst_2PI;
   omega = std::clamp(omega, 0.f, test_svf_fm_limit);  /// initially 1.5f
 
   attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
@@ -94,16 +94,16 @@ void ae_svfilter::apply(float _sampleA, float _sampleB, float _sampleComb, Signa
   m_second_int1_stateVar = bandpassOutput + DNC_const;
   m_second_int2_stateVar = lowpassOutput + DNC_const;
 
-  tmpVar = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_2)), 0.f);
-  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_2))));
-  tmpVar += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_2), 0.f));
+  tmpVar = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_2)), 0.f);
+  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_2))));
+  tmpVar += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_2), 0.f));
 
   //************************* 2nd Stage Parabol Sat ************************//
   m_second_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_second_sat_stateVar *= (1.f - std::abs(m_second_sat_stateVar) * 0.25f);
 
   //****************************** Crossfades ******************************//
-  m_out = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_1)) + (tmpVar * signals.get(SignalLabel::SVF_PAR_2));
+  m_out = (outputSample_1 * signals.get(Signals::SVF_PAR_1)) + (tmpVar * signals.get(Signals::SVF_PAR_2));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_svfilter_fir.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_svfilter_fir.cpp
@@ -46,21 +46,21 @@ void ae_svfilter_fir::init(float _samplerate)
 
 void ae_svfilter_fir::apply(float _sampleA, float _sampleB, float _sampleComb, SignalStorage &signals)
 {
-  float tmpRes = signals.get(SignalLabel::SVF_RES);
+  float tmpRes = signals.get(Signals::SVF_RES);
 
   //******************************** Sample Mix ****************************//
-  float tmpVar = signals.get(SignalLabel::SVF_AB);
+  float tmpVar = signals.get(Signals::SVF_AB);
   float mixSample = _sampleB * (1.f - tmpVar) + _sampleA * tmpVar;
-  tmpVar = signals.get(SignalLabel::SVF_CMIX);
+  tmpVar = signals.get(Signals::SVF_CMIX);
   mixSample = mixSample * (1.f - std::abs(tmpVar)) + _sampleComb * tmpVar;
 
   //************************** Frequency Modulation ************************//
-  float fmVar = _sampleA * signals.get(SignalLabel::SVF_FMAB) + _sampleB * (1.f - signals.get(SignalLabel::SVF_FMAB));
+  float fmVar = _sampleA * signals.get(Signals::SVF_FMAB) + _sampleB * (1.f - signals.get(Signals::SVF_FMAB));
 
   //************************** 1st Stage SV FILTER *************************//
   float inputSample = mixSample + (m_first_sat_stateVar * 0.1f);
 
-  float omega = (signals.get(SignalLabel::SVF_F1_CUT) + fmVar * signals.get(SignalLabel::SVF_F1_FM)) * m_warpConst_2PI;
+  float omega = (signals.get(Signals::SVF_F1_CUT) + fmVar * signals.get(Signals::SVF_F1_FM)) * m_warpConst_2PI;
   omega = std::clamp(omega, 0.f, test_svf_fm_limit);  /// initially 1.5f
 
   float attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
@@ -80,19 +80,19 @@ void ae_svfilter_fir::apply(float _sampleA, float _sampleB, float _sampleComb, S
   m_first_int1_stateVar = int1Out + DNC_const;
   m_first_int2_stateVar = int2Out + DNC_const;
 
-  float outputSample_1 = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_1)), 0.f);
-  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_1))));
-  outputSample_1 += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_1), 0.f));
+  float outputSample_1 = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_1)), 0.f);
+  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_1))));
+  outputSample_1 += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_1), 0.f));
 
   //************************** 1st Stage Parabol Sat ***********************//
   m_first_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_first_sat_stateVar *= (1.f - std::abs(m_first_sat_stateVar) * 0.25f);
 
   //************************** 2nd Stage SV FILTER *************************//
-  inputSample = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_3))
-      + (mixSample * signals.get(SignalLabel::SVF_PAR_4)) + (m_second_sat_stateVar * 0.1f);
+  inputSample = (outputSample_1 * signals.get(Signals::SVF_PAR_3))
+      + (mixSample * signals.get(Signals::SVF_PAR_4)) + (m_second_sat_stateVar * 0.1f);
 
-  omega = (signals.get(SignalLabel::SVF_F2_CUT) + fmVar * signals.get(SignalLabel::SVF_F2_FM)) * m_warpConst_2PI;
+  omega = (signals.get(Signals::SVF_F2_CUT) + fmVar * signals.get(Signals::SVF_F2_FM)) * m_warpConst_2PI;
   omega = std::clamp(omega, 0.f, test_svf_fm_limit);  /// initially 1.5f
 
   attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
@@ -112,16 +112,16 @@ void ae_svfilter_fir::apply(float _sampleA, float _sampleB, float _sampleComb, S
   m_second_int1_stateVar = int1Out + DNC_const;
   m_second_int2_stateVar = int2Out + DNC_const;
 
-  tmpVar = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_2)), 0.f);
-  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_2))));
-  tmpVar += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_2), 0.f));
+  tmpVar = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_2)), 0.f);
+  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_2))));
+  tmpVar += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_2), 0.f));
 
   //************************* 2nd Stage Parabol Sat ************************//
   m_second_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_second_sat_stateVar *= (1.f - std::abs(m_second_sat_stateVar) * 0.25f);
 
   //****************************** Crossfades ******************************//
-  m_out = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_1)) + (tmpVar * signals.get(SignalLabel::SVF_PAR_2));
+  m_out = (outputSample_1 * signals.get(Signals::SVF_PAR_1)) + (tmpVar * signals.get(Signals::SVF_PAR_2));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/ae_svfilter_proto.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/ae_svfilter_proto.cpp
@@ -47,26 +47,26 @@ void ae_svfilter_proto::init(float _samplerate)
 
 void ae_svfilter_proto::apply(float _sampleA, float _sampleB, float _sampleComb, SignalStorage &signals)
 {
-  float tmpRes = signals.get(SignalLabel::SVF_RES);
+  float tmpRes = signals.get(Signals::SVF_RES);
 
   //******************************** Sample Mix ****************************//
-  float tmpVar = signals.get(SignalLabel::SVF_AB);
+  float tmpVar = signals.get(Signals::SVF_AB);
   float mixSample = _sampleB * (1.f - tmpVar) + _sampleA * tmpVar;
-  tmpVar = signals.get(SignalLabel::SVF_CMIX);
+  tmpVar = signals.get(Signals::SVF_CMIX);
   mixSample = mixSample * (1.f - std::abs(tmpVar)) + _sampleComb * tmpVar;
 
   //************************** Frequency Modulation ************************//
-  float fmVar = _sampleA * signals.get(SignalLabel::SVF_FMAB) + _sampleB * (1.f - signals.get(SignalLabel::SVF_FMAB));
+  float fmVar = _sampleA * signals.get(Signals::SVF_FMAB) + _sampleB * (1.f - signals.get(Signals::SVF_FMAB));
 
   //************************** 1st Stage SV FILTER *************************//
   float inputSample = mixSample + (m_first_sat_stateVar * 0.1f);
 
-  float omega = signals.get(SignalLabel::SVF_F1_CUT) * m_warpConst_2PI;
+  float omega = signals.get(Signals::SVF_F1_CUT) * m_warpConst_2PI;
   omega = std::min(omega, test_svf_fm_limit);  /// initially 1.9f
 
   float attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
 
-  omega = (signals.get(SignalLabel::SVF_F1_CUT) + fmVar * signals.get(SignalLabel::SVF_F1_FM)) * m_warpConst_2PI;
+  omega = (signals.get(Signals::SVF_F1_CUT) + fmVar * signals.get(Signals::SVF_F1_FM)) * m_warpConst_2PI;
   omega = std::min(omega, test_svf_fm_limit);  /// initially 1.9f
 
   float firOut = (m_first_fir_stateVar + inputSample) * 0.25f;
@@ -84,24 +84,24 @@ void ae_svfilter_proto::apply(float _sampleA, float _sampleB, float _sampleComb,
   m_first_int1_stateVar = int1Out + DNC_const;
   m_first_int2_stateVar = int2Out + DNC_const;
 
-  float outputSample_1 = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_1)), 0.f);
-  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_1))));
-  outputSample_1 += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_1), 0.f));
+  float outputSample_1 = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_1)), 0.f);
+  outputSample_1 += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_1))));
+  outputSample_1 += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_1), 0.f));
 
   //************************** 1st Stage Parabol Sat ***********************//
   m_first_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_first_sat_stateVar *= (1.f - std::abs(m_first_sat_stateVar) * 0.25f);
 
   //************************** 2nd Stage SV FILTER *************************//
-  inputSample = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_3))
-      + (mixSample * signals.get(SignalLabel::SVF_PAR_4)) + (m_second_sat_stateVar * 0.1f);
+  inputSample = (outputSample_1 * signals.get(Signals::SVF_PAR_3))
+      + (mixSample * signals.get(Signals::SVF_PAR_4)) + (m_second_sat_stateVar * 0.1f);
 
-  omega = signals.get(SignalLabel::SVF_F2_CUT) * m_warpConst_2PI;
+  omega = signals.get(Signals::SVF_F2_CUT) * m_warpConst_2PI;
   omega = std::min(omega, test_svf_fm_limit);  /// initially 1.9f
 
   attenuation = ((2.f + omega) * (2.f - omega) * tmpRes) / (((tmpRes * omega) + (2.f - omega)) * 2.f);
 
-  omega = (signals.get(SignalLabel::SVF_F2_CUT) + fmVar * signals.get(SignalLabel::SVF_F2_FM)) * m_warpConst_2PI;
+  omega = (signals.get(Signals::SVF_F2_CUT) + fmVar * signals.get(Signals::SVF_F2_FM)) * m_warpConst_2PI;
   omega = std::min(omega, test_svf_fm_limit);  /// initially 1.9f
 
   firOut = (m_second_fir_stateVar + inputSample) * 0.25f;
@@ -119,16 +119,16 @@ void ae_svfilter_proto::apply(float _sampleA, float _sampleB, float _sampleComb,
   m_second_int1_stateVar = int1Out + DNC_const;
   m_second_int2_stateVar = int2Out + DNC_const;
 
-  tmpVar = lowpassOutput * std::max(-(signals.get(SignalLabel::SVF_LBH_2)), 0.f);
-  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(SignalLabel::SVF_LBH_2))));
-  tmpVar += (highpassOutput * std::max(signals.get(SignalLabel::SVF_LBH_2), 0.f));
+  tmpVar = lowpassOutput * std::max(-(signals.get(Signals::SVF_LBH_2)), 0.f);
+  tmpVar += (bandpassOutput * (1.f - std::abs(signals.get(Signals::SVF_LBH_2))));
+  tmpVar += (highpassOutput * std::max(signals.get(Signals::SVF_LBH_2), 0.f));
 
   //************************* 2nd Stage Parabol Sat ************************//
   m_second_sat_stateVar = std::clamp(bandpassOutput, -2.f, 2.f);
   m_second_sat_stateVar *= (1.f - std::abs(m_second_sat_stateVar) * 0.25f);
 
   //****************************** Crossfades ******************************//
-  m_out = (outputSample_1 * signals.get(SignalLabel::SVF_PAR_1)) + (tmpVar * signals.get(SignalLabel::SVF_PAR_2));
+  m_out = (outputSample_1 * signals.get(Signals::SVF_PAR_1)) + (tmpVar * signals.get(Signals::SVF_PAR_2));
 }
 
 /******************************************************************************/

--- a/audio-engine/src/synth/c15-audio-engine/dsp_defines_signallabels.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_defines_signallabels.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-enum class SignalLabel
+enum class Signals
 {
 
   /* Envelope Signals                 -- polyphonic */

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -106,9 +106,9 @@ void dsp_host::tickMain()
   {
     /* render slow mono parameters and perform mono post processing */
 #if PARAM_ITERATOR == 0
-    for(const auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO))
+    for(const auto &it : m_params.m_parameters.getClockIds(ClockTypes::Slow, PolyTypes::Mono))
     {
-      auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index;
+      auto i = m_params.getHead(static_cast<Parameters>(it)).m_index;
       m_params.getBody(i).tick();
     }
 #else
@@ -124,9 +124,9 @@ void dsp_host::tickMain()
     for(uint32_t v = 0; v < m_voices; v++)
     {
 #if PARAM_ITERATOR == 0
-      for(const auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY))
+      for(const auto &it : m_params.m_parameters.getClockIds(ClockTypes::Slow, PolyTypes::Poly))
       {
-        auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index + v;
+        auto i = m_params.getHead(static_cast<Parameters>(it)).m_index + v;
         m_params.getBody(i).tick();
       }
 #else
@@ -149,9 +149,9 @@ void dsp_host::tickMain()
   {
     /* render fast mono parameters and perform mono post processing */
 #if PARAM_ITERATOR == 0
-    for(auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO))
+    for(auto &it : m_params.m_parameters.getClockIds(ClockTypes::Fast, PolyTypes::Mono))
     {
-      auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index;
+      auto i = m_params.getHead(static_cast<Parameters>(it)).m_index;
       m_params.getBody(i).tick();
     }
 #else
@@ -167,9 +167,9 @@ void dsp_host::tickMain()
     for(uint32_t v = 0; v < m_voices; v++)
     {
 #if PARAM_ITERATOR == 0
-      for(auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_POLY))
+      for(auto &it : m_params.m_parameters.getClockIds(ClockTypes::Fast, PolyTypes::Poly))
       {
-        auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index + v;
+        auto i = m_params.getHead(static_cast<Parameters>(it)).m_index + v;
         m_params.getBody(i).tick();
       }
 #else
@@ -187,9 +187,9 @@ void dsp_host::tickMain()
   }
   /* third: evaluate audio clock (always) - mono rendering and post processing, poly rendering and post processing */
 #if PARAM_ITERATOR == 0
-  for(auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto &it : m_params.m_parameters.getClockIds(ClockTypes::Audio, PolyTypes::Mono))
   {
-    auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index;
+    auto i = m_params.getHead(static_cast<Parameters>(it)).m_index;
     m_params.getBody(i).tick();
   }
 #else
@@ -210,9 +210,9 @@ void dsp_host::tickMain()
   {
     /* render poly audio parameters */
 #if PARAM_ITERATOR == 0
-    for(auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_POLY))
+    for(auto &it : m_params.m_parameters.getClockIds(ClockTypes::Audio, PolyTypes::Poly))
     {
-      auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index + v;
+      auto i = m_params.getHead(static_cast<Parameters>(it)).m_index + v;
       m_params.getBody(i).tick();
     }
 #else
@@ -524,14 +524,14 @@ void dsp_host::preloadUpdate(uint32_t _mode, uint32_t _listId)
       /* Trigger Slow Rendering and Post Processing (Key Events should be effective immediately) */
       /* render slow mono parameters and perform mono post processing */
 #if PARAM_ITERATOR == 0
-      for(const auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO))
+      for(const auto &it : m_params.m_parameters.getClockIds(ClockTypes::Slow, PolyTypes::Mono))
       {
-        auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index;
+        auto i = m_params.getHead(static_cast<Parameters>(it)).m_index;
         m_params.getBody(i).tick();
       }
 #else
-      auto end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO);
-      for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO); it != end; it++)
+      auto end = m_params.m_parameters.end(ClockTypes::Slow, PolyTypes::Mono);
+      for(param_body* it = m_params.m_parameters.begin(ClockTypes::Slow, PolyTypes::Mono); it != end; it++)
       {
         it->tick();
       }
@@ -541,14 +541,14 @@ void dsp_host::preloadUpdate(uint32_t _mode, uint32_t _listId)
       for(v = 0; v < m_voices; v++)
       {
 #if PARAM_ITERATOR == 0
-        for(const auto &it : m_params.m_parameters.getClockIds(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY))
+        for(const auto &it : m_params.m_parameters.getClockIds(ClockTypes::Slow, PolyTypes::Poly))
         {
-          auto i = m_params.getHead(static_cast<ParameterLabel>(it)).m_index + v;
+          auto i = m_params.getHead(static_cast<Parameters>(it)).m_index + v;
           m_params.getBody(i).tick();
         }
 #else
-        end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY, v);
-        for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY, v);
+        end = m_params.m_parameters.end(ClockTypes::Slow, PolyTypes::Poly, v);
+        for(param_body* it = m_params.m_parameters.begin(ClockTypes::Slow, PolyTypes::Poly, v);
             it != end; it += m_voices)
         {
           it->tick();
@@ -782,7 +782,7 @@ void dsp_host::keyApply(uint32_t _voiceId)
 
     /* determine note steal */
 #if test_milestone < 156
-    if(static_cast<uint32_t>(m_params.getParameterValue(ParameterLabel::P_KEY_VS)) == 1)
+    if(static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_KEY_VS)) == 1)
     {
       /* AUDIO_ENGINE: trigger voice-steal */
     }
@@ -802,17 +802,17 @@ void dsp_host::keyApply(uint32_t _voiceId)
 #endif
     /* OLD approach of phase reset - over shared array */
     /* update and reset oscillator phases */
-    //m_paramsignaldata[_voiceId][OSC_A_PHS] = m_params.m_body[m_params.m_head[ParameterLabel::P_KEY_PA].m_index + _voiceId].m_signal;  // POLY PHASE_A -> OSC_A Phase
+    //m_paramsignaldata[_voiceId][OSC_A_PHS] = m_params.m_body[m_params.m_head[Parameters::P_KEY_PA].m_index + _voiceId].m_signal;  // POLY PHASE_A -> OSC_A Phase
 
     /* AUDIO_ENGINE: reset oscillator phases */
     //resetOscPhase(m_paramsignaldata[_voiceId], _voiceId);
     /* NEW approach of phase reset - no array involved - still only unisono phase */
 
     /* NEW UNISONO PHASE FUNCTIONALITY, Osc Phases are now offsets */
-    //float phaseA = m_params.m_body[m_params.m_head[ParameterLabel::P_KEY_PA].m_index + _voiceId].m_signal;
-    //float phaseB = m_params.m_body[m_params.m_head[ParameterLabel::P_KEY_PB].m_index + _voiceId].m_signal;
+    //float phaseA = m_params.m_body[m_params.m_head[Parameters::P_KEY_PA].m_index + _voiceId].m_signal;
+    //float phaseB = m_params.m_body[m_params.m_head[Parameters::P_KEY_PB].m_index + _voiceId].m_signal;
 #if test_milestone == 150
-    const float startPhase = m_params.getParameterValue(ParameterLabel::P_KEY_PH, _voiceId);
+    const float startPhase = m_params.getParameterValue(Parameters::P_KEY_PH, _voiceId);
 #elif test_milestone == 155
     const float startPhase = 0.f;
 #elif test_milestone == 156
@@ -1133,13 +1133,13 @@ void dsp_host::testRouteControls(uint32_t _id, uint32_t _value)
       /* control edits */
       if(m_test_midiMode == 0)
       {
-        auto pId = testParamRouting[m_test_selectedGroup][_id - 1];
+        auto pId = static_cast<uint32_t>(testParamRouting[m_test_selectedGroup][_id - 1]);
         /* group edits */
-        if(pId != ParameterLabel::P_INVALID)
+        if(pId != static_cast<uint32_t>(Parameters::P_INVALID))
         {
-          uint32_t tcdId = static_cast<uint32_t>(param_definition[static_cast<uint32_t>(pId)][0]);
-          uint32_t rng = static_cast<uint32_t>(param_definition[static_cast<uint32_t>(pId)][9]);
-          uint32_t pol = static_cast<uint32_t>(param_definition[static_cast<uint32_t>(pId)][8]);
+          uint32_t tcdId = param_definition[pId].id;
+          uint32_t rng = param_definition[pId].factor;
+          uint32_t pol = param_definition[pId].pol;
           float val = _value * m_test_normalizeMidi;
           if(pol > 0)
           {
@@ -1195,7 +1195,7 @@ void dsp_host::testNoteOn(uint32_t _pitch, uint32_t _velocity)
   /* prepare pitch and velocity */
   int32_t notePitch = (static_cast<int32_t>(_pitch) - 60) * 1000;
   uint32_t noteVel
-      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
+      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
   /* key event sequence */
   evalMidi(47, 2, 1);              // enable preload (key event list mode)
   evalMidi(0, 0, m_test_voiceId);  // select voice: current
@@ -1233,8 +1233,8 @@ void dsp_host::testNewNoteOn(uint32_t _pitch, uint32_t _velocity)
   /* prepare pitch, velocity und unison */
   int32_t keyPos = static_cast<int32_t>(_pitch) - 60;
   uint32_t noteVel
-      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
-  m_test_unison_voices = static_cast<uint32_t>(m_params.getParameterValue(ParameterLabel::P_UN_V)) + 1;
+      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
+  m_test_unison_voices = static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V)) + 1;
   evalMidi(47, 2, 1);              // enable preload (key event list mode)
   evalMidi(0, 0, m_test_voiceId);  // select voice: current
   for(uint32_t uIndex = 0; uIndex < m_test_unison_voices; uIndex++)
@@ -1257,8 +1257,8 @@ void dsp_host::testNoteOn156(uint32_t _pitch, uint32_t _velocity)
   /* prepare pitch, velocity und unison */
   int32_t keyPos = static_cast<int32_t>(_pitch) - 60;
   uint32_t noteVel
-      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
-  m_test_unison_voices = static_cast<uint32_t>(m_params.getParameterValue(ParameterLabel::P_UN_V)) + 1;
+      = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
+  m_test_unison_voices = static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V)) + 1;
   /* */
   evalMidi(55, 0, (m_test_voiceId << 1) + 0);  // new keyVoice (current voice, no steal)
   testParseDestination(keyPos * 1000);         // base pitch (factor 1000 because of Scaling)
@@ -1286,7 +1286,7 @@ void dsp_host::testNoteOff(uint32_t _pitch, uint32_t _velocity)
     m_test_noteId[_pitch] = 0;                                   // clear voiceId assignment
     /* prepare velocity */
     uint32_t noteVel
-        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
+        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
     /* key event sequence */
     evalMidi(47, 2, 1);                        // enable preload (key event list mode)
     evalMidi(0, 0, usedVoiceId);               // select voice: used voice (by note number)
@@ -1317,7 +1317,7 @@ void dsp_host::testNewNoteOff(uint32_t _pitch, uint32_t _velocity)
     m_test_noteId[_pitch] = 0;                                   // clear voiceId assignment
     /* prepare velocity */
     uint32_t noteVel
-        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
+        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
     /* key event sequence */
     evalMidi(47, 2, 1);           // enable preload (key event list mode)
     evalMidi(0, 0, usedVoiceId);  // select voice: used voice (by note number)
@@ -1347,7 +1347,7 @@ void dsp_host::testNoteOff156(uint32_t _pitch, uint32_t _velocity)
     m_test_noteId[_pitch] = 0;                                   // clear voiceId assignment
     /* prepare velocity */
     uint32_t noteVel
-        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0][0]);
+        = static_cast<uint32_t>(static_cast<float>(_velocity) * m_test_normalizeMidi * utility_definition[0].range);
     /* key event sequence */
     evalMidi(55, 0, (usedVoiceId << 1) + 0);   // new keyVoice (current voice, no steal)
     evalMidi(7, noteVel >> 7, noteVel & 127);  // key up: velocity
@@ -1385,7 +1385,7 @@ void dsp_host::testSetGlobalTime(uint32_t _value)
 void dsp_host::testSetReference(uint32_t _value)
 {
   /* prepare value */
-  uint32_t val = static_cast<uint32_t>(static_cast<float>(_value) * m_test_normalizeMidi * utility_definition[1][0]);
+  uint32_t val = static_cast<uint32_t>(static_cast<float>(_value) * m_test_normalizeMidi * utility_definition[1].range);
   Log::info("\nSET_REFERENCE(", val, ")");
   /* select and update reference utility */
   evalMidi(8, 0, 1);                  // select utility (reference tone)
@@ -1466,7 +1466,7 @@ void dsp_host::testGetParamHeadData()
   Log::info("PARAM_HEAD:");
   for(uint32_t p = 0; p < sig_number_of_params; p++)
   {
-    auto parameterId = static_cast<ParameterLabel>(p);
+    auto parameterId = static_cast<Parameters>(p);
     param_head *obj = &m_params.getHead(parameterId);
     Log::info<Log::LogMode::Plain>("id: ", obj->m_id, ", ");
     Log::info<Log::LogMode::Plain>("index: ", obj->m_index, ", ");
@@ -1487,7 +1487,7 @@ void dsp_host::testGetParamRenderData()
   Log::info("PARAM_BODY:");
   for(uint32_t p = 0; p < sig_number_of_params; p++)
   {
-    auto parameterId = static_cast<ParameterLabel>(p);
+    auto parameterId = static_cast<Parameters>(p);
     param_head *obj = &m_params.getHead(parameterId);
     uint32_t index = obj->m_index;
     for(uint32_t i = 0; i < obj->m_size; i++)

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -44,7 +44,7 @@ void dsp_host::init(uint32_t _samplerate, uint32_t _polyphony)
 #if log_examine
   m_tcd_input_log.reset();
 
-  m_param_status.m_selected = static_cast<ParameterLabel>(log_param_id);
+  m_param_status.m_selected = static_cast<Parameters>(log_param_id);
   m_param_status.m_id = m_params.getHead(m_param_status.m_selected).m_id;
   m_param_status.m_index = m_params.getHead(m_param_status.m_selected).m_index;
   m_param_status.m_size = m_params.getHead(m_param_status.m_selected).m_size;
@@ -71,7 +71,7 @@ void dsp_host::loadInitialPreset()
   /* traverse parameters, each one receiving zero value */
   for(uint32_t i = 0; i < lst_recall_length; i++)
   {
-    if(paramIds_recall[i] == ParameterLabel::P_UN_V)  /// Unison Voices
+    if(paramIds_recall[i] == Parameters::P_UN_V)  /// Unison Voices
     {
       evalMidi(5, 0, 1);  // send destination 1
     }
@@ -112,8 +112,8 @@ void dsp_host::tickMain()
       m_params.getBody(i).tick();
     }
 #else
-    auto end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO);
-    for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO);
+    auto end = m_params.m_parameters.end(ClockTypes::Slow, PolyTypes::Mono);
+    for(param_body* it = m_params.m_parameters.begin(ClockTypes::Slow, PolyTypes::Mono);
         it != end; it++)
     {
       it->tick();
@@ -130,8 +130,8 @@ void dsp_host::tickMain()
         m_params.getBody(i).tick();
       }
 #else
-      end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY, v);
-      for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_POLY, v);
+      end = m_params.m_parameters.end(ClockTypes::Slow, PolyTypes::Poly, v);
+      for(param_body* it = m_params.m_parameters.begin(ClockTypes::Slow, PolyTypes::Poly, v);
           it != end; it += m_voices)
       {
         it->tick();
@@ -155,8 +155,8 @@ void dsp_host::tickMain()
       m_params.getBody(i).tick();
     }
 #else
-    auto end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO);
-    for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO);
+    auto end = m_params.m_parameters.end(ClockTypes::Fast, PolyTypes::Mono);
+    for(param_body* it = m_params.m_parameters.begin(ClockTypes::Fast, PolyTypes::Mono);
         it != end; it++)
     {
       it->tick();
@@ -173,8 +173,8 @@ void dsp_host::tickMain()
         m_params.getBody(i).tick();
       }
 #else
-      end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_POLY, v);
-      for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_POLY, v);
+      end = m_params.m_parameters.end(ClockTypes::Fast, PolyTypes::Poly, v);
+      for(param_body* it = m_params.m_parameters.begin(ClockTypes::Fast, PolyTypes::Poly, v);
           it != end; it += m_voices)
       {
         it->tick();
@@ -193,8 +193,8 @@ void dsp_host::tickMain()
     m_params.getBody(i).tick();
   }
 #else
-  auto end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_MONO);
-  for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_MONO);
+  auto end = m_params.m_parameters.end(ClockTypes::Audio, PolyTypes::Mono);
+  for(param_body* it = m_params.m_parameters.begin(ClockTypes::Audio, PolyTypes::Mono);
       it != end; it++)
   {
     it->tick();
@@ -216,8 +216,8 @@ void dsp_host::tickMain()
       m_params.getBody(i).tick();
     }
 #else
-    end = m_params.m_parameters.end(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_POLY, v);
-    for(param_body* it = m_params.m_parameters.begin(PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_POLY, v);
+    end = m_params.m_parameters.end(ClockTypes::Audio, PolyTypes::Poly, v);
+    for(param_body* it = m_params.m_parameters.begin(ClockTypes::Audio, PolyTypes::Poly, v);
         it != end; it += m_voices)
     {
       it->tick();
@@ -466,7 +466,7 @@ void dsp_host::paramSelectionUpdate()
   for(uint32_t p = 0; p < sig_number_of_params; p++)
   {
     /* only TRUE TCD IDs (< 16383) */
-    auto paramID = static_cast<ParameterLabel>(p);
+    auto paramID = static_cast<Parameters>(p);
 
     if(m_params.getHead(paramID).m_id < 16383)
     {
@@ -513,7 +513,7 @@ void dsp_host::preloadUpdate(uint32_t _mode, uint32_t _listId)
       /* apply preloaded values - parameters */
       for(p = 0; p < sig_number_of_params; p++)
       {
-        auto paramID = static_cast<ParameterLabel>(p);
+        auto paramID = static_cast<Parameters>(p);
 
         for(v = 0; v < m_params.getHead(paramID).m_size; v++)
         {
@@ -828,7 +828,7 @@ void dsp_host::keyApply(uint32_t _voiceId)
 void dsp_host::keyUp156(const float _velocity)
 {
   uint32_t voiceId = m_decoder.m_voiceFrom;
-  const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(ParameterLabel::P_UN_V));
+  const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
 
   for(uint32_t v = 0; v < unisonVoices; v++)
   {
@@ -842,8 +842,8 @@ void dsp_host::keyUp156(const float _velocity)
 void dsp_host::keyDown156(const float _velocity)
 {
   uint32_t voiceId = m_decoder.m_voiceFrom;
-  const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t index = m_params.getHead(ParameterLabel::P_KEY_BP).m_index + voiceId;
+  const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
+  const uint32_t index = m_params.getHead(Parameters::P_KEY_BP).m_index + voiceId;
   const float pitch = m_params.getBody(index).m_dest;
   //
   for(uint32_t v = 0; v < unisonVoices; v++)
@@ -1626,7 +1626,7 @@ void dsp_host::makePolySound(SignalStorage &signals, uint32_t _voiceID)
 
 void dsp_host::makeMonoSound(SignalStorage &signals)
 {
-  float mst_gain = signals.get(SignalLabel::MST_VOL) * m_raised_cos_table[m_table_indx];
+  float mst_gain = signals.get(Signals::MST_VOL) * m_raised_cos_table[m_table_indx];
 
   //****************************** Mono Modules ****************************//
   m_outputmixer.filter_level(signals);

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_examine.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_examine.h
@@ -44,7 +44,7 @@ std::ostream& operator<<(std::ostream& lhs, const examine_tcd_input_log& rhs);
 
 struct examine_param
 {
-  ParameterLabel m_selected = ParameterLabel::P_EA_ATT;
+  Parameters m_selected = Parameters::P_EA_ATT;
   //
   uint32_t m_id;
   uint32_t m_index;

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
@@ -395,14 +395,14 @@ void paramengine::keyApply(const uint32_t _voiceId)
   }
   /* apply key event (update envelopes according to event type) */
 #if test_milestone == 150
-  const float pitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T)
+  const float pitch = getParameterValue(Parameters::P_KEY_NP, _voiceId) + getParameterValue(Parameters::P_MA_T)
       + m_note_shift[_voiceId];
 #elif test_milestone == 155
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
-  const float pitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(Parameters::P_KEY_IDX, _voiceId));
+  const float pitch = getParameterValue(Parameters::P_KEY_BP, _voiceId)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 156
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
@@ -913,14 +913,14 @@ void paramengine::postProcessPoly_slow(SignalStorage& signals, const uint32_t _v
   newEnvUpdateTimes(_voiceId);
   /* Pitch Updates */
 #if test_milestone == 150
-  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(Parameters::P_KEY_NP, _voiceId)
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
-  const float notePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(Parameters::P_KEY_IDX, _voiceId));
+  const float notePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 156
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
@@ -976,8 +976,8 @@ void paramengine::postProcessPoly_slow(SignalStorage& signals, const uint32_t _v
   // apply decay time directly
   envMod = 1.f
       - ((1.f - signals.get(SignalLabel::ENV_G_SIG))
-         * m_combDecayCurve.applyCurve(getParameterValue(ParameterLabel::P_CMB_DG)));
-  unitPitch = (-0.5f * notePitch * keyTracking) + (std::abs(getParameterValue(ParameterLabel::P_CMB_D)) * envMod);
+         * m_combDecayCurve.applyCurve(getParameterValue(Parameters::P_CMB_DG)));
+  unitPitch = (-0.5f * notePitch * keyTracking) + (std::abs(getParameterValue(Parameters::P_CMB_D)) * envMod);
   signals.set(SignalLabel::CMB_DEC, m_convert.eval_level(unitPitch) * unitSign);
 #elif test_comb_decay_gate_mode == 1
   // determine decay times min, max before crossfading them by gate signal (audio post processing)
@@ -1063,14 +1063,14 @@ void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _v
   /* temporary variables */
   float tmp_lvl, tmp_pan, tmp_abs;
 #if test_milestone == 150
-  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(Parameters::P_KEY_NP, _voiceId)
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
-  const float basePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId);
-  const float notePitch = basePitch + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(Parameters::P_KEY_IDX, _voiceId));
+  const float basePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId);
+  const float notePitch = basePitch + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 156
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
@@ -1092,10 +1092,10 @@ void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _v
   signals.set(Signals::SVF_PAR_4, tmp_abs);
   /* Output Mixer */
 #if test_milestone == 150
-  const float poly_pan = getParameterValue(ParameterLabel::P_KEY_VP, _voiceId);
+  const float poly_pan = getParameterValue(Parameters::P_KEY_VP, _voiceId);
 #elif test_milestone == 155
-  const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
-      + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
+  const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
+      + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #elif test_milestone == 156
   const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
       + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
@@ -1242,11 +1242,11 @@ void paramengine::postProcessPoly_audio(SignalStorage& signals, const uint32_t _
 #endif
   /* Unison Phase */
 #if test_milestone == 150
-  signals.set(SignalLabel::UN_PHS, 0.f);
+  signals.set(Signals::UN_PHS, 0.f);
 #elif test_milestone == 155
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
-  signals.set(SignalLabel::UN_PHS, getParameterValue(ParameterLabel::P_UN_PHS) * m_unison_phase[uVoice][uIndex]);
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(Parameters::P_KEY_IDX, _voiceId));
+  signals.set(Signals::UN_PHS, getParameterValue(Parameters::P_UN_PHS) * m_unison_phase[uVoice][uIndex]);
 #elif test_milestone == 156
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
@@ -1259,14 +1259,14 @@ void paramengine::postProcessPoly_key(SignalStorage& signals, const uint32_t _vo
 {
   /* Pitch Updates */
 #if test_milestone == 150
-  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(Parameters::P_KEY_NP, _voiceId)
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
-  const float basePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId);
-  const float notePitch = basePitch + getParameterValue(ParameterLabel::P_MA_T)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + m_note_shift[_voiceId];
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(Parameters::P_KEY_IDX, _voiceId));
+  const float basePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId);
+  const float notePitch = basePitch + getParameterValue(Parameters::P_MA_T)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + m_note_shift[_voiceId];
 #elif test_milestone == 156
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
@@ -1373,10 +1373,10 @@ void paramengine::postProcessPoly_key(SignalStorage& signals, const uint32_t _vo
   /* Output Mixer */
   float tmp_lvl, tmp_pan;
 #if test_milestone == 150
-  const float poly_pan = getParameterValue(ParameterLabel::P_KEY_VP, _voiceId);
+  const float poly_pan = getParameterValue(Parameters::P_KEY_VP, _voiceId);
 #elif test_milestone == 155
-  const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
-      + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
+  const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
+      + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #elif test_milestone == 156
   const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
       + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
@@ -1424,7 +1424,7 @@ void paramengine::postProcessMono_slow(SignalStorage& signals)
   /* - Flanger */
 #if test_flanger_phs == 0
   /*   - LFO/Envelope Rate, Phase */
-  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getSignal(ParameterLabel::P_FLA_PHS);
+  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getSignal(Parameters::P_FLA_PHS);
 #endif
   tmp_Rate = getParameterValue(Parameters::P_FLA_RTE);
   m_flangerLFO.m_increment = m_reciprocal_samplerate * tmp_Rate;
@@ -1593,7 +1593,7 @@ void paramengine::postProcessMono_fast(SignalStorage& signals)
   /* - Reverb (if fast rendering is enabled - see pe_defines_config.h) */
 #if test_reverbParams == 0
   /*   - Size to Size, Feedback, Balance */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_SIZE);
+  tmp_val = getParameterValue(Parameters::P_REV_SIZE);
   tmp_val *= 2.f - std::abs(tmp_val);
   signals.set(SignalLabel::REV_SIZE, tmp_val);
   tmp_fb = tmp_val * (0.6f + (0.4f * std::abs(tmp_val)));
@@ -1601,15 +1601,15 @@ void paramengine::postProcessMono_fast(SignalStorage& signals)
   tmp_fb = tmp_val * (1.3f - (0.3f * std::abs(tmp_val)));
   signals.set(SignalLabel::REV_BAL, 0.9f * tmp_fb);
   /*   - Pre Delay */
-  signals.set(SignalLabel::REV_PRE, getParameterValue(ParameterLabel::P_REV_PRE) * 200.f * m_millisecond);
+  signals.set(SignalLabel::REV_PRE, getParameterValue(Parameters::P_REV_PRE) * 200.f * m_millisecond);
   /*   - Color to Filter Frequencies (HPF, LPF) */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_COL);
+  tmp_val = getParameterValue(Parameters::P_REV_COL);
   signals.set(SignalLabel::REV_LPF,
               evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve1.applyCurve(tmp_val)) * 440.f));
   signals.set(SignalLabel::REV_HPF,
               evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve2.applyCurve(tmp_val)) * 440.f));
   /*   - Mix to Dry, Wet */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_MIX);
+  tmp_val = getParameterValue(Parameters::P_REV_MIX);
   tmp_dry = 1.f - tmp_val;
   tmp_dry = (2.f - tmp_dry) * tmp_dry;
   signals.set(SignalLabel::REV_DRY, tmp_dry);
@@ -1636,7 +1636,7 @@ void paramengine::postProcessMono_audio(SignalStorage& signals)
   /* - Flanger */
 #if test_flanger_phs == 2
   /*   - LFO/Envelope Rate, Phase */
-  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getSignal(ParameterLabel::P_FLA_PHS);
+  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getSignal(Parameters::P_FLA_PHS);
 #endif
   /*   - render LFO, crossfade flanger envelope and pass left and right signals to array */
   m_flangerLFO.tick();

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.cpp
@@ -61,31 +61,31 @@ void paramengine::init(uint32_t _sampleRate, uint32_t _voices)
   for(uint32_t p = 0; p < sig_number_of_params; p++)
   {
     /* provide parameter reference */
-    param_head* obj = &getHead(static_cast<ParameterLabel>(p));
+    param_head* obj = &getHead(static_cast<Parameters>(p));
+    const auto& paramDef = param_definition[p];
     /* declarations according to parameter definition (index is determined in second run) */
-    obj->m_clockType = static_cast<PARAM_CLOCK_TYPES>(param_definition[p][1]);  // clock type (sync/audio/fast/slow)
-    obj->m_polyType = static_cast<PARAM_POLY_TYPES>(param_definition[p][2]);    // poly type (mono/poly)
-    obj->m_size = m_routePolyphony[static_cast<uint32_t>(obj->m_polyType)];     // determine (rendering) size
-    obj->m_normalize = 1.f / param_definition[p][3];                            // TCD range
-    obj->m_scaleId = static_cast<uint32_t>(param_definition[p][4]);             // TCD scale id
-    obj->m_scaleArg = param_definition[p][5];                                   // TCD scale argument
+    obj->m_clockType = paramDef.clock;                                       // clock type (sync/audio/fast/slow)
+    obj->m_polyType = paramDef.poly;                                         // poly type (mono/poly)
+    obj->m_size = m_routePolyphony[static_cast<uint32_t>(obj->m_polyType)];  // determine (rendering) size
+    obj->m_normalize = 1.f / paramDef.range;                                 // TCD range
+    obj->m_scaleId = paramDef.scale;                                         // TCD scale id
+    obj->m_scaleArg = paramDef.scaleArg;                                     // TCD scale argument
 
     /* valid parameters are added to internal id lists, placeholders are ignored */
-    if(param_definition[p][0] > -1)
+    if(paramDef.id > -1)
     {
-      obj->m_id = static_cast<uint32_t>(param_definition[p][0]);  // TCD id
+      obj->m_id = paramDef.id;  // TCD id
       /* declare parameter according to clock type - crucial for rendering */
       m_parameters.addClockId(obj->m_clockType, obj->m_polyType, p);
-      if(param_definition[p][6] > -1)
+      if(paramDef.postId > Signals::Invalid)
       {
-        obj->m_postId = static_cast<SignalLabel>(param_definition[p][6]);  // post processing id
+        obj->m_postId = paramDef.postId;  // post processing id
         /* determine automatic post processing (copy, distribution) */
-        m_parameters.addPostId(static_cast<PARAM_SPREAD_TYPES>(param_definition[p][7]), obj->m_clockType,
-                               obj->m_polyType, static_cast<ParameterLabel>(p));
+        m_parameters.addPostId(paramDef.spread, obj->m_clockType, obj->m_polyType, paramDef.paramId);
       }
       else
       {
-        obj->m_postId = SignalLabel::Unused;
+        obj->m_postId = Signals::Unused;
       }
     }
     else
@@ -98,41 +98,41 @@ void paramengine::init(uint32_t _sampleRate, uint32_t _voices)
   for(uint32_t clockType = 0; clockType < dsp_clock_types; clockType++)
   {
 #if PARAM_ITERATOR == 1
-    m_parameters.m_start[clockType][static_cast<uint32_t>(PARAM_POLY_TYPES::PARAM_MONO)]
+    m_parameters.m_start[clockType][static_cast<uint32_t>(PolyTypes::Mono)]
         = index;  // find start position in body array (mono)
 #endif
-    for(auto& it : m_parameters.getClockIds(static_cast<PARAM_CLOCK_TYPES>(clockType), PARAM_POLY_TYPES::PARAM_MONO))
+    for(auto& it : m_parameters.getClockIds(static_cast<ClockTypes>(clockType), PolyTypes::Mono))
     {
-      m_parameters.getHead(static_cast<ParameterLabel>(it)).m_index = index;
+      m_parameters.getHead(static_cast<Parameters>(it)).m_index = index;
       index += 1;
     }
 #if PARAM_ITERATOR == 1
-    m_parameters.m_end[clockType][static_cast<uint32_t>(PARAM_POLY_TYPES::PARAM_MONO)]
+    m_parameters.m_end[clockType][static_cast<uint32_t>(PolyTypes::Mono)]
         = index;  // find end position in body array (mono)
 #endif
   }
   for(uint32_t clockType = 0; clockType < dsp_clock_types; clockType++)
   {
 #if PARAM_ITERATOR == 1
-    m_parameters.m_start[clockType][static_cast<uint32_t>(PARAM_POLY_TYPES::PARAM_POLY)]
+    m_parameters.m_start[clockType][static_cast<uint32_t>(PolyTypes::Poly)]
         = index;  // find start position in body array (poly)
 #endif
-    for(auto& it : m_parameters.getClockIds(static_cast<PARAM_CLOCK_TYPES>(clockType), PARAM_POLY_TYPES::PARAM_POLY))
+    for(auto& it : m_parameters.getClockIds(static_cast<ClockTypes>(clockType), PolyTypes::Poly))
     {
-      m_parameters.getHead(static_cast<ParameterLabel>(it)).m_index = index;
+      m_parameters.getHead(static_cast<Parameters>(it)).m_index = index;
       index += _voices;
     }
 #if PARAM_ITERATOR == 1
-    m_parameters.m_end[clockType][static_cast<uint32_t>(PARAM_POLY_TYPES::PARAM_POLY)]
+    m_parameters.m_end[clockType][static_cast<uint32_t>(PolyTypes::Poly)]
         = index;  // find end position in body array (poly)
 #endif
   }
   /* initialize global utility parameters */
   for(uint32_t i = 0; i < sig_number_of_utilities; i++)
   {
-    m_utilities[i].m_normalize = 1.f / utility_definition[i][0];
-    m_utilities[i].m_scaleId = static_cast<uint32_t>(utility_definition[i][1]);
-    m_utilities[i].m_scaleArg = utility_definition[i][2];
+    m_utilities[i].m_normalize = 1.f / utility_definition[i].range;
+    m_utilities[i].m_scaleId = utility_definition[i].scale;
+    m_utilities[i].m_scaleArg = utility_definition[i].scaleArg;
   }
   /* initialize envelopes */
   float gateRelease = 1.f / ((env_init_gateRelease * m_millisecond) + 1.f);
@@ -280,7 +280,7 @@ float paramengine::scale(const uint32_t _scaleId, const float _scaleArg, float _
 }
 
 /* TCD mechanism - time updates */
-void paramengine::setDx(const uint32_t _voiceId, const ParameterLabel _paramId, float _value)
+void paramengine::setDx(const uint32_t _voiceId, const Parameters _paramId, float _value)
 {
   /* provide object reference */
   param_head* obj = &getHead(_paramId);
@@ -292,7 +292,7 @@ void paramengine::setDx(const uint32_t _voiceId, const ParameterLabel _paramId, 
 }
 
 /* TCD mechanism - destination updates */
-void paramengine::setDest(const uint32_t _voiceId, const ParameterLabel _paramId, float _value)
+void paramengine::setDest(const uint32_t _voiceId, const Parameters _paramId, float _value)
 {
   /* provide object and (rendering) item references */
   param_head* obj = &getHead(_paramId);
@@ -305,7 +305,7 @@ void paramengine::setDest(const uint32_t _voiceId, const ParameterLabel _paramId
   if(m_preload == 0)
   {
     /* sync type parameters apply directly, non-sync type parameters apply destinations */
-    if(obj->m_clockType != PARAM_CLOCK_TYPES::PARAM_SYNC)
+    if(obj->m_clockType != ClockTypes::Sync)
     {
       applyDest(index);
     }
@@ -321,7 +321,7 @@ void paramengine::setDest(const uint32_t _voiceId, const ParameterLabel _paramId
 }
 
 /* TCD mechanism - preload functionality */
-void paramengine::applyPreloaded(const uint32_t _voiceId, const ParameterLabel _paramId)
+void paramengine::applyPreloaded(const uint32_t _voiceId, const Parameters _paramId)
 {
   /* provide object and (rendering) item references */
   param_head* obj = &getHead(_paramId);
@@ -332,7 +332,7 @@ void paramengine::applyPreloaded(const uint32_t _voiceId, const ParameterLabel _
   {
     item->m_preload = 0;
     /* sync type parameters apply directly, non-sync type parameters apply destinations */
-    if(obj->m_clockType == PARAM_CLOCK_TYPES::PARAM_SYNC)
+    if(obj->m_clockType == ClockTypes::Sync)
     {
       applySync(index);
     }
@@ -391,24 +391,24 @@ void paramengine::keyApply(const uint32_t _voiceId)
 {
   if(m_event.m_poly[_voiceId].m_type == 1)
   {
-    m_note_shift[_voiceId] = getParameterValue(ParameterLabel::P_MA_SH);
+    m_note_shift[_voiceId] = getParameterValue(Parameters::P_MA_SH);
   }
   /* apply key event (update envelopes according to event type) */
 #if test_milestone == 150
-  const float pitch
-      = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float pitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T)
+      + m_note_shift[_voiceId];
 #elif test_milestone == 155
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
   const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
   const float pitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + getParameterValue(ParameterLabel::P_MA_T)
-      + m_note_shift[_voiceId];
-#elif test_milestone == 156
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = m_unison_index[_voiceId];
-  const float pitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
       + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
       + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+#elif test_milestone == 156
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = m_unison_index[_voiceId];
+  const float pitch = getParameterValue(Parameters::P_KEY_BP, _voiceId)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #endif
   const float velocity = m_event.m_poly[_voiceId].m_velocity;
   if(m_event.m_poly[_voiceId].m_type == 0)
@@ -469,16 +469,16 @@ void paramengine::newEnvUpdateStart(const uint32_t _voiceId, const float _pitch,
 
   /* envelope a update */
 
-  timeKT = -0.5f * getParameterValue(ParameterLabel::P_EA_TKT)
-      * _pitch;  // determine time key tracking according to pitch and parameter
-  levelVel = -getParameterValue(ParameterLabel::P_EA_LV);  // get level velocity parameter
-  attackVel = -getParameterValue(ParameterLabel::P_EA_AV)
+  timeKT = -0.5f * getParameterValue(Parameters::P_EA_TKT)
+      * _pitch;                                        // determine time key tracking according to pitch and parameter
+  levelVel = -getParameterValue(Parameters::P_EA_LV);  // get level velocity parameter
+  attackVel = -getParameterValue(Parameters::P_EA_AV)
       * _velocity;  // determine attack velocity accorindg to velocity and parameter
-  decay1Vel = -getParameterValue(ParameterLabel::P_EA_D1V)
+  decay1Vel = -getParameterValue(Parameters::P_EA_D1V)
       * _velocity;  // determine decay1 velocity accorindg to velocity and parameter
-  decay2Vel = -getParameterValue(ParameterLabel::P_EA_D2V)
+  decay2Vel = -getParameterValue(Parameters::P_EA_D2V)
       * _velocity;  // determine decay2 velocity accorindg to velocity and parameter
-  levelKT = getParameterValue(ParameterLabel::P_EA_LKT)
+  levelKT = getParameterValue(Parameters::P_EA_LKT)
       * _pitch;  // determine level key tracking according to pitch and parameter
   peak = std::min(m_convert.eval_level(((1.f - _velocity) * levelVel) + levelKT),
                   env_clip_peak);  // determine peak level according to velocity and level parameters (max +3dB)
@@ -492,13 +492,13 @@ void paramengine::newEnvUpdateStart(const uint32_t _voiceId, const float _pitch,
       * m_millisecond;  // determine time factor for decay2 segment (without actual decay2 time)
 
   m_new_envelopes.m_env_a.setSplitValue(
-      getParameterValue(ParameterLabel::P_EA_SPL));  // update the split behavior by corresponding parameter
+      getParameterValue(Parameters::P_EA_SPL));  // update the split behavior by corresponding parameter
   m_new_envelopes.m_env_a.setAttackCurve(
-      getParameterValue(ParameterLabel::P_EA_AC));  // update the attack curve by corresponding parameter
+      getParameterValue(Parameters::P_EA_AC));  // update the attack curve by corresponding parameter
   m_new_envelopes.m_env_a.setPeakLevel(_voiceId,
                                        peak);  // update the current peak level (for magnitude/timbre crossfades)
 
-  time = getParameterValue(ParameterLabel::P_EA_ATT)
+  time = getParameterValue(Parameters::P_EA_ATT)
       * m_event.m_env[0]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
@@ -506,35 +506,35 @@ void paramengine::newEnvUpdateStart(const uint32_t _voiceId, const float _pitch,
                                          peak);  // update attack segment destination (peak level) (no split behavior)
 
   // determine decay1 segment time according to time factor and parameter
-  time = getParameterValue(ParameterLabel::P_EA_DEC1) * m_event.m_env[0].m_timeFactor[_voiceId][1];
+  time = getParameterValue(Parameters::P_EA_DEC1) * m_event.m_env[0].m_timeFactor[_voiceId][1];
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
   // determine decay1 segment destination according to peak level and parameter
-  dest = peak * getParameterValue(ParameterLabel::P_EA_BP);
+  dest = peak * getParameterValue(Parameters::P_EA_BP);
   m_new_envelopes.m_env_a.setSegmentDest(_voiceId, 2, true,
                                          dest);  // update decay1 segment destination (split behavior)
 
-  time = getParameterValue(ParameterLabel::P_EA_DEC2)
+  time = getParameterValue(Parameters::P_EA_DEC2)
       * m_event.m_env[0]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EA_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EA_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_a.setSegmentDest(_voiceId, 3, true,
                                          dest);  // update decay2 segment destination (split behavior)
 
   /* envelope b update */
 
-  timeKT = -0.5f * getParameterValue(ParameterLabel::P_EB_TKT)
-      * _pitch;  // determine time key tracking according to pitch and parameter
-  levelVel = -getParameterValue(ParameterLabel::P_EB_LV);  // get level velocity parameter
-  attackVel = -getParameterValue(ParameterLabel::P_EB_AV)
+  timeKT = -0.5f * getParameterValue(Parameters::P_EB_TKT)
+      * _pitch;                                        // determine time key tracking according to pitch and parameter
+  levelVel = -getParameterValue(Parameters::P_EB_LV);  // get level velocity parameter
+  attackVel = -getParameterValue(Parameters::P_EB_AV)
       * _velocity;  // determine attack velocity accorindg to velocity and parameter
-  decay1Vel = -getParameterValue(ParameterLabel::P_EB_D1V)
+  decay1Vel = -getParameterValue(Parameters::P_EB_D1V)
       * _velocity;  // determine decay1 velocity accorindg to velocity and parameter
-  decay2Vel = -getParameterValue(ParameterLabel::P_EB_D2V)
+  decay2Vel = -getParameterValue(Parameters::P_EB_D2V)
       * _velocity;  // determine decay2 velocity accorindg to velocity and parameter
-  levelKT = getParameterValue(ParameterLabel::P_EB_LKT)
+  levelKT = getParameterValue(Parameters::P_EB_LKT)
       * _pitch;  // determine level key tracking according to pitch and parameter
   peak = std::min(m_convert.eval_level(((1.f - _velocity) * levelVel) + levelKT),
                   env_clip_peak);  // determine peak level according to velocity and level parameters (max +3dB)
@@ -548,47 +548,47 @@ void paramengine::newEnvUpdateStart(const uint32_t _voiceId, const float _pitch,
       * m_millisecond;  // determine time factor for decay2 segment (without actual decay2 time)
 
   m_new_envelopes.m_env_b.setSplitValue(
-      getParameterValue(ParameterLabel::P_EB_SPL));  // update the split behavior by corresponding parameter
+      getParameterValue(Parameters::P_EB_SPL));  // update the split behavior by corresponding parameter
   m_new_envelopes.m_env_b.setAttackCurve(
-      getParameterValue(ParameterLabel::P_EB_AC));  // update the attack curve by corresponding parameter
+      getParameterValue(Parameters::P_EB_AC));  // update the attack curve by corresponding parameter
   m_new_envelopes.m_env_b.setPeakLevel(_voiceId,
                                        peak);  // update the current peak level (for magnitude/timbre crossfades)
 
-  time = getParameterValue(ParameterLabel::P_EB_ATT)
+  time = getParameterValue(Parameters::P_EB_ATT)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
   m_new_envelopes.m_env_b.setSegmentDest(_voiceId, 1, false,
                                          peak);  // update attack segment destination (peak level) (no split behavior)
 
-  time = getParameterValue(ParameterLabel::P_EB_DEC1)
+  time = getParameterValue(Parameters::P_EB_DEC1)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][1];  // determine decay1 segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EB_BP);  // determine decay1 segment destination according to peak level and parameter
+             Parameters::P_EB_BP);  // determine decay1 segment destination according to peak level and parameter
   m_new_envelopes.m_env_b.setSegmentDest(_voiceId, 2, true,
                                          dest);  // update decay1 segment destination (split behavior)
 
-  time = getParameterValue(ParameterLabel::P_EB_DEC2)
+  time = getParameterValue(Parameters::P_EB_DEC2)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EB_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EB_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_b.setSegmentDest(_voiceId, 3, true,
                                          dest);  // update decay2 segment destination (split behavior)
 
   /* envelope c update */
 
-  timeKT = -0.5f * getParameterValue(ParameterLabel::P_EC_TKT)
-      * _pitch;  // determine time key tracking according to pitch and parameter
-  levelVel = -getParameterValue(ParameterLabel::P_EC_LV);  // get level velocity parameter
-  attackVel = -getParameterValue(ParameterLabel::P_EC_AV)
+  timeKT = -0.5f * getParameterValue(Parameters::P_EC_TKT)
+      * _pitch;                                        // determine time key tracking according to pitch and parameter
+  levelVel = -getParameterValue(Parameters::P_EC_LV);  // get level velocity parameter
+  attackVel = -getParameterValue(Parameters::P_EC_AV)
       * _velocity;  // determine attack velocity accorindg to velocity and parameter
-  levelKT = getParameterValue(ParameterLabel::P_EC_LKT)
+  levelKT = getParameterValue(Parameters::P_EC_LKT)
       * _pitch;  // determine level key tracking according to pitch and parameter
   unclipped
       = m_convert.eval_level(((1.f - _velocity) * levelVel)
@@ -607,33 +607,33 @@ void paramengine::newEnvUpdateStart(const uint32_t _voiceId, const float _pitch,
             .m_timeFactor[_voiceId][1];  // determine time factor for decay2 segment (without actual decay2 time)
 
   m_new_envelopes.m_env_c.setAttackCurve(
-      getParameterValue(ParameterLabel::P_EC_AC));  // update the attack curve by corresponding parameter
+      getParameterValue(Parameters::P_EC_AC));  // update the attack curve by corresponding parameter
   m_new_envelopes.m_env_c.setRetriggerHardness(
-      getParameterValue(ParameterLabel::P_EC_RH));  // update the retrigger hardness by corresponding parameter
+      getParameterValue(Parameters::P_EC_RH));  // update the retrigger hardness by corresponding parameter
 
-  time = getParameterValue(ParameterLabel::P_EC_ATT)
+  time = getParameterValue(Parameters::P_EC_ATT)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
   m_new_envelopes.m_env_c.setSegmentDest(_voiceId, 1,
                                          peak);  // update attack segment destination (peak level) (no split behavior)
 
-  time = getParameterValue(ParameterLabel::P_EC_DEC1)
+  time = getParameterValue(Parameters::P_EC_DEC1)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][1];  // determine decay1 segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EC_BP);  // determine decay1 segment destination according to peak level and parameter
+             Parameters::P_EC_BP);  // determine decay1 segment destination according to peak level and parameter
   m_new_envelopes.m_env_c.setSegmentDest(_voiceId, 2, dest);  // update decay1 segment destination (no split behavior)
 
-  time = getParameterValue(ParameterLabel::P_EC_DEC2)
+  time = getParameterValue(Parameters::P_EC_DEC2)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EC_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EC_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_c.setSegmentDest(_voiceId, 3, dest);  // update decay2 segment destination (no split behavior)
 
   /* start envelopes */
@@ -653,19 +653,19 @@ void paramengine::newEnvUpdateStop(const uint32_t _voiceId, const float _pitch, 
 
   /* envelope a update */
 
-  timeKT = -getParameterValue(ParameterLabel::P_EA_TKT)
+  timeKT = -getParameterValue(Parameters::P_EA_TKT)
       * _pitch;  // determine time key tracking according to pitch and parameter
-  releaseVel = -getParameterValue(ParameterLabel::P_EA_RV)
+  releaseVel = -getParameterValue(Parameters::P_EA_RV)
       * _velocity;  // determine release velocity according to velocity and parameter
 
   m_event.m_env[0].m_timeFactor[_voiceId][3] = m_convert.eval_level(timeKT + releaseVel)
       * m_millisecond;  // determine time factor for release segment (without actual release time)
 
-  if(getParameterValue(ParameterLabel::P_EA_REL)
+  if(getParameterValue(Parameters::P_EA_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EA_REL)
+    time = getParameterValue(Parameters::P_EA_REL)
         * m_event.m_env[0]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -678,19 +678,19 @@ void paramengine::newEnvUpdateStop(const uint32_t _voiceId, const float _pitch, 
 
   /* envelope b update */
 
-  timeKT = -getParameterValue(ParameterLabel::P_EB_TKT)
+  timeKT = -getParameterValue(Parameters::P_EB_TKT)
       * _pitch;  // determine time key tracking according to pitch and parameter
-  releaseVel = -getParameterValue(ParameterLabel::P_EB_RV)
+  releaseVel = -getParameterValue(Parameters::P_EB_RV)
       * _velocity;  // determine release velocity according to velocity and parameter
 
   m_event.m_env[1].m_timeFactor[_voiceId][3] = m_convert.eval_level(timeKT + releaseVel)
       * m_millisecond;  // determine time factor for release segment (without actual release time)
 
-  if(getParameterValue(ParameterLabel::P_EB_REL)
+  if(getParameterValue(Parameters::P_EB_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EB_REL)
+    time = getParameterValue(Parameters::P_EB_REL)
         * m_event.m_env[1]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -703,19 +703,19 @@ void paramengine::newEnvUpdateStop(const uint32_t _voiceId, const float _pitch, 
 
   /* envelope c update */
 
-  timeKT = -getParameterValue(ParameterLabel::P_EC_TKT)
+  timeKT = -getParameterValue(Parameters::P_EC_TKT)
       * _pitch;  // determine time key tracking according to pitch and parameter
-  releaseVel = -getParameterValue(ParameterLabel::P_EC_RV)
+  releaseVel = -getParameterValue(Parameters::P_EC_RV)
       * _velocity;  // determine release velocity according to velocity and parameter
 
   m_event.m_env[2].m_timeFactor[_voiceId][3] = m_convert.eval_level(timeKT + releaseVel)
       * m_millisecond;  // determine time factor for release segment (without actual release time)
 
-  if(getParameterValue(ParameterLabel::P_EC_REL)
+  if(getParameterValue(Parameters::P_EC_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EC_REL)
+    time = getParameterValue(Parameters::P_EC_REL)
         * m_event.m_env[2]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -743,26 +743,26 @@ void paramengine::newEnvUpdateTimes(const uint32_t _voiceId)
 
   /* envelope a update */
 
-  time = getParameterValue(ParameterLabel::P_EA_ATT)
+  time = getParameterValue(Parameters::P_EA_ATT)
       * m_event.m_env[0]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
 
-  time = getParameterValue(ParameterLabel::P_EA_DEC1)
+  time = getParameterValue(Parameters::P_EA_DEC1)
       * m_event.m_env[0]
             .m_timeFactor[_voiceId][1];  // determine decay1 segment time according to time factor and parameter
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
 
-  time = getParameterValue(ParameterLabel::P_EA_DEC2)
+  time = getParameterValue(Parameters::P_EA_DEC2)
       * m_event.m_env[0]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
 
-  if(getParameterValue(ParameterLabel::P_EA_REL)
+  if(getParameterValue(Parameters::P_EA_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EA_REL)
+    time = getParameterValue(Parameters::P_EA_REL)
         * m_event.m_env[0]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_a.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -775,26 +775,26 @@ void paramengine::newEnvUpdateTimes(const uint32_t _voiceId)
 
   /* envelope b update */
 
-  time = getParameterValue(ParameterLabel::P_EB_ATT)
+  time = getParameterValue(Parameters::P_EB_ATT)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
 
-  time = getParameterValue(ParameterLabel::P_EB_DEC1)
+  time = getParameterValue(Parameters::P_EB_DEC1)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][1];  // determine decay1 segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
 
-  time = getParameterValue(ParameterLabel::P_EB_DEC2)
+  time = getParameterValue(Parameters::P_EB_DEC2)
       * m_event.m_env[1]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
 
-  if(getParameterValue(ParameterLabel::P_EB_REL)
+  if(getParameterValue(Parameters::P_EB_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EB_REL)
+    time = getParameterValue(Parameters::P_EB_REL)
         * m_event.m_env[1]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_b.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -807,26 +807,26 @@ void paramengine::newEnvUpdateTimes(const uint32_t _voiceId)
 
   /* envelope c update */
 
-  time = getParameterValue(ParameterLabel::P_EC_ATT)
+  time = getParameterValue(Parameters::P_EC_ATT)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][0];  // determine attack segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 1, 1.f / (time + 1.f));  // update attack segment time
 
-  time = getParameterValue(ParameterLabel::P_EC_DEC1)
+  time = getParameterValue(Parameters::P_EC_DEC1)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][1];  // determine decay1 segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 2, 1.f / (time + 1.f));  // update decay1 segment time
 
-  time = getParameterValue(ParameterLabel::P_EC_DEC2)
+  time = getParameterValue(Parameters::P_EC_DEC2)
       * m_event.m_env[2]
             .m_timeFactor[_voiceId][2];  // determine decay2 segment time according to time factor and parameter
   m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 3, 1.f / (time + 1.f));  // update decay2 segment time
 
-  if(getParameterValue(ParameterLabel::P_EC_REL)
+  if(getParameterValue(Parameters::P_EC_REL)
      <= env_highest_finite_time)  // if the release time is meant to be finite (tcd: [0 ... 16000]):
   {
     /* finite release time */
-    time = getParameterValue(ParameterLabel::P_EC_REL)
+    time = getParameterValue(Parameters::P_EC_REL)
         * m_event.m_env[2]
               .m_timeFactor[_voiceId][3];  //      determine release segment time according to time factor and parameter
     m_new_envelopes.m_env_c.setSegmentDx(_voiceId, 4, 1.f / (time + 1.f));  //      update release segment time
@@ -851,13 +851,13 @@ void paramengine::newEnvUpdateLevels(const uint32_t _voiceId)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EA_BP);  // determine decay1 segment destination according to peak level and parameter
+             Parameters::P_EA_BP);  // determine decay1 segment destination according to peak level and parameter
   m_new_envelopes.m_env_a.setSegmentDest(_voiceId, 2, true,
                                          dest);  // update decay1 segment destination (split behavior)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EA_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EA_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_a.setSegmentDest(_voiceId, 3, true,
                                          dest);  // update decay2 segment destinatino (split behavior)
 
@@ -867,13 +867,13 @@ void paramengine::newEnvUpdateLevels(const uint32_t _voiceId)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EB_BP);  // determine decay1 segment destination according to peak level and parameter
+             Parameters::P_EB_BP);  // determine decay1 segment destination according to peak level and parameter
   m_new_envelopes.m_env_b.setSegmentDest(_voiceId, 2, true,
                                          dest);  // update decay1 segment destination (split behavior)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EB_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EB_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_b.setSegmentDest(_voiceId, 3, true,
                                          dest);  // update decay2 segment destinatino (split behavior)
 
@@ -883,12 +883,12 @@ void paramengine::newEnvUpdateLevels(const uint32_t _voiceId)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EC_BP);  // determine decay1 segment destination according to peak level and parameter
+             Parameters::P_EC_BP);  // determine decay1 segment destination according to peak level and parameter
   m_new_envelopes.m_env_c.setSegmentDest(_voiceId, 2, dest);  // update decay1 segment destination (no split behavior)
 
   dest = peak
       * getParameterValue(
-             ParameterLabel::P_EC_SUS);  // determine decay2 segment destination according to peak level and parameter
+             Parameters::P_EC_SUS);  // determine decay2 segment destination according to peak level and parameter
   m_new_envelopes.m_env_c.setSegmentDest(_voiceId, 3, dest);  // update decay2 segment destinatino (no split behavior)
 }
 
@@ -896,15 +896,13 @@ void paramengine::newEnvUpdateLevels(const uint32_t _voiceId)
 void paramengine::postProcessPoly_slow(SignalStorage& signals, const uint32_t _voiceId)
 {
   /* automatic mono to poly distribution */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SPREAD, PARAM_CLOCK_TYPES::PARAM_SLOW,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Spread, ClockTypes::Slow, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
   }
   /* automatic poly to poly copy - each voice */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_SLOW,
-                                         PARAM_POLY_TYPES::PARAM_POLY))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Slow, PolyTypes::Poly))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it, _voiceId));
@@ -915,65 +913,65 @@ void paramengine::postProcessPoly_slow(SignalStorage& signals, const uint32_t _v
   newEnvUpdateTimes(_voiceId);
   /* Pitch Updates */
 #if test_milestone == 150
-  const float notePitch
-      = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
+      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
   const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
   const float notePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + getParameterValue(ParameterLabel::P_MA_T)
-      + m_note_shift[_voiceId];
-#elif test_milestone == 156
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
-  const uint32_t uIndex = m_unison_index[_voiceId];
-  const float notePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId)
       + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
       + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+#elif test_milestone == 156
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
+  const uint32_t uIndex = m_unison_index[_voiceId];
+  const float notePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #endif
   float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod;
   /* Oscillator A */
   /* - Oscillator A Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Osc Pitch, Envelope C) */
-  keyTracking = getParameterValue(ParameterLabel::P_OA_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_OA_P);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_OA_PEC);
+  keyTracking = getParameterValue(Parameters::P_OA_PKT);
+  unitPitch = getParameterValue(Parameters::P_OA_P);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_OA_PEC);
   signals.set(
-      SignalLabel::OSC_A_FRQ,
+      Signals::OSC_A_FRQ,
       evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   /* - Oscillator A Fluctuation (Envelope C) */
-  envMod = getParameterValue(ParameterLabel::P_OA_FEC);
-  signals.set(SignalLabel::OSC_A_FLUEC,
-              getParameterValue(ParameterLabel::P_OA_F)
-                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), envMod));
+  envMod = getParameterValue(Parameters::P_OA_FEC);
+  signals.set(Signals::OSC_A_FLUEC,
+              getParameterValue(Parameters::P_OA_F)
+                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), envMod));
   /* - Oscillator A Chirp Frequency in Hz */
-  signals.set(SignalLabel::OSC_A_CHI, evalNyquist(getParameterValue(ParameterLabel::P_OA_CHI) * 440.f));
+  signals.set(Signals::OSC_A_CHI, evalNyquist(getParameterValue(Parameters::P_OA_CHI) * 440.f));
   /* Oscillator B */
   /* - Oscillator B Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Osc Pitch, Envelope C) */
-  keyTracking = getParameterValue(ParameterLabel::P_OB_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_OB_P);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_OB_PEC);
+  keyTracking = getParameterValue(Parameters::P_OB_PKT);
+  unitPitch = getParameterValue(Parameters::P_OB_P);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_OB_PEC);
   signals.set(
-      SignalLabel::OSC_B_FRQ,
+      Signals::OSC_B_FRQ,
       evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   /* - Oscillator B Fluctuation (Envelope C) */
-  envMod = getParameterValue(ParameterLabel::P_OB_FEC);
-  signals.set(SignalLabel::OSC_B_FLUEC,
-              getParameterValue(ParameterLabel::P_OB_F)
-                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), envMod));
+  envMod = getParameterValue(Parameters::P_OB_FEC);
+  signals.set(Signals::OSC_B_FLUEC,
+              getParameterValue(Parameters::P_OB_F)
+                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), envMod));
   /* - Oscillator B Chirp Frequency in Hz */
-  signals.set(SignalLabel::OSC_B_CHI, evalNyquist(getParameterValue(ParameterLabel::P_OB_CHI) * 440.f));
+  signals.set(Signals::OSC_B_CHI, evalNyquist(getParameterValue(Parameters::P_OB_CHI) * 440.f));
   /* Comb Filter */
   /* - Comb Filter Pitch as Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Comb Pitch) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_P);
+  keyTracking = getParameterValue(Parameters::P_CMB_PKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_P);
   // as a tonal component, the reference tone frequency is applied (instead of const 440 Hz)
-  signals.set(SignalLabel::CMB_FRQ,
+  signals.set(Signals::CMB_FRQ,
               evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking))));
   /* - Comb Filter Bypass (according to Pitch parameter - without key tracking or reference freq) */
-  signals.set(SignalLabel::CMB_BYP, unitPitch > dsp_comb_max_freqFactor ? 1.f : 0.f);
+  signals.set(Signals::CMB_BYP, unitPitch > dsp_comb_max_freqFactor ? 1.f : 0.f);
   // check for bypassing comb filter, max_freqFactor corresponds to Pitch of 119.99 ST
   /* - Comb Filter Decay Time (Base Pitch, Master Tune, Gate Env, Dec Time, Key Tracking, Gate Amount) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_DKT);
-  unitSign = 0.001f * (getParameterValue(ParameterLabel::P_CMB_D) < 0 ? -1.f : 1.f);
+  keyTracking = getParameterValue(Parameters::P_CMB_DKT);
+  unitSign = 0.001f * (getParameterValue(Parameters::P_CMB_D) < 0 ? -1.f : 1.f);
 #if test_comb_decay_gate_mode == 0
   // apply decay time directly
   envMod = 1.f
@@ -983,79 +981,77 @@ void paramengine::postProcessPoly_slow(SignalStorage& signals, const uint32_t _v
   signals.set(SignalLabel::CMB_DEC, m_convert.eval_level(unitPitch) * unitSign);
 #elif test_comb_decay_gate_mode == 1
   // determine decay times min, max before crossfading them by gate signal (audio post processing)
-  envMod = 1.f - m_combDecayCurve.applyCurve(getParameterValue(ParameterLabel::P_CMB_DG));
-  unitMod = std::abs(getParameterValue(ParameterLabel::P_CMB_D));
+  envMod = 1.f - m_combDecayCurve.applyCurve(getParameterValue(Parameters::P_CMB_DG));
+  unitMod = std::abs(getParameterValue(Parameters::P_CMB_D));
   unitPitch = (-0.5f * notePitch * keyTracking);
   m_comb_decay_times[0] = m_convert.eval_level(unitPitch + (unitMod * envMod)) * unitSign;
   m_comb_decay_times[1] = m_convert.eval_level(unitPitch + unitMod) * unitSign;
 #endif
   /* - Comb Filter Allpass Frequency (Base Pitch, Master Tune, Key Tracking, AP Tune, Env C) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_APKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_APT);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_CMB_APEC);
-  signals.set(SignalLabel::CMB_APF,
+  keyTracking = getParameterValue(Parameters::P_CMB_APKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_APT);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_CMB_APEC);
+  signals.set(Signals::CMB_APF,
               evalNyquist(440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   // not sure if APF needs Nyquist Clipping?
   //signals.set(SignalLabel::CMB_APF, 440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (basePitch * keyTracking) + envMod));                   // currently APF without Nyquist Clipping
   /* - Comb Filter Lowpass ('Hi Cut') Frequency (Base Pitch, Master Tune, Key Tracking, Hi Cut, Env C) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_LPKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_LP);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_CMB_LPEC);
-  signals.set(SignalLabel::CMB_LPF,
+  keyTracking = getParameterValue(Parameters::P_CMB_LPKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_LP);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_CMB_LPEC);
+  signals.set(Signals::CMB_LPF,
               evalNyquist(440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   //signals.set(SignalLabel::CMB_LPF, 440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (basePitch * keyTracking) + envMod));                   // currently LPF without Nyquist Clipping
   /* State Variable Filter */
   /* - Cutoff Frequencies */
-  keyTracking = getParameterValue(ParameterLabel::P_SVF_CKT);  // get Key Tracking
-  envMod = signals.get(SignalLabel::ENV_C_UNCL)
-      * getParameterValue(ParameterLabel::P_SVF_CEC);  // get Envelope C Modulation (amount * envelope_c_signal)
+  keyTracking = getParameterValue(Parameters::P_SVF_CKT);  // get Key Tracking
+  envMod = signals.get(Signals::ENV_C_UNCL)
+      * getParameterValue(Parameters::P_SVF_CEC);  // get Envelope C Modulation (amount * envelope_c_signal)
   // as a tonal component, the Reference Tone frequency is applied (instead of const 440 Hz)
-  unitPitch = m_pitch_reference * getParameterValue(ParameterLabel::P_SVF_CUT);
-  unitSpread = getParameterValue(ParameterLabel::P_SVF_SPR);  // get the Spread parameter (already scaled to 50%)
-  unitMod = getParameterValue(ParameterLabel::P_SVF_FM);      // get the FM parameter
+  unitPitch = m_pitch_reference * getParameterValue(Parameters::P_SVF_CUT);
+  unitSpread = getParameterValue(Parameters::P_SVF_SPR);  // get the Spread parameter (already scaled to 50%)
+  unitMod = getParameterValue(Parameters::P_SVF_FM);      // get the FM parameter
   /*   now, calculate the actual filter frequencies and put them in the shared signal array */
 
   // SVF upper 2PF Cutoff Frequency
   signals.set(
-      SignalLabel::SVF_F1_CUT,
+      Signals::SVF_F1_CUT,
       evalNyquist(unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod + unitSpread)));
 
   // SVF lower 2PF Cutoff Frequency
   signals.set(
-      SignalLabel::SVF_F2_CUT,
+      Signals::SVF_F2_CUT,
       evalNyquist(unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod - unitSpread)));
 
   // SVF upper 2PF FM Amount (Frequency)
-  signals.set(SignalLabel::SVF_F1_FM, signals.get(SignalLabel::SVF_F1_CUT) * unitMod);
+  signals.set(Signals::SVF_F1_FM, signals.get(Signals::SVF_F1_CUT) * unitMod);
   // SVF lower 2PF FM Amount (Frequency)
-  signals.set(SignalLabel::SVF_F2_FM, signals.get(SignalLabel::SVF_F2_CUT) * unitMod);
+  signals.set(Signals::SVF_F2_FM, signals.get(Signals::SVF_F2_CUT) * unitMod);
   /* - Resonance */
-  keyTracking = getParameterValue(ParameterLabel::P_SVF_RKT) * m_svfResFactor;
-  envMod = signals.get(SignalLabel::ENV_C_CLIP) * getParameterValue(ParameterLabel::P_SVF_REC);
-  unitPitch = getParameterValue(ParameterLabel::P_SVF_RES) + envMod + (notePitch * keyTracking);
+  keyTracking = getParameterValue(Parameters::P_SVF_RKT) * m_svfResFactor;
+  envMod = signals.get(Signals::ENV_C_CLIP) * getParameterValue(Parameters::P_SVF_REC);
+  unitPitch = getParameterValue(Parameters::P_SVF_RES) + envMod + (notePitch * keyTracking);
   //signals.set(SignalLabel::SVF_RES, m_svfResonanceCurve.applyCurve(std::clamp(unitPitch, 0.f, 1.f)));
   float res = 1.f
       - m_svfResonanceCurve.applyCurve(
             std::clamp(unitPitch, 0.f, 1.f));  // NEW resonance handling directly in post processing
-  signals.set(SignalLabel::SVF_RES, std::max(res + res, 0.02f));
+  signals.set(Signals::SVF_RES, std::max(res + res, 0.02f));
   /* - Feedback Mixer */
   /*   - determine Highpass Filter Frequency */
-  signals.set(SignalLabel::FBM_HPF, evalNyquist(m_convert.eval_lin_pitch(12.f + notePitch) * 440.f));
+  signals.set(Signals::FBM_HPF, evalNyquist(m_convert.eval_lin_pitch(12.f + notePitch) * 440.f));
 }
 
 /* Poly Post Processing - fast parameters */
 void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _voiceId)
 {
   /* automatic mono to poly distribution */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SPREAD, PARAM_CLOCK_TYPES::PARAM_FAST,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Spread, ClockTypes::Fast, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
   }
   /* automatic poly to poly copy - each voice */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_FAST,
-                                         PARAM_POLY_TYPES::PARAM_POLY))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Fast, PolyTypes::Poly))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it, _voiceId));
@@ -1067,8 +1063,8 @@ void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _v
   /* temporary variables */
   float tmp_lvl, tmp_pan, tmp_abs;
 #if test_milestone == 150
-  const float notePitch
-      = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
+      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
   const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
@@ -1076,24 +1072,24 @@ void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _v
   const float notePitch = basePitch + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
       + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 156
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
-  const float basePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId);
-  const float notePitch = basePitch + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex])
-      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float basePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId);
+  const float notePitch = basePitch + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex])
+      + getParameterValue(Parameters::P_MA_T) + m_note_shift[_voiceId];
 #endif
   /* State Variable Filter */
   /* - LBH */
-  tmp_lvl = getParameterValue(ParameterLabel::P_SVF_LBH);
-  signals.set(SignalLabel::SVF_LBH_1, m_svfLBH1Curve.applyCurve(tmp_lvl));
-  signals.set(SignalLabel::SVF_LBH_2, m_svfLBH2Curve.applyCurve(tmp_lvl));
+  tmp_lvl = getParameterValue(Parameters::P_SVF_LBH);
+  signals.set(Signals::SVF_LBH_1, m_svfLBH1Curve.applyCurve(tmp_lvl));
+  signals.set(Signals::SVF_LBH_2, m_svfLBH2Curve.applyCurve(tmp_lvl));
   /* - Parallel */
-  tmp_lvl = getParameterValue(ParameterLabel::P_SVF_PAR);
+  tmp_lvl = getParameterValue(Parameters::P_SVF_PAR);
   tmp_abs = std::abs(tmp_lvl);
-  signals.set(SignalLabel::SVF_PAR_1, 0.7f * tmp_abs);
-  signals.set(SignalLabel::SVF_PAR_2, (0.7f * tmp_lvl) + (1.f - tmp_abs));
-  signals.set(SignalLabel::SVF_PAR_3, 1.f - tmp_abs);
-  signals.set(SignalLabel::SVF_PAR_4, tmp_abs);
+  signals.set(Signals::SVF_PAR_1, 0.7f * tmp_abs);
+  signals.set(Signals::SVF_PAR_2, (0.7f * tmp_lvl) + (1.f - tmp_abs));
+  signals.set(Signals::SVF_PAR_3, 1.f - tmp_abs);
+  signals.set(Signals::SVF_PAR_4, tmp_abs);
   /* Output Mixer */
 #if test_milestone == 150
   const float poly_pan = getParameterValue(ParameterLabel::P_KEY_VP, _voiceId);
@@ -1101,48 +1097,46 @@ void paramengine::postProcessPoly_fast(SignalStorage& signals, const uint32_t _v
   const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
       + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #elif test_milestone == 156
-  const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
-      + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
+  const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
+      + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #endif
   /* - Branch A */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_AL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_AP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_A_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_A_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_AL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_AP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_A_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_A_R, tmp_lvl * tmp_pan);
   /* - Branch B */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_BL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_BP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_B_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_B_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_BL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_BP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_B_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_B_R, tmp_lvl * tmp_pan);
   /* - Comb Filter */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_CL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_CP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_CMB_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_CMB_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_CL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_CP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_CMB_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_CMB_R, tmp_lvl * tmp_pan);
   /* - State Variable Filter */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_SL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_SP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_SVF_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_SVF_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_SL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_SP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_SVF_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_SVF_R, tmp_lvl * tmp_pan);
   /* - Feedback Mixer */
-  tmp_lvl = getParameterValue(ParameterLabel::P_FBM_LVL);
-  tmp_pan = std::min(m_convert.eval_level(getParameterValue(ParameterLabel::P_FBM_LKT) * (notePitch)), env_clip_peak);
-  signals.set(SignalLabel::FBM_LVL, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_FBM_LVL);
+  tmp_pan = std::min(m_convert.eval_level(getParameterValue(Parameters::P_FBM_LKT) * (notePitch)), env_clip_peak);
+  signals.set(Signals::FBM_LVL, tmp_lvl * tmp_pan);
 }
 
 /* Poly Post Processing - audio parameters */
 void paramengine::postProcessPoly_audio(SignalStorage& signals, const uint32_t _voiceId)
 {
   /* automatic mono to poly distribution */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SPREAD, PARAM_CLOCK_TYPES::PARAM_AUDIO,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Spread, ClockTypes::Audio, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
   }
   /* automatic poly to poly copy - each voice */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_AUDIO,
-                                         PARAM_POLY_TYPES::PARAM_POLY))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Audio, PolyTypes::Poly))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it, _voiceId));
@@ -1156,97 +1150,95 @@ void paramengine::postProcessPoly_audio(SignalStorage& signals, const uint32_t _
   /* poly envelope distribution */
 
   // Envelope A Magnitude post Gain
-  signals.set(SignalLabel::ENV_A_MAG,
-              m_new_envelopes.m_env_a.m_body[_voiceId].m_signal_magnitude
-                  * getParameterValue(ParameterLabel::P_EA_GAIN));
+  signals.set(Signals::ENV_A_MAG,
+              m_new_envelopes.m_env_a.m_body[_voiceId].m_signal_magnitude * getParameterValue(Parameters::P_EA_GAIN));
   // Envelope A Timbre post Gain
-  signals.set(SignalLabel::ENV_A_TMB,
-              m_new_envelopes.m_env_a.m_body[_voiceId].m_signal_timbre * getParameterValue(ParameterLabel::P_EA_GAIN));
+  signals.set(Signals::ENV_A_TMB,
+              m_new_envelopes.m_env_a.m_body[_voiceId].m_signal_timbre * getParameterValue(Parameters::P_EA_GAIN));
   // Envelope B Magnitude post Gain
-  signals.set(SignalLabel::ENV_B_MAG,
-              m_new_envelopes.m_env_b.m_body[_voiceId].m_signal_magnitude
-                  * getParameterValue(ParameterLabel::P_EB_GAIN));
+  signals.set(Signals::ENV_B_MAG,
+              m_new_envelopes.m_env_b.m_body[_voiceId].m_signal_magnitude * getParameterValue(Parameters::P_EB_GAIN));
   // Envelope B Timbre post Gain
-  signals.set(SignalLabel::ENV_B_TMB,
-              m_new_envelopes.m_env_b.m_body[_voiceId].m_signal_timbre * getParameterValue(ParameterLabel::P_EB_GAIN));
-  signals.set(SignalLabel::ENV_C_CLIP, m_new_envelopes.m_env_c.m_body[_voiceId].m_signal_magnitude);  // Envelope C
-  signals.set(SignalLabel::ENV_G_SIG, m_new_envelopes.m_env_g.m_body[_voiceId].m_signal_magnitude);   // Gate
+  signals.set(Signals::ENV_B_TMB,
+              m_new_envelopes.m_env_b.m_body[_voiceId].m_signal_timbre * getParameterValue(Parameters::P_EB_GAIN));
+  signals.set(Signals::ENV_C_CLIP, m_new_envelopes.m_env_c.m_body[_voiceId].m_signal_magnitude);  // Envelope C
+  signals.set(Signals::ENV_G_SIG, m_new_envelopes.m_env_g.m_body[_voiceId].m_signal_magnitude);   // Gate
   /* reconstruct unclipped envelope c signal by factor */
-  signals.set(SignalLabel::ENV_C_UNCL, signals.get(SignalLabel::ENV_C_CLIP) * m_env_c_clipFactor[_voiceId]);
+  signals.set(Signals::ENV_C_UNCL, signals.get(Signals::ENV_C_CLIP) * m_env_c_clipFactor[_voiceId]);
   /* Oscillator parameter post processing */
   float tmp_amt, tmp_env;
   /* Oscillator A */
   /* - Oscillator A - PM Self */
-  tmp_amt = getParameterValue(ParameterLabel::P_OA_PMS);
-  tmp_env = getParameterValue(ParameterLabel::P_OA_PMSEA);
+  tmp_amt = getParameterValue(Parameters::P_OA_PMS);
+  tmp_env = getParameterValue(Parameters::P_OA_PMSEA);
 
   // Osc A PM Self (Env A)
-  signals.set(SignalLabel::OSC_A_PMSEA,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_A_TMB), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_A_PMSEA,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_A_TMB), tmp_env) * tmp_amt);
   /* - Oscillator A - PM B */
-  tmp_amt = getParameterValue(ParameterLabel::P_OA_PMB);
-  tmp_env = getParameterValue(ParameterLabel::P_OA_PMBEB);
+  tmp_amt = getParameterValue(Parameters::P_OA_PMB);
+  tmp_env = getParameterValue(Parameters::P_OA_PMBEB);
   // Osc A PM B (Env B)
-  signals.set(SignalLabel::OSC_A_PMBEB,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_B_TMB), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_A_PMBEB,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_B_TMB), tmp_env) * tmp_amt);
   /* - Oscillator A - PM FB */
-  tmp_amt = getParameterValue(ParameterLabel::P_OA_PMF);
-  tmp_env = getParameterValue(ParameterLabel::P_OA_PMFEC);
+  tmp_amt = getParameterValue(Parameters::P_OA_PMF);
+  tmp_env = getParameterValue(Parameters::P_OA_PMFEC);
   // Osc A PM FB (Env C)
-  signals.set(SignalLabel::OSC_A_PMFEC,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_A_PMFEC,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), tmp_env) * tmp_amt);
   /* Shaper A */
   /* - Shaper A Drive (Envelope A) */
-  tmp_amt = getParameterValue(ParameterLabel::P_SA_DRV);
-  tmp_env = getParameterValue(ParameterLabel::P_SA_DEA);
-  signals.set(SignalLabel::SHP_A_DRVEA,
-              (NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_A_TMB), tmp_env) * tmp_amt)
+  tmp_amt = getParameterValue(Parameters::P_SA_DRV);
+  tmp_env = getParameterValue(Parameters::P_SA_DEA);
+  signals.set(Signals::SHP_A_DRVEA,
+              (NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_A_TMB), tmp_env) * tmp_amt)
                   + 0.18f);
   /* - Shaper A Feedback Mix (Envelope C) */
-  tmp_env = getParameterValue(ParameterLabel::P_SA_FBEC);
-  signals.set(SignalLabel::SHP_A_FBEC,
-              NlToolbox::Crossfades::unipolarCrossFade(signals.get(SignalLabel::ENV_G_SIG),
-                                                       signals.get(SignalLabel::ENV_C_CLIP), tmp_env));
+  tmp_env = getParameterValue(Parameters::P_SA_FBEC);
+  signals.set(Signals::SHP_A_FBEC,
+              NlToolbox::Crossfades::unipolarCrossFade(signals.get(Signals::ENV_G_SIG),
+                                                       signals.get(Signals::ENV_C_CLIP), tmp_env));
   /* Oscillator B */
   /* - Oscillator B - PM Self */
-  tmp_amt = getParameterValue(ParameterLabel::P_OB_PMS);
-  tmp_env = getParameterValue(ParameterLabel::P_OB_PMSEB);
+  tmp_amt = getParameterValue(Parameters::P_OB_PMS);
+  tmp_env = getParameterValue(Parameters::P_OB_PMSEB);
   // Osc B PM Self (Env B)
-  signals.set(SignalLabel::OSC_B_PMSEB,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_B_TMB), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_B_PMSEB,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_B_TMB), tmp_env) * tmp_amt);
   /* - Oscillator B - PM A */
-  tmp_amt = getParameterValue(ParameterLabel::P_OB_PMA);
-  tmp_env = getParameterValue(ParameterLabel::P_OB_PMAEA);
+  tmp_amt = getParameterValue(Parameters::P_OB_PMA);
+  tmp_env = getParameterValue(Parameters::P_OB_PMAEA);
   // Osc B PM A (Env A)
-  signals.set(SignalLabel::OSC_B_PMAEA,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_A_TMB), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_B_PMAEA,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_A_TMB), tmp_env) * tmp_amt);
   /* - Oscillator B - PM FB */
-  tmp_amt = getParameterValue(ParameterLabel::P_OB_PMF);
-  tmp_env = getParameterValue(ParameterLabel::P_OB_PMFEC);
+  tmp_amt = getParameterValue(Parameters::P_OB_PMF);
+  tmp_env = getParameterValue(Parameters::P_OB_PMFEC);
   // Osc B PM FB (Env C)
-  signals.set(SignalLabel::OSC_B_PMFEC,
-              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), tmp_env) * tmp_amt);
+  signals.set(Signals::OSC_B_PMFEC,
+              NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), tmp_env) * tmp_amt);
   /* Shaper B */
   /* - Shaper B Drive (Envelope B) */
-  tmp_amt = getParameterValue(ParameterLabel::P_SB_DRV);
-  tmp_env = getParameterValue(ParameterLabel::P_SB_DEB);
-  signals.set(SignalLabel::SHP_B_DRVEB,
-              (NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_B_TMB), tmp_env) * tmp_amt)
+  tmp_amt = getParameterValue(Parameters::P_SB_DRV);
+  tmp_env = getParameterValue(Parameters::P_SB_DEB);
+  signals.set(Signals::SHP_B_DRVEB,
+              (NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_B_TMB), tmp_env) * tmp_amt)
                   + 0.18f);
   /* - Shaper B Feedback Mix (Envelope C) */
-  tmp_env = getParameterValue(ParameterLabel::P_SB_FBEC);
-  signals.set(SignalLabel::SHP_B_FBEC,
-              NlToolbox::Crossfades::unipolarCrossFade(signals.get(SignalLabel::ENV_G_SIG),
-                                                       signals.get(SignalLabel::ENV_C_CLIP), tmp_env));
+  tmp_env = getParameterValue(Parameters::P_SB_FBEC);
+  signals.set(Signals::SHP_B_FBEC,
+              NlToolbox::Crossfades::unipolarCrossFade(signals.get(Signals::ENV_G_SIG),
+                                                       signals.get(Signals::ENV_C_CLIP), tmp_env));
   /* Comb Filter */
   /* - Comb Filter Pitch Envelope C, converted into Frequency Factor */
-  tmp_amt = getParameterValue(ParameterLabel::P_CMB_PEC);
-  signals.set(SignalLabel::CMB_FEC, m_convert.eval_lin_pitch(69.f - (tmp_amt * signals.get(SignalLabel::ENV_C_UNCL))));
+  tmp_amt = getParameterValue(Parameters::P_CMB_PEC);
+  signals.set(Signals::CMB_FEC, m_convert.eval_lin_pitch(69.f - (tmp_amt * signals.get(Signals::ENV_C_UNCL))));
   /* Decay Time - Gate Signal crossfading */
 #if test_comb_decay_gate_mode == 1
-  signals.set(SignalLabel::CMB_DEC,
+  signals.set(Signals::CMB_DEC,
               NlToolbox::Crossfades::unipolarCrossFade(m_comb_decay_times[0], m_comb_decay_times[1],
-                                                       signals.get(SignalLabel::ENV_G_SIG)));
+                                                       signals.get(Signals::ENV_G_SIG)));
 #endif
   /* Unison Phase */
 #if test_milestone == 150
@@ -1256,9 +1248,9 @@ void paramengine::postProcessPoly_audio(SignalStorage& signals, const uint32_t _
   const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
   signals.set(SignalLabel::UN_PHS, getParameterValue(ParameterLabel::P_UN_PHS) * m_unison_phase[uVoice][uIndex]);
 #elif test_milestone == 156
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
-  signals.set(SignalLabel::UN_PHS, getParameterValue(ParameterLabel::P_UN_PHS) * m_unison_phase[uVoice][uIndex]);
+  signals.set(Signals::UN_PHS, getParameterValue(Parameters::P_UN_PHS) * m_unison_phase[uVoice][uIndex]);
 #endif
 }
 
@@ -1267,8 +1259,8 @@ void paramengine::postProcessPoly_key(SignalStorage& signals, const uint32_t _vo
 {
   /* Pitch Updates */
 #if test_milestone == 150
-  const float notePitch
-      = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId) + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
+  const float notePitch = getParameterValue(ParameterLabel::P_KEY_NP, _voiceId)
+      + getParameterValue(ParameterLabel::P_MA_T) + m_note_shift[_voiceId];
 #elif test_milestone == 155
   const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
   const uint32_t uIndex = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_KEY_IDX, _voiceId));
@@ -1276,108 +1268,108 @@ void paramengine::postProcessPoly_key(SignalStorage& signals, const uint32_t _vo
   const float notePitch = basePitch + getParameterValue(ParameterLabel::P_MA_T)
       + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + m_note_shift[_voiceId];
 #elif test_milestone == 156
-  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(ParameterLabel::P_UN_V));
+  const uint32_t uVoice = static_cast<uint32_t>(getParameterValue(Parameters::P_UN_V));
   const uint32_t uIndex = m_unison_index[_voiceId];
-  const float basePitch = getParameterValue(ParameterLabel::P_KEY_BP, _voiceId);
-  const float notePitch = basePitch + getParameterValue(ParameterLabel::P_MA_T)
-      + (getParameterValue(ParameterLabel::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + m_note_shift[_voiceId];
+  const float basePitch = getParameterValue(Parameters::P_KEY_BP, _voiceId);
+  const float notePitch = basePitch + getParameterValue(Parameters::P_MA_T)
+      + (getParameterValue(Parameters::P_UN_DET) * m_unison_detune[uVoice][uIndex]) + m_note_shift[_voiceId];
 #endif
   float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod;
   /* Oscillator A */
   /* - Oscillator A Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Osc Pitch, Envelope C) */
-  keyTracking = getParameterValue(ParameterLabel::P_OA_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_OA_P);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_OA_PEC);
+  keyTracking = getParameterValue(Parameters::P_OA_PKT);
+  unitPitch = getParameterValue(Parameters::P_OA_P);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_OA_PEC);
   signals.set(
-      SignalLabel::OSC_A_FRQ,
+      Signals::OSC_A_FRQ,
       evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   /* - Oscillator A Fluctuation (Envelope C) */
-  envMod = getParameterValue(ParameterLabel::P_OA_FEC);
-  signals.set(SignalLabel::OSC_A_FLUEC,
-              getParameterValue(ParameterLabel::P_OA_F)
-                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), envMod));
+  envMod = getParameterValue(Parameters::P_OA_FEC);
+  signals.set(Signals::OSC_A_FLUEC,
+              getParameterValue(Parameters::P_OA_F)
+                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), envMod));
   /* - Oscillator A Chirp Frequency in Hz */
-  signals.set(SignalLabel::OSC_A_CHI, evalNyquist(getParameterValue(ParameterLabel::P_OA_CHI) * 440.f));
+  signals.set(Signals::OSC_A_CHI, evalNyquist(getParameterValue(Parameters::P_OA_CHI) * 440.f));
   /* Oscillator B */
   /* - Oscillator B Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Osc Pitch, Envelope C) */
-  keyTracking = getParameterValue(ParameterLabel::P_OB_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_OB_P);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_OB_PEC);
+  keyTracking = getParameterValue(Parameters::P_OB_PKT);
+  unitPitch = getParameterValue(Parameters::P_OB_P);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_OB_PEC);
   signals.set(
-      SignalLabel::OSC_B_FRQ,
+      Signals::OSC_B_FRQ,
       evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   /* - Oscillator B Fluctuation (Envelope C) */
-  envMod = getParameterValue(ParameterLabel::P_OB_FEC);
-  signals.set(SignalLabel::OSC_B_FLUEC,
-              getParameterValue(ParameterLabel::P_OB_F)
-                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(SignalLabel::ENV_C_CLIP), envMod));
+  envMod = getParameterValue(Parameters::P_OB_FEC);
+  signals.set(Signals::OSC_B_FLUEC,
+              getParameterValue(Parameters::P_OB_F)
+                  * NlToolbox::Crossfades::unipolarCrossFade(1.f, signals.get(Signals::ENV_C_CLIP), envMod));
   /* - Oscillator B Chirp Frequency in Hz */
-  signals.set(SignalLabel::OSC_B_CHI, evalNyquist(getParameterValue(ParameterLabel::P_OB_CHI) * 440.f));
+  signals.set(Signals::OSC_B_CHI, evalNyquist(getParameterValue(Parameters::P_OB_CHI) * 440.f));
   /* Comb Filter */
   /* - Comb Filter Pitch as Frequency in Hz (Base Pitch, Master Tune, Key Tracking, Comb Pitch) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_PKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_P);
+  keyTracking = getParameterValue(Parameters::P_CMB_PKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_P);
   // as a tonal component, the reference tone frequency is applied (instead of const 440 Hz)
-  signals.set(SignalLabel::CMB_FRQ,
+  signals.set(Signals::CMB_FRQ,
               evalNyquist(m_pitch_reference * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking))));
   /* - Comb Filter Bypass (according to Pitch parameter - without key tracking or reference freq) */
   // check for bypassing comb filter, max_freqFactor corresponds to Pitch of 119.99 ST
-  signals.set(SignalLabel::CMB_BYP, unitPitch > dsp_comb_max_freqFactor ? 1.f : 0.f);
+  signals.set(Signals::CMB_BYP, unitPitch > dsp_comb_max_freqFactor ? 1.f : 0.f);
   /* - Comb Filter Decay Time (Base Pitch, Master Tune, Gate Env, Dec Time, Key Tracking, Gate Amount) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_DKT);
+  keyTracking = getParameterValue(Parameters::P_CMB_DKT);
   envMod = 1.f
-      - ((1.f - signals.get(SignalLabel::ENV_G_SIG))
-         * m_combDecayCurve.applyCurve(getParameterValue(ParameterLabel::P_CMB_DG)));
-  unitPitch = (-0.5f * notePitch * keyTracking) + (std::abs(getParameterValue(ParameterLabel::P_CMB_D)) * envMod);
-  unitSign = getParameterValue(ParameterLabel::P_CMB_D) < 0 ? -1.f : 1.f;
-  signals.set(SignalLabel::CMB_DEC, 0.001f * m_convert.eval_level(unitPitch) * unitSign);
+      - ((1.f - signals.get(Signals::ENV_G_SIG))
+         * m_combDecayCurve.applyCurve(getParameterValue(Parameters::P_CMB_DG)));
+  unitPitch = (-0.5f * notePitch * keyTracking) + (std::abs(getParameterValue(Parameters::P_CMB_D)) * envMod);
+  unitSign = getParameterValue(Parameters::P_CMB_D) < 0 ? -1.f : 1.f;
+  signals.set(Signals::CMB_DEC, 0.001f * m_convert.eval_level(unitPitch) * unitSign);
   /* - Comb Filter Allpass Frequency (Base Pitch, Master Tune, Key Tracking, AP Tune, Env C) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_APKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_APT);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_CMB_APEC);
+  keyTracking = getParameterValue(Parameters::P_CMB_APKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_APT);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_CMB_APEC);
   // not sure if APF needs Nyquist Clipping?
-  signals.set(SignalLabel::CMB_APF,
+  signals.set(Signals::CMB_APF,
               evalNyquist(440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   //signals.set(SignalLabel::CMB_APF, 440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (basePitch * keyTracking) + envMod));                   // currently APF without Nyquist Clipping
   /* - Comb Filter Lowpass ('Hi Cut') Frequency (Base Pitch, Master Tune, Key Tracking, Hi Cut, Env C) */
-  keyTracking = getParameterValue(ParameterLabel::P_CMB_LPKT);
-  unitPitch = getParameterValue(ParameterLabel::P_CMB_LP);
-  envMod = signals.get(SignalLabel::ENV_C_UNCL) * getParameterValue(ParameterLabel::P_CMB_LPEC);
+  keyTracking = getParameterValue(Parameters::P_CMB_LPKT);
+  unitPitch = getParameterValue(Parameters::P_CMB_LP);
+  envMod = signals.get(Signals::ENV_C_UNCL) * getParameterValue(Parameters::P_CMB_LPEC);
   // not sure if LPF needs Nyquist Clipping?
-  signals.set(SignalLabel::CMB_LPF,
+  signals.set(Signals::CMB_LPF,
               evalNyquist(440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod)));
   //signals.set(SignalLabel::CMB_LPF, 440.f * unitPitch * m_convert.eval_lin_pitch(69.f + (basePitch * keyTracking) + envMod));                   // currently LPF without Nyquist Clipping
   /* State Variable Filter */
   /* - Cutoff Frequencies */
-  keyTracking = getParameterValue(ParameterLabel::P_SVF_CKT);  // get Key Tracking
-  envMod = signals.get(SignalLabel::ENV_C_UNCL)
-      * getParameterValue(ParameterLabel::P_SVF_CEC);  // get Envelope C Modulation (amount * envelope_c_signal)
+  keyTracking = getParameterValue(Parameters::P_SVF_CKT);  // get Key Tracking
+  envMod = signals.get(Signals::ENV_C_UNCL)
+      * getParameterValue(Parameters::P_SVF_CEC);  // get Envelope C Modulation (amount * envelope_c_signal)
   // as a tonal component, the Reference Tone frequency is applied (instead of const 440 Hz)
-  unitPitch = m_pitch_reference * getParameterValue(ParameterLabel::P_SVF_CUT);
-  unitSpread = getParameterValue(ParameterLabel::P_SVF_SPR);  // get the Spread parameter (already scaled to 50%)
-  unitMod = getParameterValue(ParameterLabel::P_SVF_FM);      // get the FM parameter
+  unitPitch = m_pitch_reference * getParameterValue(Parameters::P_SVF_CUT);
+  unitSpread = getParameterValue(Parameters::P_SVF_SPR);  // get the Spread parameter (already scaled to 50%)
+  unitMod = getParameterValue(Parameters::P_SVF_FM);      // get the FM parameter
   /*   now, calculate the actual filter frequencies and put them in the shared signal array */
   // SVF upper 2PF Cutoff Frequency
   signals.set(
-      SignalLabel::SVF_F1_CUT,
+      Signals::SVF_F1_CUT,
       evalNyquist(unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod + unitSpread)));
   // SVF lower 2PF Cutoff Frequency
   signals.set(
-      SignalLabel::SVF_F2_CUT,
+      Signals::SVF_F2_CUT,
       evalNyquist(unitPitch * m_convert.eval_lin_pitch(69.f + (notePitch * keyTracking) + envMod - unitSpread)));
-  signals.set(SignalLabel::SVF_F1_FM,
-              signals.get(SignalLabel::SVF_F1_CUT) * unitMod);  // SVF upper 2PF FM Amount (Frequency)
-  signals.set(SignalLabel::SVF_F2_FM,
-              signals.get(SignalLabel::SVF_F2_CUT) * unitMod);  // SVF lower 2PF FM Amount (Frequency)
+  signals.set(Signals::SVF_F1_FM,
+              signals.get(Signals::SVF_F1_CUT) * unitMod);  // SVF upper 2PF FM Amount (Frequency)
+  signals.set(Signals::SVF_F2_FM,
+              signals.get(Signals::SVF_F2_CUT) * unitMod);  // SVF lower 2PF FM Amount (Frequency)
   /* - Resonance */
-  keyTracking = getParameterValue(ParameterLabel::P_SVF_RKT) * m_svfResFactor;
-  envMod = signals.get(SignalLabel::ENV_C_CLIP) * getParameterValue(ParameterLabel::P_SVF_REC);
-  unitPitch = getParameterValue(ParameterLabel::P_SVF_RES) + envMod + (notePitch * keyTracking);
+  keyTracking = getParameterValue(Parameters::P_SVF_RKT) * m_svfResFactor;
+  envMod = signals.get(Signals::ENV_C_CLIP) * getParameterValue(Parameters::P_SVF_REC);
+  unitPitch = getParameterValue(Parameters::P_SVF_RES) + envMod + (notePitch * keyTracking);
   //signals.set(SignalLabel::SVF_RES, m_svfResonanceCurve.applyCurve(std::clamp(unitPitch, 0.f, 1.f)));
   float res = 1.f
       - m_svfResonanceCurve.applyCurve(
             std::clamp(unitPitch, 0.f, 1.f));  // NEW resonance handling directly in post processing
-  signals.set(SignalLabel::SVF_RES, std::max(res + res, 0.02f));
+  signals.set(Signals::SVF_RES, std::max(res + res, 0.02f));
   /* Output Mixer */
   float tmp_lvl, tmp_pan;
 #if test_milestone == 150
@@ -1386,43 +1378,42 @@ void paramengine::postProcessPoly_key(SignalStorage& signals, const uint32_t _vo
   const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
       + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #elif test_milestone == 156
-  const float poly_pan = (getParameterValue(ParameterLabel::P_OM_KP) * (basePitch - 6.f))
-      + (getParameterValue(ParameterLabel::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
+  const float poly_pan = (getParameterValue(Parameters::P_OM_KP) * (basePitch - 6.f))
+      + (getParameterValue(Parameters::P_UN_PAN) * m_unison_pan[uVoice][uIndex]);
 #endif
   /* - Branch A */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_AL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_AP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_A_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_A_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_AL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_AP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_A_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_A_R, tmp_lvl * tmp_pan);
   /* - Branch B */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_BL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_BP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_B_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_B_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_BL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_BP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_B_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_B_R, tmp_lvl * tmp_pan);
   /* - Comb Filter */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_CL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_CP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_CMB_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_CMB_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_CL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_CP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_CMB_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_CMB_R, tmp_lvl * tmp_pan);
   /* - State Variable Filter */
-  tmp_lvl = getParameterValue(ParameterLabel::P_OM_SL);
-  tmp_pan = std::clamp(getParameterValue(ParameterLabel::P_OM_SP) + poly_pan, 0.f, 1.f);
-  signals.set(SignalLabel::OUT_SVF_L, tmp_lvl * (1.f - tmp_pan));
-  signals.set(SignalLabel::OUT_SVF_R, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_OM_SL);
+  tmp_pan = std::clamp(getParameterValue(Parameters::P_OM_SP) + poly_pan, 0.f, 1.f);
+  signals.set(Signals::OUT_SVF_L, tmp_lvl * (1.f - tmp_pan));
+  signals.set(Signals::OUT_SVF_R, tmp_lvl * tmp_pan);
   /* - Feedback Mixer */
-  tmp_lvl = getParameterValue(ParameterLabel::P_FBM_LVL);
-  tmp_pan = std::min(m_convert.eval_level(getParameterValue(ParameterLabel::P_FBM_LKT) * (notePitch)), env_clip_peak);
-  signals.set(SignalLabel::FBM_LVL, tmp_lvl * tmp_pan);
+  tmp_lvl = getParameterValue(Parameters::P_FBM_LVL);
+  tmp_pan = std::min(m_convert.eval_level(getParameterValue(Parameters::P_FBM_LKT) * (notePitch)), env_clip_peak);
+  signals.set(Signals::FBM_LVL, tmp_lvl * tmp_pan);
   /*   - determine Highpass Filter Frequency */
-  signals.set(SignalLabel::FBM_HPF, evalNyquist(m_convert.eval_lin_pitch(12.f + notePitch) * 440.f));
+  signals.set(Signals::FBM_HPF, evalNyquist(m_convert.eval_lin_pitch(12.f + notePitch) * 440.f));
 }
 
 /* Mono Post Processing - slow parameters */
 void paramengine::postProcessMono_slow(SignalStorage& signals)
 {
   /* automatic mono to mono copy (always voice zero) */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_SLOW,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Slow, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
@@ -1435,76 +1426,73 @@ void paramengine::postProcessMono_slow(SignalStorage& signals)
   /*   - LFO/Envelope Rate, Phase */
   m_flangerLFO.m_phaseOffset = m_flaNormPhase * getSignal(ParameterLabel::P_FLA_PHS);
 #endif
-  tmp_Rate = getParameterValue(ParameterLabel::P_FLA_RTE);
+  tmp_Rate = getParameterValue(Parameters::P_FLA_RTE);
   m_flangerLFO.m_increment = m_reciprocal_samplerate * tmp_Rate;
   tmp_Rate *= m_flangerRateToDecay;
   m_new_envelopes.m_env_f.setSegmentDx(0, 2, tmp_Rate);
   /*   - Stereo Time */
-  tmp_Center = getParameterValue(ParameterLabel::P_FLA_TIME) * dsp_samples_to_ms
-      * tmp_SR;  // time (in ms) is handled in samples
-  tmp_Stereo = getParameterValue(ParameterLabel::P_FLA_STE) * 0.01f;
-  signals.set(SignalLabel::FLA_TL, tmp_Center * (1.f + tmp_Stereo));
-  signals.set(SignalLabel::FLA_TR, tmp_Center * (1.f - tmp_Stereo));
+  tmp_Center
+      = getParameterValue(Parameters::P_FLA_TIME) * dsp_samples_to_ms * tmp_SR;  // time (in ms) is handled in samples
+  tmp_Stereo = getParameterValue(Parameters::P_FLA_STE) * 0.01f;
+  signals.set(Signals::FLA_TL, tmp_Center * (1.f + tmp_Stereo));
+  signals.set(Signals::FLA_TR, tmp_Center * (1.f - tmp_Stereo));
   /*   - Hi Cut Frequency */
-  signals.set(SignalLabel::FLA_LPF, evalNyquist(getParameterValue(ParameterLabel::P_FLA_LPF) * 440.f));
+  signals.set(Signals::FLA_LPF, evalNyquist(getParameterValue(Parameters::P_FLA_LPF) * 440.f));
   /* - Cabinet */
   /*   - Hi Cut Frequency in Hz (Hi Cut == Lowpass) */
-  signals.set(SignalLabel::CAB_LPF, evalNyquist(getParameterValue(ParameterLabel::P_CAB_LPF) * 440.f));
+  signals.set(Signals::CAB_LPF, evalNyquist(getParameterValue(Parameters::P_CAB_LPF) * 440.f));
   /*   - Lo Cut Frequency in Hz (Lo Cut == Highpass) */
-  signals.set(SignalLabel::CAB_HPF,
-              evalNyquist(getParameterValue(ParameterLabel::P_CAB_HPF) * 440.f));  // nyquist clipping not necessary...
+  signals.set(Signals::CAB_HPF,
+              evalNyquist(getParameterValue(Parameters::P_CAB_HPF) * 440.f));  // nyquist clipping not necessary...
   /*   - Tilt to Shelving EQs */
-  signals.set(SignalLabel::CAB_TILT, getParameterValue(ParameterLabel::P_CAB_TILT));
+  signals.set(Signals::CAB_TILT, getParameterValue(Parameters::P_CAB_TILT));
   /* - Gap Filter */
-  tmp_Gap = (getParameterValue(ParameterLabel::P_GAP_MIX) < 0.f ? -1.f : 1.f)
-      * getParameterValue(ParameterLabel::P_GAP_GAP);
-  tmp_Center = getParameterValue(ParameterLabel::P_GAP_CNT);
-  tmp_Stereo = getParameterValue(ParameterLabel::P_GAP_STE);
+  tmp_Gap = (getParameterValue(Parameters::P_GAP_MIX) < 0.f ? -1.f : 1.f) * getParameterValue(Parameters::P_GAP_GAP);
+  tmp_Center = getParameterValue(Parameters::P_GAP_CNT);
+  tmp_Stereo = getParameterValue(Parameters::P_GAP_STE);
   /*   - Left LP Frequency in Hz */
   // nyquist clipping not necessary...
-  signals.set(SignalLabel::GAP_LFL, evalNyquist(m_convert.eval_lin_pitch(tmp_Center - tmp_Gap - tmp_Stereo) * 440.f));
+  signals.set(Signals::GAP_LFL, evalNyquist(m_convert.eval_lin_pitch(tmp_Center - tmp_Gap - tmp_Stereo) * 440.f));
   /*   - Left HP Frequency in Hz */
-  signals.set(SignalLabel::GAP_HFL, evalNyquist(m_convert.eval_lin_pitch(tmp_Center + tmp_Gap - tmp_Stereo) * 440.f));
+  signals.set(Signals::GAP_HFL, evalNyquist(m_convert.eval_lin_pitch(tmp_Center + tmp_Gap - tmp_Stereo) * 440.f));
   /*   - Right LP Frequency in Hz */
   // nyquist clipping not necessary...
-  signals.set(SignalLabel::GAP_LFR, evalNyquist(m_convert.eval_lin_pitch(tmp_Center - tmp_Gap + tmp_Stereo) * 440.f));
+  signals.set(Signals::GAP_LFR, evalNyquist(m_convert.eval_lin_pitch(tmp_Center - tmp_Gap + tmp_Stereo) * 440.f));
   /*   - Right HP Frequency in Hz */
-  signals.set(SignalLabel::GAP_HFR, evalNyquist(m_convert.eval_lin_pitch(tmp_Center + tmp_Gap + tmp_Stereo) * 440.f));
+  signals.set(Signals::GAP_HFR, evalNyquist(m_convert.eval_lin_pitch(tmp_Center + tmp_Gap + tmp_Stereo) * 440.f));
   /* - Echo */
   /*   - Time and Stereo */
-  tmp_Center = getParameterValue(ParameterLabel::P_DLY_TIME) * tmp_SR;  // time is handled in samples
-  tmp_Stereo = getParameterValue(ParameterLabel::P_DLY_STE) * m_dlyNormStereo;
-  signals.set(SignalLabel::DLY_TL, tmp_Center * (1.f + tmp_Stereo));
-  signals.set(SignalLabel::DLY_TR, tmp_Center * (1.f - tmp_Stereo));
+  tmp_Center = getParameterValue(Parameters::P_DLY_TIME) * tmp_SR;  // time is handled in samples
+  tmp_Stereo = getParameterValue(Parameters::P_DLY_STE) * m_dlyNormStereo;
+  signals.set(Signals::DLY_TL, tmp_Center * (1.f + tmp_Stereo));
+  signals.set(Signals::DLY_TR, tmp_Center * (1.f - tmp_Stereo));
   /*   - High Cut Frequency */
-  signals.set(SignalLabel::DLY_LPF, evalNyquist(getParameterValue(ParameterLabel::P_DLY_LPF) * 440.f));
+  signals.set(Signals::DLY_LPF, evalNyquist(getParameterValue(Parameters::P_DLY_LPF) * 440.f));
   /* - Reverb (if slow rendering is enabled - see pe_defines_config.h) */
 #if test_reverbParams == 1
   float tmp_val, tmp_fb, tmp_dry, tmp_wet;
   /*   - Size to Size, Feedback, Balance */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_SIZE);
+  tmp_val = getParameterValue(Parameters::P_REV_SIZE);
   tmp_val *= 2.f - std::abs(tmp_val);
-  signals.set(SignalLabel::REV_SIZE, tmp_val);
+  signals.set(Signals::REV_SIZE, tmp_val);
   tmp_fb = tmp_val * (0.6f + (0.4f * std::abs(tmp_val)));
-  signals.set(SignalLabel::REV_FEED, 4.32f - (3.32f * tmp_fb));
+  signals.set(Signals::REV_FEED, 4.32f - (3.32f * tmp_fb));
   tmp_fb = tmp_val * (1.3f - (0.3f * std::abs(tmp_val)));
-  signals.set(SignalLabel::REV_BAL, 0.9f * tmp_fb);
+  signals.set(Signals::REV_BAL, 0.9f * tmp_fb);
   /*   - Pre Delay */
-  signals.set(SignalLabel::REV_PRE, getParameterValue(ParameterLabel::P_REV_PRE) * 200.f * m_millisecond);
+  signals.set(Signals::REV_PRE, getParameterValue(Parameters::P_REV_PRE) * 200.f * m_millisecond);
   /*   - Color to Filter Frequencies (HPF, LPF) */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_COL);
-  signals.set(SignalLabel::REV_LPF,
-              evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve1.applyCurve(tmp_val)) * 440.f));
-  signals.set(SignalLabel::REV_HPF,
-              evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve2.applyCurve(tmp_val)) * 440.f));
+  tmp_val = getParameterValue(Parameters::P_REV_COL);
+  signals.set(Signals::REV_LPF, evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve1.applyCurve(tmp_val)) * 440.f));
+  signals.set(Signals::REV_HPF, evalNyquist(m_convert.eval_lin_pitch(m_revColorCurve2.applyCurve(tmp_val)) * 440.f));
   /*   - Mix to Dry, Wet */
-  tmp_val = getParameterValue(ParameterLabel::P_REV_MIX);
+  tmp_val = getParameterValue(Parameters::P_REV_MIX);
   tmp_dry = 1.f - tmp_val;
   tmp_dry = (2.f - tmp_dry) * tmp_dry;
-  signals.set(SignalLabel::REV_DRY, tmp_dry);
+  signals.set(Signals::REV_DRY, tmp_dry);
   tmp_wet = tmp_val;
   tmp_wet = (2.f - tmp_wet) * tmp_wet;
-  signals.set(SignalLabel::REV_WET, tmp_wet);
+  signals.set(Signals::REV_WET, tmp_wet);
 #endif
 }
 
@@ -1512,8 +1500,7 @@ void paramengine::postProcessMono_slow(SignalStorage& signals)
 void paramengine::postProcessMono_fast(SignalStorage& signals)
 {
   /* automatic mono to mono copy (always voice zero) */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_FAST,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Fast, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
@@ -1525,85 +1512,84 @@ void paramengine::postProcessMono_fast(SignalStorage& signals)
   /* - Flanger */
 #if test_flanger_phs == 1
   /*   - LFO/Envelope Rate, Phase */
-  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getParameterValue(ParameterLabel::P_FLA_PHS);
+  m_flangerLFO.m_phaseOffset = m_flaNormPhase * getParameterValue(Parameters::P_FLA_PHS);
 #endif
   /*   - Feedback and Cross Feedback */
-  tmp_fb = m_flaFeedbackCurve.applyCurve(getParameterValue(ParameterLabel::P_FLA_FB));
-  tmp_val = getParameterValue(ParameterLabel::P_FLA_CFB);
-  signals.set(SignalLabel::FLA_FB_LOC, tmp_fb * (1.f - std::abs(tmp_val)));
-  signals.set(SignalLabel::FLA_FB_CR, tmp_fb * tmp_val);
+  tmp_fb = m_flaFeedbackCurve.applyCurve(getParameterValue(Parameters::P_FLA_FB));
+  tmp_val = getParameterValue(Parameters::P_FLA_CFB);
+  signals.set(Signals::FLA_FB_LOC, tmp_fb * (1.f - std::abs(tmp_val)));
+  signals.set(Signals::FLA_FB_CR, tmp_fb * tmp_val);
   /*   - Dry and Wet Amounts */
-  tmp_val = getParameterValue(ParameterLabel::P_FLA_MIX);
-  signals.set(SignalLabel::FLA_DRY, 1.f - std::abs(tmp_val));
-  signals.set(SignalLabel::FLA_WET, tmp_val);
+  tmp_val = getParameterValue(Parameters::P_FLA_MIX);
+  signals.set(Signals::FLA_DRY, 1.f - std::abs(tmp_val));
+  signals.set(Signals::FLA_WET, tmp_val);
   /*   - Allpass Frequencies */
-  tmp_val = getParameterValue(ParameterLabel::P_FLA_APM);
-  tmp_dry = getParameterValue(ParameterLabel::P_FLA_APT);
-  signals.set(SignalLabel::FLA_APF_L,
-              evalNyquist(m_convert.eval_lin_pitch((signals.get(SignalLabel::FLA_LFO_L) * tmp_val) + tmp_dry) * 440.f));
-  signals.set(SignalLabel::FLA_APF_R,
-              evalNyquist(m_convert.eval_lin_pitch((signals.get(SignalLabel::FLA_LFO_R) * tmp_val) + tmp_dry) * 440.f));
+  tmp_val = getParameterValue(Parameters::P_FLA_APM);
+  tmp_dry = getParameterValue(Parameters::P_FLA_APT);
+  signals.set(Signals::FLA_APF_L,
+              evalNyquist(m_convert.eval_lin_pitch((signals.get(Signals::FLA_LFO_L) * tmp_val) + tmp_dry) * 440.f));
+  signals.set(Signals::FLA_APF_R,
+              evalNyquist(m_convert.eval_lin_pitch((signals.get(Signals::FLA_LFO_R) * tmp_val) + tmp_dry) * 440.f));
   /* - Cabinet */
   /*   - Tilt to Saturation Levels (pre, post Shaper) */
-  tmp_val = std::max(m_cabTiltFloor, m_convert.eval_level(0.5f * getParameterValue(ParameterLabel::P_CAB_TILT)));
-  signals.set(SignalLabel::CAB_PRESAT, 0.1588f / tmp_val);
-  signals.set(SignalLabel::CAB_SAT, tmp_val);
+  tmp_val = std::max(m_cabTiltFloor, m_convert.eval_level(0.5f * getParameterValue(Parameters::P_CAB_TILT)));
+  signals.set(Signals::CAB_PRESAT, 0.1588f / tmp_val);
+  signals.set(Signals::CAB_SAT, tmp_val);
   /*   - Cab Level and Dry/Wet Mix Levels */
-  signals.set(SignalLabel::CAB_DRY, 1.f - getParameterValue(ParameterLabel::P_CAB_MIX));
-  signals.set(SignalLabel::CAB_WET,
-              getParameterValue(ParameterLabel::P_CAB_LVL) * getParameterValue(ParameterLabel::P_CAB_MIX));
+  signals.set(Signals::CAB_DRY, 1.f - getParameterValue(Parameters::P_CAB_MIX));
+  signals.set(Signals::CAB_WET, getParameterValue(Parameters::P_CAB_LVL) * getParameterValue(Parameters::P_CAB_MIX));
   /* - Gap Filter */
-  tmp_val = std::abs(getParameterValue(ParameterLabel::P_GAP_MIX));
+  tmp_val = std::abs(getParameterValue(Parameters::P_GAP_MIX));
   tmp_wet = NlToolbox::Math::sin(NlToolbox::Constants::halfpi * tmp_val);
   tmp_dry = NlToolbox::Math::sin(NlToolbox::Constants::halfpi * (1.f - tmp_val));
-  tmp_val = getParameterValue(ParameterLabel::P_GAP_BAL);
+  tmp_val = getParameterValue(Parameters::P_GAP_BAL);
   tmp_hi_par = 0.5f + (0.5f * tmp_val);
   tmp_lo_par = 1.f - tmp_hi_par;
   tmp_hi_par = NlToolbox::Math::sin(NlToolbox::Constants::halfpi * tmp_hi_par) * NlToolbox::Constants::sqrt_two;
   tmp_lo_par = NlToolbox::Math::sin(NlToolbox::Constants::halfpi * tmp_lo_par) * NlToolbox::Constants::sqrt_two;
   tmp_val *= tmp_val;
-  tmp_hi_ser = getParameterValue(ParameterLabel::P_GAP_BAL) > 0.f ? tmp_val : 0.f;
-  tmp_lo_ser = getParameterValue(ParameterLabel::P_GAP_BAL) > 0.f ? 0.f : tmp_val;
-  if(getParameterValue(ParameterLabel::P_GAP_MIX) > 0.f)
+  tmp_hi_ser = getParameterValue(Parameters::P_GAP_BAL) > 0.f ? tmp_val : 0.f;
+  tmp_lo_ser = getParameterValue(Parameters::P_GAP_BAL) > 0.f ? 0.f : tmp_val;
+  if(getParameterValue(Parameters::P_GAP_MIX) > 0.f)
   {
     /* parallel mode */
     /* - HP to LP input signal */
-    signals.set(SignalLabel::GAP_HPLP, 0.f);
+    signals.set(Signals::GAP_HPLP, 0.f);
     /* - LP input signal */
-    signals.set(SignalLabel::GAP_INLP, 1.f);
+    signals.set(Signals::GAP_INLP, 1.f);
     /* - HP output signal */
-    signals.set(SignalLabel::GAP_HPOUT, tmp_wet * tmp_hi_par);
+    signals.set(Signals::GAP_HPOUT, tmp_wet * tmp_hi_par);
     /* - LP output signal */
-    signals.set(SignalLabel::GAP_LPOUT, tmp_wet * tmp_lo_par);
+    signals.set(Signals::GAP_LPOUT, tmp_wet * tmp_lo_par);
     /* - Main output signal */
-    signals.set(SignalLabel::GAP_INOUT, tmp_dry);
+    signals.set(Signals::GAP_INOUT, tmp_dry);
   }
   else
   {
     /* serial mode */
     tmp_val = tmp_wet * tmp_hi_ser;
     /* - HP to LP input signal */
-    signals.set(SignalLabel::GAP_HPLP, 1.f - tmp_lo_ser);
+    signals.set(Signals::GAP_HPLP, 1.f - tmp_lo_ser);
     /* - LP input signal */
-    signals.set(SignalLabel::GAP_INLP, tmp_lo_ser);
+    signals.set(Signals::GAP_INLP, tmp_lo_ser);
     /* - HP output signal */
-    signals.set(SignalLabel::GAP_HPOUT, signals.get(SignalLabel::GAP_HPLP) * tmp_val);
+    signals.set(Signals::GAP_HPOUT, signals.get(Signals::GAP_HPLP) * tmp_val);
     /* - LP output signal */
-    signals.set(SignalLabel::GAP_LPOUT, tmp_wet - tmp_val);
+    signals.set(Signals::GAP_LPOUT, tmp_wet - tmp_val);
     /* - Main output signal */
-    signals.set(SignalLabel::GAP_INOUT, (tmp_val * tmp_lo_ser) + tmp_dry);
+    signals.set(Signals::GAP_INOUT, (tmp_val * tmp_lo_ser) + tmp_dry);
   }
   /* - Echo */
   /*   - Feedback and Cross Feedback */
-  tmp_fb = getParameterValue(ParameterLabel::P_DLY_FB);
-  tmp_val = getParameterValue(ParameterLabel::P_DLY_CFB);
-  signals.set(SignalLabel::DLY_FB_LOC, tmp_fb * (1.f - tmp_val));
-  signals.set(SignalLabel::DLY_FB_CR, tmp_fb * tmp_val);
+  tmp_fb = getParameterValue(Parameters::P_DLY_FB);
+  tmp_val = getParameterValue(Parameters::P_DLY_CFB);
+  signals.set(Signals::DLY_FB_LOC, tmp_fb * (1.f - tmp_val));
+  signals.set(Signals::DLY_FB_CR, tmp_fb * tmp_val);
   /*   - Dry and Wet Mix Amounts */
-  tmp_val = getParameterValue(ParameterLabel::P_DLY_MIX);
-  signals.set(SignalLabel::DLY_WET, (2.f * tmp_val) - (tmp_val * tmp_val));
+  tmp_val = getParameterValue(Parameters::P_DLY_MIX);
+  signals.set(Signals::DLY_WET, (2.f * tmp_val) - (tmp_val * tmp_val));
   tmp_val = 1.f - tmp_val;
-  signals.set(SignalLabel::DLY_DRY, (2.f * tmp_val) - (tmp_val * tmp_val));
+  signals.set(Signals::DLY_DRY, (2.f * tmp_val) - (tmp_val * tmp_val));
   /* - Reverb (if fast rendering is enabled - see pe_defines_config.h) */
 #if test_reverbParams == 0
   /*   - Size to Size, Feedback, Balance */
@@ -1637,8 +1623,7 @@ void paramengine::postProcessMono_fast(SignalStorage& signals)
 void paramengine::postProcessMono_audio(SignalStorage& signals)
 {
   /* automatic mono to mono copy (always voice zero) */
-  for(auto& it : m_parameters.getPostIds(PARAM_SPREAD_TYPES::PARAM_SINGLE, PARAM_CLOCK_TYPES::PARAM_AUDIO,
-                                         PARAM_POLY_TYPES::PARAM_MONO))
+  for(auto& it : m_parameters.getPostIds(SpreadTypes::Single, ClockTypes::Audio, PolyTypes::Mono))
   {
     auto p = getHead(it).m_postId;
     signals.set(p, getParameterValue(it));
@@ -1655,10 +1640,10 @@ void paramengine::postProcessMono_audio(SignalStorage& signals)
 #endif
   /*   - render LFO, crossfade flanger envelope and pass left and right signals to array */
   m_flangerLFO.tick();
-  float tmp_wet = getParameterValue(ParameterLabel::P_FLA_ENV);
+  float tmp_wet = getParameterValue(Parameters::P_FLA_ENV);
   float tmp_dry = 1.f - tmp_wet;
-  signals.set(SignalLabel::FLA_LFO_L, (tmp_dry * m_flangerLFO.m_left) + (tmp_wet * tmp_env));
-  signals.set(SignalLabel::FLA_LFO_R, (tmp_dry * m_flangerLFO.m_right) + (tmp_wet * tmp_env));
+  signals.set(Signals::FLA_LFO_L, (tmp_dry * m_flangerLFO.m_left) + (tmp_wet * tmp_env));
+  signals.set(Signals::FLA_LFO_R, (tmp_dry * m_flangerLFO.m_right) + (tmp_wet * tmp_env));
 }
 
 void paramengine::testLevelVelocity()

--- a/audio-engine/src/synth/c15-audio-engine/paramengine.h
+++ b/audio-engine/src/synth/c15-audio-engine/paramengine.h
@@ -32,10 +32,10 @@ struct param_head
   uint32_t m_id;
   uint32_t m_index;
   uint32_t m_size;
-  PARAM_CLOCK_TYPES m_clockType;
-  PARAM_POLY_TYPES m_polyType;
+  ClockTypes m_clockType;
+  PolyTypes m_polyType;
   uint32_t m_scaleId;
-  SignalLabel m_postId;
+  Signals m_postId;
   float m_normalize;
   float m_scaleArg;
 };
@@ -64,13 +64,13 @@ struct param_utility
   float m_scaleArg;
 };
 
-struct Parameters
+struct ParameterStorage
 {
 #if PARAM_ITERATOR == 1
   uint32_t m_start[dsp_clock_types][dsp_poly_types];
   uint32_t m_end[dsp_clock_types][dsp_poly_types];
 #endif
-  inline param_head &getHead(ParameterLabel id)
+  inline param_head &getHead(Parameters id)
   {
     return m_head[static_cast<uint32_t>(id)];
   }
@@ -80,54 +80,53 @@ struct Parameters
     return m_body[id];
   }
 
-  inline float getParameterValue(ParameterLabel paramId) const
+  inline float getParameterValue(Parameters paramId) const
   {
     return m_body[m_head[static_cast<uint32_t>(paramId)].m_index].m_value;
   }
 
-  inline float getParameterValue(ParameterLabel paramId, uint32_t voice) const
+  inline float getParameterValue(Parameters paramId, uint32_t voice) const
   {
     return m_body[m_head[static_cast<uint32_t>(paramId)].m_index + voice].m_value;
   }
 
-  inline void addClockId(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType, uint32_t _id)
+  inline void addClockId(ClockTypes _clockType, PolyTypes _polyType, uint32_t _id)
   {
     m_clockIds.add(_clockType, _polyType, _id);
   }
 
-  inline const std::vector<uint32_t> &getClockIds(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType) const
+  inline const std::vector<uint32_t> &getClockIds(ClockTypes _clockType, PolyTypes _polyType) const
   {
     return m_clockIds.get(_clockType, _polyType);
   }
 
-  inline void addPostId(PARAM_SPREAD_TYPES _spreadType, PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType,
-                        ParameterLabel _id)
+  inline void addPostId(SpreadTypes _spreadType, ClockTypes _clockType, PolyTypes _polyType, Parameters _id)
   {
     m_postIds.add(_spreadType, _clockType, _polyType, _id);
   }
 
-  inline const std::vector<ParameterLabel> &getPostIds(PARAM_SPREAD_TYPES _spreadType, PARAM_CLOCK_TYPES _clockType,
-                                                       PARAM_POLY_TYPES _polyType) const
+  inline const std::vector<Parameters> &getPostIds(SpreadTypes _spreadType, ClockTypes _clockType,
+                                                   PolyTypes _polyType) const
   {
     return m_postIds.get(_spreadType, _clockType, _polyType);
   }
 #if PARAM_ITERATOR == 1
-  inline param_body *begin(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType)
+  inline param_body *begin(ClockTypes _clockType, PolyTypes _polyType)
   {
     return &m_body[m_start[static_cast<int>(_clockType)][static_cast<int>(_polyType)]];
   }
 
-  inline param_body *begin(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType, uint32_t _voiceId)
+  inline param_body *begin(ClockTypes _clockType, PolyTypes _polyType, uint32_t _voiceId)
   {
     return &m_body[m_start[static_cast<int>(_clockType)][static_cast<int>(_polyType)] + _voiceId];
   }
 
-  inline param_body *end(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType)
+  inline param_body *end(ClockTypes _clockType, PolyTypes _polyType)
   {
     return &m_body[m_end[static_cast<int>(_clockType)][static_cast<int>(_polyType)]];
   }
 
-  inline param_body *end(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType, uint32_t _voiceId)
+  inline param_body *end(ClockTypes _clockType, PolyTypes _polyType, uint32_t _voiceId)
   {
     return &m_body[m_end[static_cast<int>(_clockType)][static_cast<int>(_polyType)] + _voiceId];
   }
@@ -143,9 +142,9 @@ struct Parameters
 struct paramengine
 {
 
-  Parameters m_parameters;
+  ParameterStorage m_parameters;
 
-  inline param_head &getHead(ParameterLabel id)
+  inline param_head &getHead(Parameters id)
   {
     return m_parameters.getHead(id);
   }
@@ -155,12 +154,12 @@ struct paramengine
     return m_parameters.getBody(id);
   }
 
-  inline float getParameterValue(ParameterLabel paramId) const
+  inline float getParameterValue(Parameters paramId) const
   {
     return m_parameters.getParameterValue(paramId);
   }
 
-  inline float getParameterValue(ParameterLabel paramId, uint32_t voice) const
+  inline float getParameterValue(Parameters paramId, uint32_t voice) const
   {
     return m_parameters.getParameterValue(paramId, voice);
   }
@@ -212,12 +211,12 @@ struct paramengine
   /* helper */
   float evalNyquist(float _freq);
   /* TCD mechanism */
-  float scale(const uint32_t _scaleId, const float _scaleArg, float _value);           // provided tcd scale functions
-  void setDx(const uint32_t _voiceId, const ParameterLabel _paramId, float _value);    // param dx update
-  void setDest(const uint32_t _voiceId, const ParameterLabel _paramId, float _value);  // param dest update
-  void applyPreloaded(const uint32_t _voiceId, const ParameterLabel _paramId);         // param apply preloaded
-  void applyDest(const uint32_t _index);  // param apply dest (non-sync types)
-  void applySync(const uint32_t _index);  // param apply dest (sync types)
+  float scale(const uint32_t _scaleId, const float _scaleArg, float _value);       // provided tcd scale functions
+  void setDx(const uint32_t _voiceId, const Parameters _paramId, float _value);    // param dx update
+  void setDest(const uint32_t _voiceId, const Parameters _paramId, float _value);  // param dest update
+  void applyPreloaded(const uint32_t _voiceId, const Parameters _paramId);         // param apply preloaded
+  void applyDest(const uint32_t _index);                                           // param apply dest (non-sync types)
+  void applySync(const uint32_t _index);                                           // param apply dest (sync types)
   /* key events */
   void keyDown(const uint32_t _voiceId, float _velocity);  // key events: key down (note on) mechanism
   void keyUp(const uint32_t _voiceId, float _velocity);    // key events: key up (note off) mechanism

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_labels.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_labels.h
@@ -37,7 +37,7 @@ enum class EnvelopeLabel
 };
 
 /* 'normal' Parameter Labels - access parameter with m_head[ID] - maybe, the rendering index would be much more efficient? */
-enum class ParameterLabel
+enum class Parameters
 {
   P_INVALID = -1,
   P_EA_ATT = 0,

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_lists.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_lists.h
@@ -18,95 +18,89 @@
 // NOTE:    - recall param id order by PLAYGROUND, list mechanism fragile/risky in this case -> discard
 
 /* later: define "official" parameter order (playground, ...) in order to transmit preset lists -> also affects testconfig preset data! */
-const ParameterLabel paramIds_recall[lst_recall_length] = {
+const Parameters paramIds_recall[lst_recall_length] = {
 
   // ENVELOPE A
-  ParameterLabel::P_EA_ATT, ParameterLabel::P_EA_DEC1, ParameterLabel::P_EA_BP, ParameterLabel::P_EA_DEC2,
-  ParameterLabel::P_EA_SUS, ParameterLabel::P_EA_REL, ParameterLabel::P_EA_GAIN, ParameterLabel::P_EA_LV,
-  ParameterLabel::P_EA_AV, ParameterLabel::P_EA_D1V, ParameterLabel::P_EA_D2V, ParameterLabel::P_EA_RV,
-  ParameterLabel::P_EA_LKT, ParameterLabel::P_EA_TKT, ParameterLabel::P_EA_AC, ParameterLabel::P_EA_SPL,
+  Parameters::P_EA_ATT, Parameters::P_EA_DEC1, Parameters::P_EA_BP, Parameters::P_EA_DEC2, Parameters::P_EA_SUS,
+  Parameters::P_EA_REL, Parameters::P_EA_GAIN, Parameters::P_EA_LV, Parameters::P_EA_AV, Parameters::P_EA_D1V,
+  Parameters::P_EA_D2V, Parameters::P_EA_RV, Parameters::P_EA_LKT, Parameters::P_EA_TKT, Parameters::P_EA_AC,
+  Parameters::P_EA_SPL,
 
   // ENVELOPE B
-  ParameterLabel::P_EB_ATT, ParameterLabel::P_EB_DEC1, ParameterLabel::P_EB_BP, ParameterLabel::P_EB_DEC2,
-  ParameterLabel::P_EB_SUS, ParameterLabel::P_EB_REL, ParameterLabel::P_EB_GAIN, ParameterLabel::P_EB_LV,
-  ParameterLabel::P_EB_AV, ParameterLabel::P_EB_D1V, ParameterLabel::P_EB_D2V, ParameterLabel::P_EB_RV,
-  ParameterLabel::P_EB_LKT, ParameterLabel::P_EB_TKT, ParameterLabel::P_EB_AC, ParameterLabel::P_EB_SPL,
+  Parameters::P_EB_ATT, Parameters::P_EB_DEC1, Parameters::P_EB_BP, Parameters::P_EB_DEC2, Parameters::P_EB_SUS,
+  Parameters::P_EB_REL, Parameters::P_EB_GAIN, Parameters::P_EB_LV, Parameters::P_EB_AV, Parameters::P_EB_D1V,
+  Parameters::P_EB_D2V, Parameters::P_EB_RV, Parameters::P_EB_LKT, Parameters::P_EB_TKT, Parameters::P_EB_AC,
+  Parameters::P_EB_SPL,
 
   // ENVELOPE C
-  ParameterLabel::P_EC_ATT, ParameterLabel::P_EC_DEC1, ParameterLabel::P_EC_BP, ParameterLabel::P_EC_DEC2,
-  ParameterLabel::P_EC_SUS, ParameterLabel::P_EC_REL, ParameterLabel::P_EC_LV, ParameterLabel::P_EC_AV,
-  ParameterLabel::P_EC_RV, ParameterLabel::P_EC_LKT, ParameterLabel::P_EC_TKT, ParameterLabel::P_EC_AC,
-  ParameterLabel::P_EC_RH,
+  Parameters::P_EC_ATT, Parameters::P_EC_DEC1, Parameters::P_EC_BP, Parameters::P_EC_DEC2, Parameters::P_EC_SUS,
+  Parameters::P_EC_REL, Parameters::P_EC_LV, Parameters::P_EC_AV, Parameters::P_EC_RV, Parameters::P_EC_LKT,
+  Parameters::P_EC_TKT, Parameters::P_EC_AC, Parameters::P_EC_RH,
 
   // OSCILLATOR A
-  ParameterLabel::P_OA_P, ParameterLabel::P_OA_PKT, ParameterLabel::P_OA_PEC, ParameterLabel::P_OA_F,
-  ParameterLabel::P_OA_FEC, ParameterLabel::P_OA_PMS, ParameterLabel::P_OA_PMSEA, ParameterLabel::P_OA_PMSSH,
-  ParameterLabel::P_OA_PMB, ParameterLabel::P_OA_PMBEB, ParameterLabel::P_OA_PMBSH, ParameterLabel::P_OA_PMF,
-  ParameterLabel::P_OA_PMFEC, ParameterLabel::P_OA_PHS, ParameterLabel::P_OA_CHI,
+  Parameters::P_OA_P, Parameters::P_OA_PKT, Parameters::P_OA_PEC, Parameters::P_OA_F, Parameters::P_OA_FEC,
+  Parameters::P_OA_PMS, Parameters::P_OA_PMSEA, Parameters::P_OA_PMSSH, Parameters::P_OA_PMB, Parameters::P_OA_PMBEB,
+  Parameters::P_OA_PMBSH, Parameters::P_OA_PMF, Parameters::P_OA_PMFEC, Parameters::P_OA_PHS, Parameters::P_OA_CHI,
 
   // SHAPER A
-  ParameterLabel::P_SA_DRV, ParameterLabel::P_SA_DEA, ParameterLabel::P_SA_FLD, ParameterLabel::P_SA_ASM,
-  ParameterLabel::P_SA_MIX, ParameterLabel::P_SA_FBM, ParameterLabel::P_SA_FBEC, ParameterLabel::P_SA_RM,
+  Parameters::P_SA_DRV, Parameters::P_SA_DEA, Parameters::P_SA_FLD, Parameters::P_SA_ASM, Parameters::P_SA_MIX,
+  Parameters::P_SA_FBM, Parameters::P_SA_FBEC, Parameters::P_SA_RM,
 
   // OSCILLATOR B
-  ParameterLabel::P_OB_P, ParameterLabel::P_OB_PKT, ParameterLabel::P_OB_PEC, ParameterLabel::P_OB_F,
-  ParameterLabel::P_OB_FEC, ParameterLabel::P_OB_PMS, ParameterLabel::P_OB_PMSEB, ParameterLabel::P_OB_PMSSH,
-  ParameterLabel::P_OB_PMA, ParameterLabel::P_OB_PMAEA, ParameterLabel::P_OB_PMASH, ParameterLabel::P_OB_PMF,
-  ParameterLabel::P_OB_PMFEC, ParameterLabel::P_OB_PHS, ParameterLabel::P_OB_CHI,
+  Parameters::P_OB_P, Parameters::P_OB_PKT, Parameters::P_OB_PEC, Parameters::P_OB_F, Parameters::P_OB_FEC,
+  Parameters::P_OB_PMS, Parameters::P_OB_PMSEB, Parameters::P_OB_PMSSH, Parameters::P_OB_PMA, Parameters::P_OB_PMAEA,
+  Parameters::P_OB_PMASH, Parameters::P_OB_PMF, Parameters::P_OB_PMFEC, Parameters::P_OB_PHS, Parameters::P_OB_CHI,
 
   // SHAPER B
-  ParameterLabel::P_SB_DRV, ParameterLabel::P_SB_DEB, ParameterLabel::P_SB_FLD, ParameterLabel::P_SB_ASM,
-  ParameterLabel::P_SB_MIX, ParameterLabel::P_SB_FBM, ParameterLabel::P_SB_FBEC, ParameterLabel::P_SB_RM,
+  Parameters::P_SB_DRV, Parameters::P_SB_DEB, Parameters::P_SB_FLD, Parameters::P_SB_ASM, Parameters::P_SB_MIX,
+  Parameters::P_SB_FBM, Parameters::P_SB_FBEC, Parameters::P_SB_RM,
 
   // COMB FILTER
-  ParameterLabel::P_CMB_AB, ParameterLabel::P_CMB_P, ParameterLabel::P_CMB_PKT, ParameterLabel::P_CMB_PEC,
-  ParameterLabel::P_CMB_D, ParameterLabel::P_CMB_DKT, ParameterLabel::P_CMB_DG, ParameterLabel::P_CMB_APT,
-  ParameterLabel::P_CMB_APKT, ParameterLabel::P_CMB_APEC, ParameterLabel::P_CMB_APR, ParameterLabel::P_CMB_LP,
-  ParameterLabel::P_CMB_LPKT, ParameterLabel::P_CMB_LPEC, ParameterLabel::P_CMB_PM, ParameterLabel::P_CMB_PMAB,
+  Parameters::P_CMB_AB, Parameters::P_CMB_P, Parameters::P_CMB_PKT, Parameters::P_CMB_PEC, Parameters::P_CMB_D,
+  Parameters::P_CMB_DKT, Parameters::P_CMB_DG, Parameters::P_CMB_APT, Parameters::P_CMB_APKT, Parameters::P_CMB_APEC,
+  Parameters::P_CMB_APR, Parameters::P_CMB_LP, Parameters::P_CMB_LPKT, Parameters::P_CMB_LPEC, Parameters::P_CMB_PM,
+  Parameters::P_CMB_PMAB,
 
   // STATE VARIABLE FILTER
-  ParameterLabel::P_SVF_AB, ParameterLabel::P_SVF_CMB, ParameterLabel::P_SVF_CUT, ParameterLabel::P_SVF_CKT,
-  ParameterLabel::P_SVF_CEC, ParameterLabel::P_SVF_SPR, ParameterLabel::P_SVF_FM, ParameterLabel::P_SVF_RES,
-  ParameterLabel::P_SVF_RKT, ParameterLabel::P_SVF_REC, ParameterLabel::P_SVF_LBH, ParameterLabel::P_SVF_PAR,
-  ParameterLabel::P_SVF_FMAB,
+  Parameters::P_SVF_AB, Parameters::P_SVF_CMB, Parameters::P_SVF_CUT, Parameters::P_SVF_CKT, Parameters::P_SVF_CEC,
+  Parameters::P_SVF_SPR, Parameters::P_SVF_FM, Parameters::P_SVF_RES, Parameters::P_SVF_RKT, Parameters::P_SVF_REC,
+  Parameters::P_SVF_LBH, Parameters::P_SVF_PAR, Parameters::P_SVF_FMAB,
 
   // FEEDBACK MIXER
-  ParameterLabel::P_FBM_CMB, ParameterLabel::P_FBM_SVF, ParameterLabel::P_FBM_FX, ParameterLabel::P_FBM_REV,
-  ParameterLabel::P_FBM_DRV, ParameterLabel::P_FBM_FLD, ParameterLabel::P_FBM_ASM, ParameterLabel::P_FBM_LKT,
-  ParameterLabel::P_FBM_LVL,
+  Parameters::P_FBM_CMB, Parameters::P_FBM_SVF, Parameters::P_FBM_FX, Parameters::P_FBM_REV, Parameters::P_FBM_DRV,
+  Parameters::P_FBM_FLD, Parameters::P_FBM_ASM, Parameters::P_FBM_LKT, Parameters::P_FBM_LVL,
 
   // OUTPUT MIXER
-  ParameterLabel::P_OM_AL, ParameterLabel::P_OM_AP, ParameterLabel::P_OM_BL, ParameterLabel::P_OM_BP,
-  ParameterLabel::P_OM_CL, ParameterLabel::P_OM_CP, ParameterLabel::P_OM_SL, ParameterLabel::P_OM_SP,
-  ParameterLabel::P_OM_DRV, ParameterLabel::P_OM_FLD, ParameterLabel::P_OM_ASM, ParameterLabel::P_OM_LVL,
-  ParameterLabel::P_OM_KP,
+  Parameters::P_OM_AL, Parameters::P_OM_AP, Parameters::P_OM_BL, Parameters::P_OM_BP, Parameters::P_OM_CL,
+  Parameters::P_OM_CP, Parameters::P_OM_SL, Parameters::P_OM_SP, Parameters::P_OM_DRV, Parameters::P_OM_FLD,
+  Parameters::P_OM_ASM, Parameters::P_OM_LVL, Parameters::P_OM_KP,
 
   // CABINET
-  ParameterLabel::P_CAB_DRV, ParameterLabel::P_CAB_FLD, ParameterLabel::P_CAB_ASM, ParameterLabel::P_CAB_TILT,
-  ParameterLabel::P_CAB_LPF, ParameterLabel::P_CAB_HPF, ParameterLabel::P_CAB_LVL, ParameterLabel::P_CAB_MIX,
+  Parameters::P_CAB_DRV, Parameters::P_CAB_FLD, Parameters::P_CAB_ASM, Parameters::P_CAB_TILT, Parameters::P_CAB_LPF,
+  Parameters::P_CAB_HPF, Parameters::P_CAB_LVL, Parameters::P_CAB_MIX,
 
   // GAP FILTER
-  ParameterLabel::P_GAP_CNT, ParameterLabel::P_GAP_STE, ParameterLabel::P_GAP_GAP, ParameterLabel::P_GAP_RES,
-  ParameterLabel::P_GAP_BAL, ParameterLabel::P_GAP_MIX,
+  Parameters::P_GAP_CNT, Parameters::P_GAP_STE, Parameters::P_GAP_GAP, Parameters::P_GAP_RES, Parameters::P_GAP_BAL,
+  Parameters::P_GAP_MIX,
 
   // FLANGER
-  ParameterLabel::P_FLA_TMOD, ParameterLabel::P_FLA_PHS, ParameterLabel::P_FLA_RTE, ParameterLabel::P_FLA_TIME,
-  ParameterLabel::P_FLA_STE, ParameterLabel::P_FLA_FB, ParameterLabel::P_FLA_CFB, ParameterLabel::P_FLA_LPF,
-  ParameterLabel::P_FLA_MIX, ParameterLabel::P_FLA_ENV, ParameterLabel::P_FLA_APM, ParameterLabel::P_FLA_APT,
+  Parameters::P_FLA_TMOD, Parameters::P_FLA_PHS, Parameters::P_FLA_RTE, Parameters::P_FLA_TIME, Parameters::P_FLA_STE,
+  Parameters::P_FLA_FB, Parameters::P_FLA_CFB, Parameters::P_FLA_LPF, Parameters::P_FLA_MIX, Parameters::P_FLA_ENV,
+  Parameters::P_FLA_APM, Parameters::P_FLA_APT,
 
   // ECHO
-  ParameterLabel::P_DLY_TIME, ParameterLabel::P_DLY_STE, ParameterLabel::P_DLY_FB, ParameterLabel::P_DLY_CFB,
-  ParameterLabel::P_DLY_LPF, ParameterLabel::P_DLY_MIX, ParameterLabel::P_DLY_SND,
+  Parameters::P_DLY_TIME, Parameters::P_DLY_STE, Parameters::P_DLY_FB, Parameters::P_DLY_CFB, Parameters::P_DLY_LPF,
+  Parameters::P_DLY_MIX, Parameters::P_DLY_SND,
 
   // REVERB
-  ParameterLabel::P_REV_SIZE, ParameterLabel::P_REV_PRE, ParameterLabel::P_REV_COL, ParameterLabel::P_REV_CHO,
-  ParameterLabel::P_REV_MIX, ParameterLabel::P_REV_SND,
+  Parameters::P_REV_SIZE, Parameters::P_REV_PRE, Parameters::P_REV_COL, Parameters::P_REV_CHO, Parameters::P_REV_MIX,
+  Parameters::P_REV_SND,
 
   // MASTER
-  ParameterLabel::P_MA_V, ParameterLabel::P_MA_T,
+  Parameters::P_MA_V, Parameters::P_MA_T,
 
   // UNISON
-  ParameterLabel::P_UN_V, ParameterLabel::P_UN_DET, ParameterLabel::P_UN_PHS, ParameterLabel::P_UN_PAN
+  Parameters::P_UN_V, Parameters::P_UN_DET, Parameters::P_UN_PHS, Parameters::P_UN_PAN
 
 };
 
@@ -125,6 +119,6 @@ const ParameterLabel paramIds_keyEvent[lst_keyEvent_length]
 
 #elif test_milestone == 156
 
-const ParameterLabel paramIds_keyEvent[lst_keyEvent_length] = { ParameterLabel::P_KEY_BP };
+const Parameters paramIds_keyEvent[lst_keyEvent_length] = { Parameters::P_KEY_BP };
 
 #endif

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_lists.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_lists.h
@@ -109,13 +109,13 @@ const Parameters paramIds_recall[lst_recall_length] = {
 
 #if test_milestone == 150
 
-const ParameterLabel paramIds_keyEvent[lst_keyEvent_length]
-    = { ParameterLabel::P_KEY_PH, ParameterLabel::P_KEY_NP, ParameterLabel::P_KEY_VP, ParameterLabel::P_KEY_VS };
+const Parameters paramIds_keyEvent[lst_keyEvent_length]
+    = { Parameters::P_KEY_PH, Parameters::P_KEY_NP, Parameters::P_KEY_VP, Parameters::P_KEY_VS };
 
 #elif test_milestone == 155
 
-const ParameterLabel paramIds_keyEvent[lst_keyEvent_length]
-    = { ParameterLabel::P_KEY_BP, ParameterLabel::P_KEY_IDX, ParameterLabel::P_KEY_STL };
+const Parameters paramIds_keyEvent[lst_keyEvent_length]
+    = { Parameters::P_KEY_BP, Parameters::P_KEY_IDX, Parameters::P_KEY_STL };
 
 #elif test_milestone == 156
 

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
@@ -408,14 +408,14 @@ const ParameterDefinition param_definition[sig_number_of_params] = {
   { 211, Parameters::P_FLA_TMOD, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 1, Signals::FLA_TMOD, SpreadTypes::Single,
     1, 8000 },  // 162 FLANGER_TIME_MOD
 #if test_flanger_phs == 0
-  { 213, ParameterLabel::P_FLA_PHS, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 80, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 14400 },  // 163 FLANGER_PHASE
+  { 213, Parameters::P_FLA_PHS, ClockTypes::Slow, PolyTypes::Mono, 80, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 14400 },  // 163 FLANGER_PHASE
 #elif test_flanger_phs == 1
   { 213, Parameters::P_FLA_PHS, ClockTypes::Fast, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
     14400 },  // 163 FLANGER_PHASE
 #elif test_flanger_phs == 2
-  { 213, ParameterLabel::P_FLA_PHS, PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_MONO, 80, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 14400 },  // 163 FLANGER_PHASE
+  { 213, Parameters::P_FLA_PHS, ClockTypes::Audio, PolyTypes::Mono, 80, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 14400 },  // 163 FLANGER_PHASE
 #endif
   { 214, Parameters::P_FLA_RTE, ClockTypes::Audio, PolyTypes::Mono, 16000, 4, 10, Signals::Invalid, SpreadTypes::Single,
     0, 16000 },  // 164 FLANGER_RATE (audio)
@@ -432,11 +432,11 @@ const ParameterDefinition param_definition[sig_number_of_params] = {
   { 223, Parameters::P_FLA_MIX, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
     8000 },  // 170 FLANGER_MIX
 #if test_flanger_env == 0
-  { 307, ParameterLabel::P_FLA_ENV, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 171 FLANGER_ENVELOPE
+  { 307, Parameters::P_FLA_ENV, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 16000 },  // 171 FLANGER_ENVELOPE
 #elif test_flanger_env == 1
-  { 307, ParameterLabel::P_FLA_ENV, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 171 FLANGER_ENVELOPE
+  { 307, Parameters::P_FLA_ENV, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 16000 },  // 171 FLANGER_ENVELOPE
 #elif test_flanger_env == 2
   { 307, Parameters::P_FLA_ENV, ClockTypes::Audio, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
     0, 16000 },  // 171 FLANGER_ENVELOPE
@@ -467,14 +467,14 @@ const ParameterDefinition param_definition[sig_number_of_params] = {
 //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
 #if test_reverbParams == 0
   /* should the parameters run with fast clock? (except chorus) - see pe_defines_config.h */
-  { 235, ParameterLabel::P_REV_SIZE, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 181 REVERB_SIZE
-  { 237, ParameterLabel::P_REV_PRE, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 5, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 182 REVERB_PRE_DELAY
-  { 238, ParameterLabel::P_REV_COL, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 183 REVERB_COLOR
-  { 240, ParameterLabel::P_REV_CHO, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 4, 1,
-    SignalLabel::REV_CHO, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 184 REVERB_CHORUS
+  { 235, Parameters::P_REV_SIZE, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 16000 },  // 181 REVERB_SIZE
+  { 237, Parameters::P_REV_PRE, ClockTypes::Fast, PolyTypes::Mono, 16000, 5, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 16000 },  // 182 REVERB_PRE_DELAY
+  { 238, Parameters::P_REV_COL, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 16000 },  // 183 REVERB_COLOR
+  { 240, Parameters::P_REV_CHO, ClockTypes::Slow, PolyTypes::Mono, 16000, 4, 1,
+    Signals::REV_CHO, SpreadTypes::Single, 0, 16000 },  // 184 REVERB_CHORUS
 #elif test_reverbParams == 1
   /* should the parameters run with slow clock? - see pe_defines_config.h */
   { 235, Parameters::P_REV_SIZE, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
@@ -514,21 +514,21 @@ const ParameterDefinition param_definition[sig_number_of_params] = {
 // - - - POLY KEY EVENT - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
 #if test_milestone == 150
-  { 400, ParameterLabel::P_KEY_PH, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 14400, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 7200 },  // 194 KEY_UNISON_PHASE
-  { 406, ParameterLabel::P_KEY_NP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 1000 },  // 195 KEY_NOTE_PITCH
-  { 407, ParameterLabel::P_KEY_VP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 8000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 8000 },  // 196 KEY_VOICE_PAN
-  { 409, ParameterLabel::P_KEY_VS, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 }  // 197 KEY_VOICE_STEAL
+  { 400, Parameters::P_KEY_PH, ClockTypes::Sync, PolyTypes::Poly, 14400, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 1, 7200 },  // 194 KEY_UNISON_PHASE
+  { 406, Parameters::P_KEY_NP, ClockTypes::Sync, PolyTypes::Poly, 1000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 1, 1000 },  // 195 KEY_NOTE_PITCH
+  { 407, Parameters::P_KEY_VP, ClockTypes::Sync, PolyTypes::Poly, 8000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 1, 8000 },  // 196 KEY_VOICE_PAN
+  { 409, Parameters::P_KEY_VS, ClockTypes::Sync, PolyTypes::Poly, 1, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 1 }  // 197 KEY_VOICE_STEAL
 #elif test_milestone == 155
-  { 416, ParameterLabel::P_KEY_BP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1000, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 1000 },  // 194 KEY_BASE_PITCH
-  { 417, ParameterLabel::P_KEY_IDX, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 },  // 195 KEY_UNISON_IDX
-  { 418, ParameterLabel::P_KEY_STL, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
-    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 }  // 196 KEY_VOICE_STEAL
+  { 416, Parameters::P_KEY_BP, ClockTypes::Sync, PolyTypes::Poly, 1000, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 1, 1000 },  // 194 KEY_BASE_PITCH
+  { 417, Parameters::P_KEY_IDX, ClockTypes::Sync, PolyTypes::Poly, 1, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 1 },  // 195 KEY_UNISON_IDX
+  { 418, Parameters::P_KEY_STL, ClockTypes::Sync, PolyTypes::Poly, 1, 0, 0,
+    Signals::Invalid, SpreadTypes::Single, 0, 1 }  // 196 KEY_VOICE_STEAL
 #elif test_milestone == 156
   { 416, Parameters::P_KEY_BP, ClockTypes::Sync, PolyTypes::Poly, 1000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
     1000 }  // 194 KEY_BASE_PITCH

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_params.h
@@ -1,3 +1,4 @@
+
 /******************************************************************************/
 /** @file       pe_defines_params.h
     @date       2018-03-13
@@ -11,6 +12,9 @@
 #pragma once
 
 #include "pe_defines_config.h"
+#include "pe_defines_labels.h"
+#include "dsp_defines_signallabels.h"
+#include "pe_utilities.h"
 
 // define: param id, clock type, poly type, range, scale id, scale arg, postID (-1: ignore, > -1: array pos), spread (0, 1), polarity, tcd factor
 // convention: define poly params with spread = 0 !!
@@ -19,297 +23,530 @@
 
 /* Parameter Definition */
 
-const float param_definition[sig_number_of_params][10] = {
+struct ParameterDefinition
+{
+  int32_t id;
+  Parameters paramId;
+  ClockTypes clock;
+  PolyTypes poly;
+  int32_t range;
+  uint32_t scale;
+  float scaleArg;
+  Signals postId;
+  SpreadTypes spread;
+  int32_t pol;
+  int32_t factor;
+};
+
+const ParameterDefinition param_definition[sig_number_of_params] = {
 
   // - - - ENVELOPE A - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 0, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },   // 0   ENV_A_ATTACK_TIME
-  { 2, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },   // 1   ENV_A_DECAY1_TIME
-  { 4, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 2   ENV_A_BREAKPOINT_LEVEL
-  { 6, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },   // 3   ENV_A_DECAY2_TIME
-  { 8, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 4   ENV_A_SUSTAIN_LEVEL
-  { 10, 3, 0, 16000, 13, -20, -1, 0, 0, 16160 },  // 5   ENV_A_RELEASE_TIME
-  { 12, 2, 0, 300, 7, 0, -1, 0, 1, 7200 },        // 6   ENV_A_GAIN
-  { 14, 0, 0, 256, 0, 0, -1, 0, 0, 15360 },       // 7   ENV_A_LEVEL_VELOCITY
-  { 15, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 8   ENV_A_ATTACK_VELOCITY
-  { 340, 0, 0, 100, 0, 0, -1, 0, 1, 6000 },       // 9   ENV_A_DECAY1_VELOCITY
-  { 341, 0, 0, 100, 0, 0, -1, 0, 1, 6000 },       // 10  ENV_A_DECAY2_VELOCITY
-  { 16, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 11  ENV_A_RELEASE_VELOCITY
-  { 17, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 12  ENV_A_LEVEL_KEYTRACK
-  { 18, 0, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 13  ENV_A_TIME_KEYTRACK
-  { 294, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 14  ENV_A_ATTACK_CURVE
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 15  (RETRIGGER HARDNESS PLACEHOLDER)
-  { 328, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 16  ENV_A_SPLIT
+  { 0, Parameters::P_EA_ATT, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 0   ENV_A_ATTACK_TIME
+  { 2, Parameters::P_EA_DEC1, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 1   ENV_A_DECAY1_TIME
+  { 4, Parameters::P_EA_BP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 2   ENV_A_BREAKPOINT_LEVEL
+  { 6, Parameters::P_EA_DEC2, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 3   ENV_A_DECAY2_TIME
+  { 8, Parameters::P_EA_SUS, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 4   ENV_A_SUSTAIN_LEVEL
+  { 10, Parameters::P_EA_REL, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16160 },  // 5   ENV_A_RELEASE_TIME
+  { 12, Parameters::P_EA_GAIN, ClockTypes::Fast, PolyTypes::Mono, 300, 7, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    7200 },  // 6   ENV_A_GAIN
+  { 14, Parameters::P_EA_LV, ClockTypes::Sync, PolyTypes::Mono, 256, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    15360 },  // 7   ENV_A_LEVEL_VELOCITY
+  { 15, Parameters::P_EA_AV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 8   ENV_A_ATTACK_VELOCITY
+  { 340, Parameters::P_EA_D1V, ClockTypes::Sync, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    6000 },  // 9   ENV_A_DECAY1_VELOCITY
+  { 341, Parameters::P_EA_D2V, ClockTypes::Sync, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    6000 },  // 10  ENV_A_DECAY2_VELOCITY
+  { 16, Parameters::P_EA_RV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 11  ENV_A_RELEASE_VELOCITY
+  { 17, Parameters::P_EA_LKT, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 12  ENV_A_LEVEL_KEYTRACK
+  { 18, Parameters::P_EA_TKT, ClockTypes::Sync, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 13  ENV_A_TIME_KEYTRACK
+  { 294, Parameters::P_EA_AC, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 14  ENV_A_ATTACK_CURVE
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 15  (RETRIGGER HARDNESS PLACEHOLDER)
+  { 328, Parameters::P_EA_SPL, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 16  ENV_A_SPLIT
 
   // - - - ENVELOPE B - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 19, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 17  ENV_B_ATTACK_TIME
-  { 21, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 18  ENV_B_DECAY1_TIME
-  { 23, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 19  ENV_B_BREAKPOINT_LEVEL
-  { 25, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 20  ENV_B_DECAY2_TIME
-  { 27, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 21  ENV_B_SUSTAIN_LEVEL
-  { 29, 3, 0, 16000, 13, -20, -1, 0, 0, 16160 },  // 22  ENV_B_RELEASE_TIME
-  { 31, 2, 0, 300, 7, 0, -1, 0, 1, 7200 },        // 23  ENV_B_GAIN
-  { 33, 0, 0, 256, 0, 0, -1, 0, 0, 15360 },       // 24  ENV_B_LEVEL_VELOCITY
-  { 34, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 25  ENV_B_ATTACK_VELOCITY
-  { 342, 0, 0, 100, 0, 0, -1, 0, 1, 6000 },       // 26  ENV_B_DECAY1_VELOCITY
-  { 343, 0, 0, 100, 0, 0, -1, 0, 1, 6000 },       // 27  ENV_B_DECAY2_VELOCITY
-  { 35, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 28  ENV_B_RELEASE_VELOCITY
-  { 36, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 29  ENV_B_LEVEL_KEYTRACK
-  { 37, 0, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 30  ENV_B_TIME_KEYTRACK
-  { 295, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 31  ENV_B_ATTACK_CURVE
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 32  (RETRIGGER HARDNESS PLACEHOLDER)
-  { 330, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 33  ENV_B_SPLIT
+  { 19, Parameters::P_EB_ATT, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 17  ENV_B_ATTACK_TIME
+  { 21, Parameters::P_EB_DEC1, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 18  ENV_B_DECAY1_TIME
+  { 23, Parameters::P_EB_BP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 19  ENV_B_BREAKPOINT_LEVEL
+  { 25, Parameters::P_EB_DEC2, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 20  ENV_B_DECAY2_TIME
+  { 27, Parameters::P_EB_SUS, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 21  ENV_B_SUSTAIN_LEVEL
+  { 29, Parameters::P_EB_REL, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16160 },  // 22  ENV_B_RELEASE_TIME
+  { 31, Parameters::P_EB_GAIN, ClockTypes::Fast, PolyTypes::Mono, 300, 7, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    7200 },  // 23  ENV_B_GAIN
+  { 33, Parameters::P_EB_LV, ClockTypes::Sync, PolyTypes::Mono, 256, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    15360 },  // 24  ENV_B_LEVEL_VELOCITY
+  { 34, Parameters::P_EB_AV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 25  ENV_B_ATTACK_VELOCITY
+  { 342, Parameters::P_EB_D1V, ClockTypes::Sync, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    6000 },  // 26  ENV_B_DECAY1_VELOCITY
+  { 343, Parameters::P_EB_D2V, ClockTypes::Sync, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    6000 },  // 27  ENV_B_DECAY2_VELOCITY
+  { 35, Parameters::P_EB_RV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 28  ENV_B_RELEASE_VELOCITY
+  { 36, Parameters::P_EB_LKT, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 29  ENV_B_LEVEL_KEYTRACK
+  { 37, Parameters::P_EB_TKT, ClockTypes::Sync, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 30  ENV_B_TIME_KEYTRACK
+  { 295, Parameters::P_EB_AC, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 31  ENV_B_ATTACK_CURVE
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 32  (RETRIGGER HARDNESS PLACEHOLDER)
+  { 330, Parameters::P_EB_SPL, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 33  ENV_B_SPLIT
 
   // - - - ENVELOPE C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 38, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 34  ENV_C_ATTACK_TIME
-  { 40, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 35  ENV_C_DECAY1_TIME
-  { 42, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 36  ENV_C_BREAKPOINT_LEVEL
-  { 44, 3, 0, 16000, 13, -20, -1, 0, 0, 16000 },  // 37  ENV_C_DECAY2_TIME
-  { 297, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 38  ENV_C_SUSTAIN_LEVEL
-  { 46, 3, 0, 16000, 13, -20, -1, 0, 0, 16160 },  // 39  ENV_C_RELEASE_TIME
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 40  (GAIN PLACEHOLDER)
-  { 48, 0, 0, 256, 0, 0, -1, 0, 0, 15360 },       // 41  ENV_C_LEVEL_VELOCITY
-  { 49, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 42  ENV_C_ATTACK_VELOCITY
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 43  (D1V PLACEHOLDER)
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 44  (D2V PLACEHOLDER)
-  { 50, 0, 0, 200, 0, 0, -1, 0, 0, 12000 },       // 45  ENV_C_RELEASE_VELOCITY
-  { 51, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 46  ENV_C_LEVEL_KEYTRACK
-  { 52, 0, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 47  ENV_C_TIME_KEYTRACK
-  { 296, 0, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 48  ENV_C_ATTACK_CURVE
-  { 332, 0, 0, 16000, 0, 0, -1, 0, 0, 16000 },    // 49  ENV_C_RETRIGGER_HARDNESS
-  { -1, 0, 0, 1, 0, 0, -1, 0, 0, 0 },             // 50  (SPLIT PLACEHOLDER)
+  { 38, Parameters::P_EC_ATT, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 34  ENV_C_ATTACK_TIME
+  { 40, Parameters::P_EC_DEC1, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 35  ENV_C_DECAY1_TIME
+  { 42, Parameters::P_EC_BP, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 36  ENV_C_BREAKPOINT_LEVEL
+  { 44, Parameters::P_EC_DEC2, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 37  ENV_C_DECAY2_TIME
+  { 297, Parameters::P_EC_SUS, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 38  ENV_C_SUSTAIN_LEVEL
+  { 46, Parameters::P_EC_REL, ClockTypes::Slow, PolyTypes::Mono, 16000, 13, -20, Signals::Invalid, SpreadTypes::Single,
+    0, 16160 },  // 39  ENV_C_RELEASE_TIME
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 40  (GAIN PLACEHOLDER)
+  { 48, Parameters::P_EC_LV, ClockTypes::Sync, PolyTypes::Mono, 256, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    15360 },  // 41  ENV_C_LEVEL_VELOCITY
+  { 49, Parameters::P_EC_AV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 42  ENV_C_ATTACK_VELOCITY
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 43  (D1V PLACEHOLDER)
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 44  (D2V PLACEHOLDER)
+  { 50, Parameters::P_EC_RV, ClockTypes::Sync, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 45  ENV_C_RELEASE_VELOCITY
+  { 51, Parameters::P_EC_LKT, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 46  ENV_C_LEVEL_KEYTRACK
+  { 52, Parameters::P_EC_TKT, ClockTypes::Sync, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 47  ENV_C_TIME_KEYTRACK
+  { 296, Parameters::P_EC_AC, ClockTypes::Sync, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 48  ENV_C_ATTACK_CURVE
+  { 332, Parameters::P_EC_RH, ClockTypes::Sync, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 49  ENV_C_RETRIGGER_HARDNESS
+  { -1, Parameters::P_INVALID, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    0 },  // 50  (SPLIT PLACEHOLDER)
 
   // - - - OSCILLATOR A - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 53, 3, 0, 100, 8, -20, -1, 0, 0, 15000 },      // 51  OSC_A_PITCH
-  { 55, 3, 0, 10000, 0, 0, -1, 0, 0, 10000 },      // 52  OSC_A_PITCH_KEYTRACK
-  { 56, 3, 0, 100, 0, 0, -1, 0, 1, 8000 },         // 53  OSC_A_PITCH_ENV_C
-  { 57, 3, 0, 16000, 4, 0.95f, -1, 0, 0, 16000 },  // 54  OSC_A_FLUCTUATION
-  { 59, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 55  OSC_A_FLUCTUATION_ENV_C
-  { 60, 2, 0, 8000, 4, 0.5f, -1, 0, 1, 8000 },     // 56  OSC_A_PM_SELF
-  { 62, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 57  OSC_A_PM_SELF_ENV_A
-  { 63, 3, 0, 8000, 0, 0, 10, 1, 1, 8000 },        // 58  OSC_A_PM_SELF_SHAPER
-  { 64, 2, 0, 8000, 4, 1, -1, 0, 1, 8000 },        // 59  OSC_A_PM_B
-  { 66, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 60  OSC_A_PM_B_ENV_B
-  { 67, 3, 0, 8000, 0, 0, 12, 1, 1, 8000 },        // 61  OSC_A_PM_B_SHAPER
-  { 68, 2, 0, 8000, 4, 0.5f, -1, 0, 1, 8000 },     // 62  OSC_A_PM_FB
-  { 70, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 63  OSC_A_PM_FB_ENV_C
-  { 301, 1, 0, 14400, 0, 0, 14, 1, 1, 7200 },      // 64  OSC_A_PHASE
-  { 303, 3, 0, 200, 9, 80, -1, 0, 0, 12000 },      // 65  OSC_A_CHIRP
+  { 53, Parameters::P_OA_P, ClockTypes::Slow, PolyTypes::Mono, 100, 8, -20, Signals::Invalid, SpreadTypes::Single, 0,
+    15000 },  // 51  OSC_A_PITCH
+  { 55, Parameters::P_OA_PKT, ClockTypes::Slow, PolyTypes::Mono, 10000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    10000 },  // 52  OSC_A_PITCH_KEYTRACK
+  { 56, Parameters::P_OA_PEC, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 53  OSC_A_PITCH_ENV_C
+  { 57, Parameters::P_OA_F, ClockTypes::Slow, PolyTypes::Mono, 16000, 4, 0.95f, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 54  OSC_A_FLUCTUATION
+  { 59, Parameters::P_OA_FEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 55  OSC_A_FLUCTUATION_ENV_C
+  { 60, Parameters::P_OA_PMS, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 56  OSC_A_PM_SELF
+  { 62, Parameters::P_OA_PMSEA, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 57  OSC_A_PM_SELF_ENV_A
+  { 63, Parameters::P_OA_PMSSH, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::OSC_A_PMSSH,
+    SpreadTypes::Spread, 1, 8000 },  // 58  OSC_A_PM_SELF_SHAPER
+  { 64, Parameters::P_OA_PMB, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 1, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 59  OSC_A_PM_B
+  { 66, Parameters::P_OA_PMBEB, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 60  OSC_A_PM_B_ENV_B
+  { 67, Parameters::P_OA_PMBSH, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::OSC_A_PMBSH,
+    SpreadTypes::Spread, 1, 8000 },  // 61  OSC_A_PM_B_SHAPER
+  { 68, Parameters::P_OA_PMF, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 62  OSC_A_PM_FB
+  { 70, Parameters::P_OA_PMFEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 63  OSC_A_PM_FB_ENV_C
+  { 301, Parameters::P_OA_PHS, ClockTypes::Audio, PolyTypes::Mono, 14400, 0, 0, Signals::OSC_A_PHS, SpreadTypes::Spread,
+    1, 7200 },  // 64  OSC_A_PHASE
+  { 303, Parameters::P_OA_CHI, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 80, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 65  OSC_A_CHIRP
 
   // - - - SHAPER A - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 71, 2, 0, 200, 10, 0.18f, -1, 0, 0, 10000 },  // 66  SHP_A_DRIVE
-  { 73, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 67  SHP_A_DRIVE_ENV_A (later maybe fast type)
-  { 74, 2, 0, 16000, 0, 0, 17, 1, 0, 16000 },     // 68  SHP_A_FOLD (later maybe fast type)
-  { 75, 2, 0, 16000, 0, 0, 18, 1, 0, 16000 },     // 69  SHP_A_ASYMETRY (later maybe fast type)
-  { 76, 2, 0, 8000, 0, 0, 19, 1, 1, 8000 },       // 70  SHP_A_MIX
-  { 78, 2, 0, 16000, 5, 0, 20, 1, 0, 16000 },     // 71  SHP_A_FEEDBACK_MIX
-  { 80, 3, 0, 16000, 0, 0, -1, 1, 0, 16000 },     // 72  SHP_A_FEEDBACK_ENV_C
-  { 81, 2, 0, 16000, 0, 0, 22, 1, 0, 16000 },     // 73  SHP_A_RINGMOD
+  { 71, Parameters::P_SA_DRV, ClockTypes::Fast, PolyTypes::Mono, 200, 10, 0.18f, Signals::Invalid, SpreadTypes::Single,
+    0, 10000 },  // 66  SHP_A_DRIVE
+  { 73, Parameters::P_SA_DEA, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 67  SHP_A_DRIVE_ENV_A (later maybe fast type)
+  { 74, Parameters::P_SA_FLD, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_A_FLD, SpreadTypes::Spread,
+    0, 16000 },  // 68  SHP_A_FOLD (later maybe fast type)
+  { 75, Parameters::P_SA_ASM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_A_ASM, SpreadTypes::Spread,
+    0, 16000 },  // 69  SHP_A_ASYMETRY (later maybe fast type)
+  { 76, Parameters::P_SA_MIX, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::SHP_A_MIX, SpreadTypes::Spread, 1,
+    8000 },  // 70  SHP_A_MIX
+  { 78, Parameters::P_SA_FBM, ClockTypes::Fast, PolyTypes::Mono, 16000, 5, 0, Signals::SHP_A_FBM, SpreadTypes::Spread,
+    0, 16000 },  // 71  SHP_A_FEEDBACK_MIX
+  { 80, Parameters::P_SA_FBEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Spread, 0,
+    16000 },  // 72  SHP_A_FEEDBACK_ENV_C
+  { 81, Parameters::P_SA_RM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_A_RM, SpreadTypes::Spread, 0,
+    16000 },  // 73  SHP_A_RINGMOD
 
   // - - - OSCILLATOR B - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 83, 3, 0, 100, 8, -20, -1, 0, 0, 15000 },      // 74  OSC_B_PITCH
-  { 85, 3, 0, 10000, 0, 0, -1, 0, 0, 10000 },      // 75  OSC_B_PITCH_KEYTRACK
-  { 86, 3, 0, 100, 0, 0, -1, 0, 1, 8000 },         // 76  OSC_B_PITCH_ENV_C
-  { 87, 3, 0, 16000, 4, 0.95f, -1, 0, 0, 16000 },  // 77  OSC_B_FLUCTUATION
-  { 89, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 78  OSC_B_FLUCTUATION_ENV_C
-  { 90, 2, 0, 8000, 4, 0.5f, -1, 0, 1, 8000 },     // 79  OSC_B_PM_SELF
-  { 92, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 80  OSC_B_PM_SELF_ENV_B
-  { 93, 3, 0, 8000, 0, 0, 26, 1, 1, 8000 },        // 81  OSC_B_PM_SELF_SHAPER
-  { 94, 2, 0, 8000, 4, 1, -1, 0, 1, 8000 },        // 82  OSC_B_PM_A
-  { 96, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },      // 83  OSC_B_PM_A_ENV_A
-  { 97, 3, 0, 8000, 0, 0, 28, 1, 1, 8000 },        // 84  OSC_B_PM_A_SHAPER
-  { 98, 2, 0, 8000, 4, 0.5f, -1, 0, 1, 8000 },     // 85  OSC_B_PM_FB
-  { 100, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 86  OSC_B_PM_FB_ENV_C
-  { 302, 1, 0, 14400, 0, 0, 30, 1, 1, 7200 },      // 87  OSC_B_PHASE
-  { 304, 3, 0, 200, 9, 80, -1, 0, 0, 12000 },      // 88  OSC_B_CHIRP
+  { 83, Parameters::P_OB_P, ClockTypes::Slow, PolyTypes::Mono, 100, 8, -20, Signals::Invalid, SpreadTypes::Single, 0,
+    15000 },  // 74  OSC_B_PITCH
+  { 85, Parameters::P_OB_PKT, ClockTypes::Slow, PolyTypes::Mono, 10000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    10000 },  // 75  OSC_B_PITCH_KEYTRACK
+  { 86, Parameters::P_OB_PEC, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 76  OSC_B_PITCH_ENV_C
+  { 87, Parameters::P_OB_F, ClockTypes::Slow, PolyTypes::Mono, 16000, 4, 0.95f, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 77  OSC_B_FLUCTUATION
+  { 89, Parameters::P_OB_FEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 78  OSC_B_FLUCTUATION_ENV_C
+  { 90, Parameters::P_OB_PMS, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 79  OSC_B_PM_SELF
+  { 92, Parameters::P_OB_PMSEB, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 80  OSC_B_PM_SELF_ENV_B
+  { 93, Parameters::P_OB_PMSSH, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::OSC_B_PMSSH,
+    SpreadTypes::Spread, 1, 8000 },  // 81  OSC_B_PM_SELF_SHAPER
+  { 94, Parameters::P_OB_PMA, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 1, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 82  OSC_B_PM_A
+  { 96, Parameters::P_OB_PMAEA, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 83  OSC_B_PM_A_ENV_A
+  { 97, Parameters::P_OB_PMASH, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::OSC_B_PMASH,
+    SpreadTypes::Spread, 1, 8000 },  // 84  OSC_B_PM_A_SHAPER
+  { 98, Parameters::P_OB_PMF, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 85  OSC_B_PM_FB
+  { 100, Parameters::P_OB_PMFEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 86  OSC_B_PM_FB_ENV_C
+  { 302, Parameters::P_OB_PHS, ClockTypes::Audio, PolyTypes::Mono, 14400, 0, 0, Signals::OSC_B_PHS, SpreadTypes::Spread,
+    1, 7200 },  // 87  OSC_B_PHASE
+  { 304, Parameters::P_OB_CHI, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 80, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 88  OSC_B_CHIRP
 
   // - - - SHAPER B - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 101, 2, 0, 200, 10, 0.18f, -1, 0, 0, 10000 },  // 89  SHP_B_DRIVE
-  { 103, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },     // 90  SHP_B_DRIVE_ENV_B (later maybe fast type)
-  { 104, 2, 0, 16000, 0, 0, 33, 1, 0, 16000 },     // 91  SHP_B_FOLD (later maybe fast type)
-  { 105, 2, 0, 16000, 0, 0, 34, 1, 0, 16000 },     // 92  SHP_B_ASYMETRY (later maybe fast type)
-  { 106, 2, 0, 8000, 0, 0, 35, 1, 1, 8000 },       // 93  SHP_B_MIX
-  { 108, 2, 0, 16000, 5, 0, 36, 1, 0, 16000 },     // 94  SHP_B_FEEDBACK_MIX
-  { 110, 3, 0, 16000, 0, 0, -1, 1, 0, 16000 },     // 95  SHP_B_FEEDBACK_ENV_C
-  { 111, 2, 0, 16000, 0, 0, 38, 1, 0, 16000 },     // 96  SHP_B_RINGMOD
+  { 101, Parameters::P_SB_DRV, ClockTypes::Fast, PolyTypes::Mono, 200, 10, 0.18f, Signals::Invalid, SpreadTypes::Single,
+    0, 10000 },  // 89  SHP_B_DRIVE
+  { 103, Parameters::P_SB_DEB, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 90  SHP_B_DRIVE_ENV_B (later maybe fast type)
+  { 104, Parameters::P_SB_FLD, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_B_FLD, SpreadTypes::Spread,
+    0, 16000 },  // 91  SHP_B_FOLD (later maybe fast type)
+  { 105, Parameters::P_SB_ASM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_B_ASM, SpreadTypes::Spread,
+    0, 16000 },  // 92  SHP_B_ASYMETRY (later maybe fast type)
+  { 106, Parameters::P_SB_MIX, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::SHP_B_MIX, SpreadTypes::Spread,
+    1, 8000 },  // 93  SHP_B_MIX
+  { 108, Parameters::P_SB_FBM, ClockTypes::Fast, PolyTypes::Mono, 16000, 5, 0, Signals::SHP_B_FBM, SpreadTypes::Spread,
+    0, 16000 },  // 94  SHP_B_FEEDBACK_MIX
+  { 110, Parameters::P_SB_FBEC, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Spread,
+    0, 16000 },  // 95  SHP_B_FEEDBACK_ENV_C
+  { 111, Parameters::P_SB_RM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::SHP_B_RM, SpreadTypes::Spread, 0,
+    16000 },  // 96  SHP_B_RINGMOD
 
   // - - - COMB FILTER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 113, 2, 0, 16000, 6, 1, 39, 1, 0, 16000 },   // 97  CMB_AB
-  { 115, 3, 0, 100, 9, 0, -1, 0, 0, 12000 },     // 98  CMB_PITCH
-  { 117, 3, 0, 10000, 0, 0, -1, 0, 0, 10500 },   // 99  CMB_PITCH_KT
-  { 118, 3, 0, 100, 0, 0, -1, 0, 1, 8000 },      // 100 CMB_PITCH_ENV_C
-  { 119, 3, 0, 80, 0, 0, -1, 0, 1, 8000 },       // 101 CMB_DECAY
-  { 121, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 102 CMB_DECAY_KT
-  { 305, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 103 CMB_DECAY_GATE
-  { 123, 3, 0, 100, 9, 0, -1, 0, 0, 14000 },     // 104 CMB_ALLPASS_TUNE
-  { 125, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 105 CMB_ALLPASS_KT
-  { 126, 3, 0, 100, 0, 0, -1, 0, 1, 8000 },      // 106 CMB_ALLPASS_ENV_C
-  { 127, 3, 0, 16000, 0, 0, 45, 1, 0, 16000 },   // 107 CMB_ALLPASS_RESON
-  { 129, 3, 0, 100, 9, 40, -1, 0, 0, 10000 },    // 108 CMB_HICUT
-  { 131, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 109 CMB_HICUT_KT
-  { 132, 3, 0, 80, 0, 0, -1, 0, 1, 8000 },       // 110 CMB_HICUT_ENV_C
-  { 133, 3, 0, 8000, 4, 0.9f, 47, 1, 1, 8000 },  // 111 CMB_PM
-  { 135, 3, 0, 16000, 2, 1, 48, 1, 0, 16000 },   // 112 CMB_PM_AB
+  { 113, Parameters::P_CMB_AB, ClockTypes::Fast, PolyTypes::Mono, 16000, 6, 1, Signals::CMB_AB, SpreadTypes::Spread, 0,
+    16000 },  // 97  CMB_AB
+  { 115, Parameters::P_CMB_P, ClockTypes::Slow, PolyTypes::Mono, 100, 9, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 98  CMB_PITCH
+  { 117, Parameters::P_CMB_PKT, ClockTypes::Slow, PolyTypes::Mono, 10000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 10500 },  // 99  CMB_PITCH_KT
+  { 118, Parameters::P_CMB_PEC, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 100 CMB_PITCH_ENV_C
+  { 119, Parameters::P_CMB_D, ClockTypes::Slow, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 101 CMB_DECAY
+  { 121, Parameters::P_CMB_DKT, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 102 CMB_DECAY_KT
+  { 305, Parameters::P_CMB_DG, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 103 CMB_DECAY_GATE
+  { 123, Parameters::P_CMB_APT, ClockTypes::Slow, PolyTypes::Mono, 100, 9, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    14000 },  // 104 CMB_ALLPASS_TUNE
+  { 125, Parameters::P_CMB_APKT, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 105 CMB_ALLPASS_KT
+  { 126, Parameters::P_CMB_APEC, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 106 CMB_ALLPASS_ENV_C
+  { 127, Parameters::P_CMB_APR, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::CMB_APR, SpreadTypes::Spread,
+    0, 16000 },  // 107 CMB_ALLPASS_RESON
+  { 129, Parameters::P_CMB_LP, ClockTypes::Slow, PolyTypes::Mono, 100, 9, 40, Signals::Invalid, SpreadTypes::Single, 0,
+    10000 },  // 108 CMB_HICUT
+  { 131, Parameters::P_CMB_LPKT, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 109 CMB_HICUT_KT
+  { 132, Parameters::P_CMB_LPEC, ClockTypes::Slow, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 110 CMB_HICUT_ENV_C
+  { 133, Parameters::P_CMB_PM, ClockTypes::Slow, PolyTypes::Mono, 8000, 4, 0.9f, Signals::CMB_PM, SpreadTypes::Spread,
+    1, 8000 },  // 111 CMB_PM
+  { 135, Parameters::P_CMB_PMAB, ClockTypes::Slow, PolyTypes::Mono, 16000, 2, 1, Signals::CMB_PMAB, SpreadTypes::Spread,
+    0, 16000 },  // 112 CMB_PM_AB
 
   // - - - STATE VARIABLE FILTER  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 136, 2, 0, 16000, 2, 1, 49, 1, 0, 16000 },  // 113 SVF_AB
-  { 138, 2, 0, 8000, 0, 0, 50, 1, 1, 8000 },    // 114 SVF_COMB_MIX
-  { 140, 3, 0, 100, 9, 20, -1, 0, 0, 12000 },   // 115 SVF_CUTOFF
-  { 142, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 116 SVF_CUTOFF_KT
-  { 143, 3, 0, 80, 0, 0, -1, 0, 1, 8000 },      // 117 SVF_CUTOFF_ENV_C
-  { 148, 3, 0, 100, 1, 0.5f, -1, 0, 1, 6000 },  // 118 SVF_SPREAD
-  { 153, 3, 0, 8000, 0, 0, -1, 0, 1, 8000 },    // 119 SVF_FM
-  { 144, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 120 SVF_RESONANCE
-  { 146, 3, 0, 8000, 0, 0, -1, 0, 1, 8000 },    // 121 SVF_RESONANCE_KT
-  { 147, 3, 0, 8000, 0, 0, -1, 0, 1, 8000 },    // 122 SVF_RESONANCE_ENV_C
-  { 150, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 123 SVF_LBH
-  { 152, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },    // 124 SVF_PARALLEL
-  { 155, 3, 0, 16000, 2, 1, 62, 1, 0, 16000 },  // 125 SVF_FM_AB
+  { 136, Parameters::P_SVF_AB, ClockTypes::Fast, PolyTypes::Mono, 16000, 2, 1, Signals::SVF_AB, SpreadTypes::Spread, 0,
+    16000 },  // 113 SVF_AB
+  { 138, Parameters::P_SVF_CMB, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::SVF_CMIX, SpreadTypes::Spread,
+    1, 8000 },  // 114 SVF_COMB_MIX
+  { 140, Parameters::P_SVF_CUT, ClockTypes::Slow, PolyTypes::Mono, 100, 9, 20, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 115 SVF_CUTOFF
+  { 142, Parameters::P_SVF_CKT, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 116 SVF_CUTOFF_KT
+  { 143, Parameters::P_SVF_CEC, ClockTypes::Slow, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 117 SVF_CUTOFF_ENV_C
+  { 148, Parameters::P_SVF_SPR, ClockTypes::Slow, PolyTypes::Mono, 100, 1, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 6000 },  // 118 SVF_SPREAD
+  { 153, Parameters::P_SVF_FM, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 119 SVF_FM
+  { 144, Parameters::P_SVF_RES, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 120 SVF_RESONANCE
+  { 146, Parameters::P_SVF_RKT, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 121 SVF_RESONANCE_KT
+  { 147, Parameters::P_SVF_REC, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 122 SVF_RESONANCE_ENV_C
+  { 150, Parameters::P_SVF_LBH, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 123 SVF_LBH
+  { 152, Parameters::P_SVF_PAR, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 124 SVF_PARALLEL
+  { 155, Parameters::P_SVF_FMAB, ClockTypes::Slow, PolyTypes::Mono, 16000, 2, 1, Signals::SVF_FMAB, SpreadTypes::Single,
+    0, 16000 },  // 125 SVF_FM_AB
 
   // - - - FEEDBACK MIXER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 156, 2, 0, 8000, 0, 0, 63, 1, 1, 8000 },      // 126 FBM_COMB_MIX
-  { 158, 2, 0, 8000, 0, 0, 64, 1, 1, 8000 },      // 127 FBM_SVF_MIX
-  { 160, 2, 0, 8000, 3, 0, 65, 1, 1, 8000 },      // 128 FBM_EFFECTS_MIX
-  { 162, 2, 0, 16000, 0, 0, 66, 0, 0, 16000 },    // 129 FBM_REVERB_MIX
-  { 164, 2, 0, 200, 11, 2.5f, 67, 1, 0, 10000 },  // 130 FBM_DRIVE
-  { 166, 2, 0, 16000, 0, 0, 68, 1, 0, 16000 },    // 131 FBM_FOLD
-  { 167, 2, 0, 16000, 0, 0, 69, 1, 0, 16000 },    // 132 FBM_ASYM
-  { 168, 3, 0, 8000, 0, 0, -1, 1, 1, 8000 },      // 133 FBM_LEVEL_KT
-  { 299, 2, 0, 16000, 4, 4, -1, 1, 0, 16000 },    // 134 FBM_LEVEL
+  { 156, Parameters::P_FBM_CMB, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::FBM_CMB, SpreadTypes::Spread, 1,
+    8000 },  // 126 FBM_COMB_MIX
+  { 158, Parameters::P_FBM_SVF, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::FBM_SVF, SpreadTypes::Spread, 1,
+    8000 },  // 127 FBM_SVF_MIX
+  { 160, Parameters::P_FBM_FX, ClockTypes::Fast, PolyTypes::Mono, 8000, 3, 0, Signals::FBM_FX, SpreadTypes::Spread, 1,
+    8000 },  // 128 FBM_EFFECTS_MIX
+  { 162, Parameters::P_FBM_REV, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::FBM_REV, SpreadTypes::Single,
+    0, 16000 },  // 129 FBM_REVERB_MIX
+  { 164, Parameters::P_FBM_DRV, ClockTypes::Fast, PolyTypes::Mono, 200, 11, 2.5f, Signals::FBM_DRV, SpreadTypes::Spread,
+    0, 10000 },  // 130 FBM_DRIVE
+  { 166, Parameters::P_FBM_FLD, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::FBM_FLD, SpreadTypes::Spread,
+    0, 16000 },  // 131 FBM_FOLD
+  { 167, Parameters::P_FBM_ASM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::FBM_ASM, SpreadTypes::Spread,
+    0, 16000 },  // 132 FBM_ASYM
+  { 168, Parameters::P_FBM_LKT, ClockTypes::Slow, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Spread, 1,
+    8000 },  // 133 FBM_LEVEL_KT
+  { 299, Parameters::P_FBM_LVL, ClockTypes::Fast, PolyTypes::Mono, 16000, 4, 4, Signals::Invalid, SpreadTypes::Spread,
+    0, 16000 },  // 134 FBM_LEVEL
 
   // - - - OUTPUT MIXER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 169, 2, 0, 4000, 0, 0, -1, 0, 1, 8000 },        // 135 OUT_A_LEVEL
-  { 171, 2, 0, 16000, 0, 0.5f, -1, 0, 1, 8000 },    // 136 OUT_A_PAN
-  { 172, 2, 0, 4000, 0, 0, -1, 0, 1, 8000 },        // 137 OUT_B_LEVEL
-  { 174, 2, 0, 16000, 0, 0.5f, -1, 0, 1, 8000 },    // 138 OUT_B_PAN
-  { 175, 2, 0, 4000, 0, 0, -1, 0, 1, 8000 },        // 139 OUT_COMB_LEVEL
-  { 177, 2, 0, 16000, 0, 0.5f, -1, 0, 1, 8000 },    // 140 OUT_COMB_PAN
-  { 178, 2, 0, 4000, 0, 0, -1, 0, 1, 8000 },        // 141 OUT_SVF_LEVEL
-  { 180, 2, 0, 16000, 0, 0.5f, -1, 0, 1, 8000 },    // 142 OUT_SVF_PAN
-  { 181, 2, 0, 200, 11, 0.25f, 80, 1, 0, 10000 },   // 143 OUT_DRIVE
-  { 183, 2, 0, 16000, 0, 0, 81, 1, 0, 16000 },      // 144 OUT_FOLD (later maybe fast type)
-  { 184, 2, 0, 16000, 0, 0, 82, 1, 0, 16000 },      // 145 OUT_ASYMETRY (later maybe fast type)
-  { 185, 2, 0, 16000, 4, 2.56f, 83, 0, 0, 16000 },  // 146 OUT_LEVEL
-  { 187, 2, 0, 960000, 0, 0, -1, 0, 0, 16000 },     // 147 OUT_KEY_PAN
+  { 169, Parameters::P_OM_AL, ClockTypes::Fast, PolyTypes::Mono, 4000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 135 OUT_A_LEVEL
+  { 171, Parameters::P_OM_AP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 136 OUT_A_PAN
+  { 172, Parameters::P_OM_BL, ClockTypes::Fast, PolyTypes::Mono, 4000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 137 OUT_B_LEVEL
+  { 174, Parameters::P_OM_BP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 138 OUT_B_PAN
+  { 175, Parameters::P_OM_CL, ClockTypes::Fast, PolyTypes::Mono, 4000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 139 OUT_COMB_LEVEL
+  { 177, Parameters::P_OM_CP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 140 OUT_COMB_PAN
+  { 178, Parameters::P_OM_SL, ClockTypes::Fast, PolyTypes::Mono, 4000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 141 OUT_SVF_LEVEL
+  { 180, Parameters::P_OM_SP, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 142 OUT_SVF_PAN
+  { 181, Parameters::P_OM_DRV, ClockTypes::Fast, PolyTypes::Mono, 200, 11, 0.25f, Signals::OUT_DRV, SpreadTypes::Spread,
+    0, 10000 },  // 143 OUT_DRIVE
+  { 183, Parameters::P_OM_FLD, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::OUT_FLD, SpreadTypes::Spread, 0,
+    16000 },  // 144 OUT_FOLD (later maybe fast type)
+  { 184, Parameters::P_OM_ASM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::OUT_ASM, SpreadTypes::Spread, 0,
+    16000 },  // 145 OUT_ASYMETRY (later maybe fast type)
+  { 185, Parameters::P_OM_LVL, ClockTypes::Fast, PolyTypes::Mono, 16000, 4, 2.56f, Signals::OUT_LVL,
+    SpreadTypes::Single, 0, 16000 },  // 146 OUT_LEVEL
+  { 187, Parameters::P_OM_KP, ClockTypes::Fast, PolyTypes::Mono, 960000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 147 OUT_KEY_PAN
 
   // - - - CABINET  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 188, 2, 0, 200, 12, 0, 84, 0, 0, 10000 },    // 148 CABINET_DRIVE
-  { 190, 2, 0, 16000, 0, 0, 85, 0, 0, 16000 },   // 149 CABINET_FOLD (later maybe fast type)
-  { 191, 2, 0, 16000, 0, 0, 86, 0, 0, 16000 },   // 150 CABINET_ASYMETRY (later maybe fast type)
-  { 192, 2, 0, 80, 0, 0, -1, 0, 1, 8000 },       // 151 CABINET_TILT (implement fast and slow handling)
-  { 194, 3, 0, 200, 9, 60, -1, 0, 0, 16000 },    // 152 CABINET_HI_CUT
-  { 196, 3, 0, 200, 9, 20, -1, 0, 0, 16000 },    // 153 CABINET_LOW_CUT
-  { 197, 2, 0, 200, 12, -50, -1, 0, 0, 10000 },  // 154 CABINET_CAB_LEVEL
-  { 199, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 155 CABINET_MIX
+  { 188, Parameters::P_CAB_DRV, ClockTypes::Fast, PolyTypes::Mono, 200, 12, 0, Signals::CAB_DRV, SpreadTypes::Single, 0,
+    10000 },  // 148 CABINET_DRIVE
+  { 190, Parameters::P_CAB_FLD, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::CAB_FLD, SpreadTypes::Single,
+    0, 16000 },  // 149 CABINET_FOLD (later maybe fast type)
+  { 191, Parameters::P_CAB_ASM, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::CAB_ASM, SpreadTypes::Single,
+    0, 16000 },  // 150 CABINET_ASYMETRY (later maybe fast type)
+  { 192, Parameters::P_CAB_TILT, ClockTypes::Fast, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 151 CABINET_TILT (implement fast and slow handling)
+  { 194, Parameters::P_CAB_LPF, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 60, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 152 CABINET_HI_CUT
+  { 196, Parameters::P_CAB_HPF, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 20, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 153 CABINET_LOW_CUT
+  { 197, Parameters::P_CAB_LVL, ClockTypes::Fast, PolyTypes::Mono, 200, 12, -50, Signals::Invalid, SpreadTypes::Single,
+    0, 10000 },  // 154 CABINET_CAB_LEVEL
+  { 199, Parameters::P_CAB_MIX, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 155 CABINET_MIX
 
   // - - - GAP FILTER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 201, 3, 0, 100, 0, 24, -1, 0, 0, 9600 },       // 156 GAP_FILTER_CENTER
-  { 203, 3, 0, 200, 1, 0.5f, -1, 0, 1, 7200 },     // 157 GAP_FILTER_STEREO
-  { 204, 3, 0, 100, 1, 0.5f, -1, 0, 0, 9600 },     // 158 GAP_FILTER_GAP
-  { 206, 3, 0, 16000, 1, 0.9f, 98, 0, 0, 16000 },  // 159 GAP_FILTER_RESONANCE
-  { 207, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 160 GAP_FILTER_BALANCE
-  { 209, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },       // 161 GAP_FILTER_MIX
+  { 201, Parameters::P_GAP_CNT, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 24, Signals::Invalid, SpreadTypes::Single, 0,
+    9600 },  // 156 GAP_FILTER_CENTER
+  { 203, Parameters::P_GAP_STE, ClockTypes::Slow, PolyTypes::Mono, 200, 1, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 7200 },  // 157 GAP_FILTER_STEREO
+  { 204, Parameters::P_GAP_GAP, ClockTypes::Slow, PolyTypes::Mono, 100, 1, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    0, 9600 },  // 158 GAP_FILTER_GAP
+  { 206, Parameters::P_GAP_RES, ClockTypes::Slow, PolyTypes::Mono, 16000, 1, 0.9f, Signals::GAP_RES,
+    SpreadTypes::Single, 0, 16000 },  // 159 GAP_FILTER_RESONANCE
+  { 207, Parameters::P_GAP_BAL, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 160 GAP_FILTER_BALANCE
+  { 209, Parameters::P_GAP_MIX, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 161 GAP_FILTER_MIX
 
   // - - - FLANGER  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 211, 2, 0, 8000, 4, 1, 104, 0, 1, 8000 },  // 162 FLANGER_TIME_MOD
+  { 211, Parameters::P_FLA_TMOD, ClockTypes::Fast, PolyTypes::Mono, 8000, 4, 1, Signals::FLA_TMOD, SpreadTypes::Single,
+    1, 8000 },  // 162 FLANGER_TIME_MOD
 #if test_flanger_phs == 0
-  { 213, 3, 0, 80, 0, 0, -1, 0, 0, 14400 },  // 163 FLANGER_PHASE
+  { 213, ParameterLabel::P_FLA_PHS, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 80, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 14400 },  // 163 FLANGER_PHASE
 #elif test_flanger_phs == 1
-  { 213, 2, 0, 80, 0, 0, -1, 0, 0, 14400 },     // 163 FLANGER_PHASE
+  { 213, Parameters::P_FLA_PHS, ClockTypes::Fast, PolyTypes::Mono, 80, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    14400 },  // 163 FLANGER_PHASE
 #elif test_flanger_phs == 2
-  { 213, 1, 0, 80, 0, 0, -1, 0, 0, 14400 },     // 163 FLANGER_PHASE
+  { 213, ParameterLabel::P_FLA_PHS, PARAM_CLOCK_TYPES::PARAM_AUDIO, PARAM_POLY_TYPES::PARAM_MONO, 80, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 14400 },  // 163 FLANGER_PHASE
 #endif
-  { 214, 1, 0, 16000, 4, 10, -1, 0, 0, 16000 },   // 164 FLANGER_RATE (audio)
-  { 216, 3, 0, 12500, 4, 50, -1, 0, 0, 12500 },   // 165 FLANGER_TIME
-  { 218, 3, 0, 160, 0, 0, -1, 0, 1, 8000 },       // 166 FLANGER_STEREO
-  { 219, 2, 0, 16000, 0, 0.5f, -1, 0, 1, 8000 },  // 167 FLANGER_FEEDBACK
-  { 221, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 168 FLANGER_CROSS_FEEDBACK
-  { 222, 3, 0, 200, 9, 60, -1, 0, 0, 16000 },     // 169 FLANGER_HI_CUT
-  { 223, 2, 0, 8000, 0, 0, -1, 0, 1, 8000 },      // 170 FLANGER_MIX
+  { 214, Parameters::P_FLA_RTE, ClockTypes::Audio, PolyTypes::Mono, 16000, 4, 10, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 164 FLANGER_RATE (audio)
+  { 216, Parameters::P_FLA_TIME, ClockTypes::Slow, PolyTypes::Mono, 12500, 4, 50, Signals::Invalid, SpreadTypes::Single,
+    0, 12500 },  // 165 FLANGER_TIME
+  { 218, Parameters::P_FLA_STE, ClockTypes::Slow, PolyTypes::Mono, 160, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 166 FLANGER_STEREO
+  { 219, Parameters::P_FLA_FB, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 167 FLANGER_FEEDBACK
+  { 221, Parameters::P_FLA_CFB, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 168 FLANGER_CROSS_FEEDBACK
+  { 222, Parameters::P_FLA_LPF, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 60, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 169 FLANGER_HI_CUT
+  { 223, Parameters::P_FLA_MIX, ClockTypes::Fast, PolyTypes::Mono, 8000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    8000 },  // 170 FLANGER_MIX
 #if test_flanger_env == 0
-  { 307, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 171 FLANGER_ENVELOPE
+  { 307, ParameterLabel::P_FLA_ENV, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 171 FLANGER_ENVELOPE
 #elif test_flanger_env == 1
-  { 307, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 171 FLANGER_ENVELOPE
+  { 307, ParameterLabel::P_FLA_ENV, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 171 FLANGER_ENVELOPE
 #elif test_flanger_env == 2
-  { 307, 1, 0, 16000, 0, 0, -1, 0, 0, 16000 },  // 171 FLANGER_ENVELOPE
+  { 307, Parameters::P_FLA_ENV, ClockTypes::Audio, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 171 FLANGER_ENVELOPE
 #endif
-  { 308, 3, 0, 8000, 1, 70, -1, 0, 1, 8000 },  // 172 FLANGER_ALLPASS_MOD
-  { 310, 3, 0, 100, 0, 0, -1, 0, 0, 14000 },   // 173 FLANGER_ALLPASS_TUNE
+  { 308, Parameters::P_FLA_APM, ClockTypes::Slow, PolyTypes::Mono, 8000, 1, 70, Signals::Invalid, SpreadTypes::Single,
+    1, 8000 },  // 172 FLANGER_ALLPASS_MOD
+  { 310, Parameters::P_FLA_APT, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    14000 },  // 173 FLANGER_ALLPASS_TUNE
 
   // - - - ECHO - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 225, 3, 0, 16000, 4, 2, -1, 0, 0, 16000 },   // 174 ECHO_DELAY_TIME
-  { 227, 3, 0, 200, 0, 0, -1, 0, 1, 6600 },      // 175 ECHO_STEREO
-  { 229, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 176 ECHO_FEEDBACK
-  { 231, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 177 ECHO_CROSS_FEEDBACK
-  { 232, 3, 0, 200, 9, 60, -1, 0, 0, 16000 },    // 178 ECHO_HI_CUT
-  { 233, 2, 0, 16000, 4, 1, -1, 0, 0, 16000 },   // 179 ECHO_MIX
-  { 334, 2, 0, 16000, 0, 0, 123, 0, 0, 16000 },  // 180 ECHO_SEND
+  { 225, Parameters::P_DLY_TIME, ClockTypes::Slow, PolyTypes::Mono, 16000, 4, 2, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 174 ECHO_DELAY_TIME
+  { 227, Parameters::P_DLY_STE, ClockTypes::Slow, PolyTypes::Mono, 200, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    6600 },  // 175 ECHO_STEREO
+  { 229, Parameters::P_DLY_FB, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 176 ECHO_FEEDBACK
+  { 231, Parameters::P_DLY_CFB, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 177 ECHO_CROSS_FEEDBACK
+  { 232, Parameters::P_DLY_LPF, ClockTypes::Slow, PolyTypes::Mono, 200, 9, 60, Signals::Invalid, SpreadTypes::Single, 0,
+    16000 },  // 178 ECHO_HI_CUT
+  { 233, Parameters::P_DLY_MIX, ClockTypes::Fast, PolyTypes::Mono, 16000, 4, 1, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 179 ECHO_MIX
+  { 334, Parameters::P_DLY_SND, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::DLY_SND, SpreadTypes::Single,
+    0, 16000 },  // 180 ECHO_SEND
 
 // - - - REVERB - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
 #if test_reverbParams == 0
   /* should the parameters run with fast clock? (except chorus) - see pe_defines_config.h */
-  { 235, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 181 REVERB_SIZE
-  { 237, 2, 0, 16000, 5, 0, -1, 0, 0, 16000 },   // 182 REVERB_PRE_DELAY
-  { 238, 2, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 183 REVERB_COLOR
-  { 240, 3, 0, 16000, 4, 1, 130, 0, 0, 16000 },  // 184 REVERB_CHORUS
+  { 235, ParameterLabel::P_REV_SIZE, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 181 REVERB_SIZE
+  { 237, ParameterLabel::P_REV_PRE, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 5, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 182 REVERB_PRE_DELAY
+  { 238, ParameterLabel::P_REV_COL, PARAM_CLOCK_TYPES::PARAM_FAST, PARAM_POLY_TYPES::PARAM_MONO, 16000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 183 REVERB_COLOR
+  { 240, ParameterLabel::P_REV_CHO, PARAM_CLOCK_TYPES::PARAM_SLOW, PARAM_POLY_TYPES::PARAM_MONO, 16000, 4, 1,
+    SignalLabel::REV_CHO, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 16000 },  // 184 REVERB_CHORUS
 #elif test_reverbParams == 1
   /* should the parameters run with slow clock? - see pe_defines_config.h */
-  { 235, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 181 REVERB_SIZE
-  { 237, 3, 0, 16000, 5, 0, -1, 0, 0, 16000 },   // 182 REVERB_PRE_DELAY
-  { 238, 3, 0, 16000, 0, 0, -1, 0, 0, 16000 },   // 183 REVERB_COLOR
-  { 240, 3, 0, 16000, 4, 1, 130, 0, 0, 16000 },  // 184 REVERB_CHORUS
+  { 235, Parameters::P_REV_SIZE, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 181 REVERB_SIZE
+  { 237, Parameters::P_REV_PRE, ClockTypes::Slow, PolyTypes::Mono, 16000, 5, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 182 REVERB_PRE_DELAY
+  { 238, Parameters::P_REV_COL, ClockTypes::Slow, PolyTypes::Mono, 16000, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 183 REVERB_COLOR
+  { 240, Parameters::P_REV_CHO, ClockTypes::Slow, PolyTypes::Mono, 16000, 4, 1, Signals::REV_CHO, SpreadTypes::Single,
+    0, 16000 },  // 184 REVERB_CHORUS
 #endif
-  { 241, 2, 0, 16000, 4, 1, -1, 0, 0, 16000 },   // 185 REVERB_MIX
-  { 336, 2, 0, 16000, 0, 0, 133, 0, 0, 16000 },  // 186 REVERB_SEND
+  { 241, Parameters::P_REV_MIX, ClockTypes::Fast, PolyTypes::Mono, 16000, 4, 1, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 185 REVERB_MIX
+  { 336, Parameters::P_REV_SND, ClockTypes::Fast, PolyTypes::Mono, 16000, 0, 0, Signals::REV_SND, SpreadTypes::Single,
+    0, 16000 },  // 186 REVERB_SEND
 
   // - - - MASTER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 247, 2, 0, 16000, 4, 4, 134, 0, 0, 16000 },  // 187 MASTER_VOLUME
-  { 248, 3, 0, 100, 0, 0, -1, 0, 1, 4800 },      // 188 MASTER_TUNE
-  { 338, 0, 0, 1, 0, 0, -1, 0, 1, 48 },          // 189 NOTE_SHIFT
+  { 247, Parameters::P_MA_V, ClockTypes::Fast, PolyTypes::Mono, 16000, 4, 4, Signals::MST_VOL, SpreadTypes::Single, 0,
+    16000 },  // 187 MASTER_VOLUME
+  { 248, Parameters::P_MA_T, ClockTypes::Slow, PolyTypes::Mono, 100, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    4800 },  // 188 MASTER_TUNE
+  { 338, Parameters::P_MA_SH, ClockTypes::Sync, PolyTypes::Mono, 1, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    48 },  // 189 NOTE_SHIFT
 
   // - - - UNISON - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
-  { 249, 0, 0, 1, 0, -1, -1, 0, 0, 11 },           // 190 UNISON_VOICES
-  { 250, 3, 0, 1000, 0, 0, -1, 0, 0, 12000 },      // 191 UNISON_DETUNE
-  { 252, 1, 0, 14400, 0, 0, -1, 0, 0, 14400 },     // 192 UNISON_PHASE
-  { 253, 2, 0, 16000, 1, 0.5f, -1, 0, 0, 16000 },  // 193 UNISON_PAN
+  { 249, Parameters::P_UN_V, ClockTypes::Sync, PolyTypes::Mono, 1, 0, -1, Signals::Invalid, SpreadTypes::Single, 0,
+    11 },  // 190 UNISON_VOICES
+  { 250, Parameters::P_UN_DET, ClockTypes::Slow, PolyTypes::Mono, 1000, 0, 0, Signals::Invalid, SpreadTypes::Single, 0,
+    12000 },  // 191 UNISON_DETUNE
+  { 252, Parameters::P_UN_PHS, ClockTypes::Audio, PolyTypes::Mono, 14400, 0, 0, Signals::Invalid, SpreadTypes::Single,
+    0, 14400 },  // 192 UNISON_PHASE
+  { 253, Parameters::P_UN_PAN, ClockTypes::Fast, PolyTypes::Mono, 16000, 1, 0.5f, Signals::Invalid, SpreadTypes::Single,
+    0, 16000 },  // 193 UNISON_PAN
 
 // - - - POLY KEY EVENT - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //       ID      CLOCK   POLY    RANGE   SCALE   (ARG)   POST    SPREAD  POL     FACTOR
 #if test_milestone == 150
-  { 400, 0, 1, 14400, 0, 0, -1, 0, 1, 7200 },  // 194 KEY_UNISON_PHASE
-  { 406, 0, 1, 1000, 0, 0, -1, 0, 1, 1000 },   // 195 KEY_NOTE_PITCH
-  { 407, 0, 1, 8000, 0, 0, -1, 0, 1, 8000 },   // 196 KEY_VOICE_PAN
-  { 409, 0, 1, 1, 0, 0, -1, 0, 0, 1 }          // 197 KEY_VOICE_STEAL
+  { 400, ParameterLabel::P_KEY_PH, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 14400, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 7200 },  // 194 KEY_UNISON_PHASE
+  { 406, ParameterLabel::P_KEY_NP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 1000 },  // 195 KEY_NOTE_PITCH
+  { 407, ParameterLabel::P_KEY_VP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 8000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 8000 },  // 196 KEY_VOICE_PAN
+  { 409, ParameterLabel::P_KEY_VS, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 }  // 197 KEY_VOICE_STEAL
 #elif test_milestone == 155
-  { 416, 0, 1, 1000, 0, 0, -1, 0, 1, 1000 },     // 194 KEY_BASE_PITCH
-  { 417, 0, 1, 1, 0, 0, -1, 0, 0, 1 },           // 195 KEY_UNISON_IDX
-  { 418, 0, 1, 1, 0, 0, -1, 0, 0, 1 }            // 196 KEY_VOICE_STEAL
+  { 416, ParameterLabel::P_KEY_BP, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1000, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 1, 1000 },  // 194 KEY_BASE_PITCH
+  { 417, ParameterLabel::P_KEY_IDX, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 },  // 195 KEY_UNISON_IDX
+  { 418, ParameterLabel::P_KEY_STL, PARAM_CLOCK_TYPES::PARAM_SYNC, PARAM_POLY_TYPES::PARAM_POLY, 1, 0, 0,
+    SignalLabel::Invalid, PARAM_SPREAD_TYPES::PARAM_SINGLE, 0, 1 }  // 196 KEY_VOICE_STEAL
 #elif test_milestone == 156
-  { 416, 0, 1, 1000, 0, 0, -1, 0, 1, 1000 }     // 194 KEY_BASE_PITCH
+  { 416, Parameters::P_KEY_BP, ClockTypes::Sync, PolyTypes::Poly, 1000, 0, 0, Signals::Invalid, SpreadTypes::Single, 1,
+    1000 }  // 194 KEY_BASE_PITCH
 #endif
 
 };
 
 /* Utility Parameters */
 
-const float utility_definition[sig_number_of_utilities][3] = {
+struct UtilityDefinition
+{
+  uint32_t range;
+  uint32_t scale;
+  float scaleArg;
+};
+
+const UtilityDefinition utility_definition[sig_number_of_utilities] = {
+
   //       RANGE   SCALE   (ARG)
   { 4096, 0, 0 },   // velocity definition (for now: tcd range 4096)
   { 100, 0, 400 },  // pitch reference (A3)

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_testconfig.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_testconfig.h
@@ -229,255 +229,255 @@ const uint32_t testMidiMapping[testMidiModes][128] = {
   },
 };
 
-const ParameterLabel testParamRouting[25][24] = {
+const Parameters testParamRouting[25][24] = {
   /* IGNORE group */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* ENV A */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_EA_ATT,  ParameterLabel::P_EA_DEC1, ParameterLabel::P_EA_BP,   ParameterLabel::P_EA_DEC2,
-      ParameterLabel::P_EA_SUS,  ParameterLabel::P_EA_REL,  ParameterLabel::P_EA_GAIN, ParameterLabel::P_EA_LV,
-      ParameterLabel::P_EA_AV,   ParameterLabel::P_EA_AC,   ParameterLabel::P_EA_D1V,  ParameterLabel::P_EA_D2V,
-      ParameterLabel::P_EA_SPL,  ParameterLabel::P_EA_RV,   ParameterLabel::P_EA_LKT,  ParameterLabel::P_EA_TKT,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_EA_ATT,  Parameters::P_EA_DEC1, Parameters::P_EA_BP,   Parameters::P_EA_DEC2,
+      Parameters::P_EA_SUS,  Parameters::P_EA_REL,  Parameters::P_EA_GAIN, Parameters::P_EA_LV,
+      Parameters::P_EA_AV,   Parameters::P_EA_AC,   Parameters::P_EA_D1V,  Parameters::P_EA_D2V,
+      Parameters::P_EA_SPL,  Parameters::P_EA_RV,   Parameters::P_EA_LKT,  Parameters::P_EA_TKT,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* ENV B */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_EB_ATT,  ParameterLabel::P_EB_DEC1, ParameterLabel::P_EB_BP,   ParameterLabel::P_EB_DEC2,
-      ParameterLabel::P_EB_SUS,  ParameterLabel::P_EB_REL,  ParameterLabel::P_EB_GAIN, ParameterLabel::P_EB_LV,
-      ParameterLabel::P_EB_AV,   ParameterLabel::P_EB_AC,   ParameterLabel::P_EB_D1V,  ParameterLabel::P_EB_D2V,
-      ParameterLabel::P_EB_SPL,  ParameterLabel::P_EB_RV,   ParameterLabel::P_EB_LKT,  ParameterLabel::P_EB_TKT,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_EB_ATT,  Parameters::P_EB_DEC1, Parameters::P_EB_BP,   Parameters::P_EB_DEC2,
+      Parameters::P_EB_SUS,  Parameters::P_EB_REL,  Parameters::P_EB_GAIN, Parameters::P_EB_LV,
+      Parameters::P_EB_AV,   Parameters::P_EB_AC,   Parameters::P_EB_D1V,  Parameters::P_EB_D2V,
+      Parameters::P_EB_SPL,  Parameters::P_EB_RV,   Parameters::P_EB_LKT,  Parameters::P_EB_TKT,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* ENV C */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_EC_ATT,  ParameterLabel::P_EC_DEC1, ParameterLabel::P_EC_BP,   ParameterLabel::P_EC_DEC2,
-      ParameterLabel::P_EC_SUS,  ParameterLabel::P_EC_REL,  ParameterLabel::P_INVALID, ParameterLabel::P_EC_LV,
-      ParameterLabel::P_EC_AV,   ParameterLabel::P_EC_AC,   ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_EC_RH,   ParameterLabel::P_EC_RV,   ParameterLabel::P_EC_LKT,  ParameterLabel::P_EC_TKT,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_EC_ATT,  Parameters::P_EC_DEC1, Parameters::P_EC_BP,   Parameters::P_EC_DEC2,
+      Parameters::P_EC_SUS,  Parameters::P_EC_REL,  Parameters::P_INVALID, Parameters::P_EC_LV,
+      Parameters::P_EC_AV,   Parameters::P_EC_AC,   Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_EC_RH,   Parameters::P_EC_RV,   Parameters::P_EC_LKT,  Parameters::P_EC_TKT,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* OSC A */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_OA_P,     ParameterLabel::P_OA_PKT,  ParameterLabel::P_OA_PEC,   ParameterLabel::P_OA_F,
-      ParameterLabel::P_OA_FEC,   ParameterLabel::P_OA_PMS,  ParameterLabel::P_OA_PMSEA, ParameterLabel::P_OA_PMSSH,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_OA_PHS,  ParameterLabel::P_OA_CHI,   ParameterLabel::P_OA_PMF,
-      ParameterLabel::P_OA_PMFEC, ParameterLabel::P_OA_PMB,  ParameterLabel::P_OA_PMBEB, ParameterLabel::P_OA_PMBSH,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
+      Parameters::P_OA_P,     Parameters::P_OA_PKT,  Parameters::P_OA_PEC,   Parameters::P_OA_F,
+      Parameters::P_OA_FEC,   Parameters::P_OA_PMS,  Parameters::P_OA_PMSEA, Parameters::P_OA_PMSSH,
+      Parameters::P_INVALID,  Parameters::P_OA_PHS,  Parameters::P_OA_CHI,   Parameters::P_OA_PMF,
+      Parameters::P_OA_PMFEC, Parameters::P_OA_PMB,  Parameters::P_OA_PMBEB, Parameters::P_OA_PMBSH,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,
   },
   /* SHP A */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_SA_DRV,  ParameterLabel::P_SA_FLD,  ParameterLabel::P_SA_ASM,  ParameterLabel::P_SA_MIX,
-      ParameterLabel::P_SA_FBM,  ParameterLabel::P_SA_RM,   ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_SA_DEA,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_SA_FBEC, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_SA_DRV,  Parameters::P_SA_FLD,  Parameters::P_SA_ASM,  Parameters::P_SA_MIX,
+      Parameters::P_SA_FBM,  Parameters::P_SA_RM,   Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_SA_DEA,  Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_SA_FBEC, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* OSC B */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_OB_P,     ParameterLabel::P_OB_PKT,  ParameterLabel::P_OB_PEC,   ParameterLabel::P_OB_F,
-      ParameterLabel::P_OB_FEC,   ParameterLabel::P_OB_PMS,  ParameterLabel::P_OB_PMSEB, ParameterLabel::P_OB_PMSSH,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_OB_PHS,  ParameterLabel::P_OB_CHI,   ParameterLabel::P_OB_PMF,
-      ParameterLabel::P_OB_PMFEC, ParameterLabel::P_OB_PMA,  ParameterLabel::P_OB_PMAEA, ParameterLabel::P_OB_PMASH,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
+      Parameters::P_OB_P,     Parameters::P_OB_PKT,  Parameters::P_OB_PEC,   Parameters::P_OB_F,
+      Parameters::P_OB_FEC,   Parameters::P_OB_PMS,  Parameters::P_OB_PMSEB, Parameters::P_OB_PMSSH,
+      Parameters::P_INVALID,  Parameters::P_OB_PHS,  Parameters::P_OB_CHI,   Parameters::P_OB_PMF,
+      Parameters::P_OB_PMFEC, Parameters::P_OB_PMA,  Parameters::P_OB_PMAEA, Parameters::P_OB_PMASH,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,
   },
   /* SHP B */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_SB_DRV,  ParameterLabel::P_SB_FLD,  ParameterLabel::P_SB_ASM,  ParameterLabel::P_SB_MIX,
-      ParameterLabel::P_SB_FBM,  ParameterLabel::P_SB_RM,   ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_SB_DEB,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_SB_FBEC, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_SB_DRV,  Parameters::P_SB_FLD,  Parameters::P_SB_ASM,  Parameters::P_SB_MIX,
+      Parameters::P_SB_FBM,  Parameters::P_SB_RM,   Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_SB_DEB,  Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_SB_FBEC, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* OUT MIX */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_OM_AL,   ParameterLabel::P_OM_BL,   ParameterLabel::P_OM_CL,   ParameterLabel::P_OM_SL,
-      ParameterLabel::P_OM_LVL,  ParameterLabel::P_OM_DRV,  ParameterLabel::P_OM_FLD,  ParameterLabel::P_OM_ASM,
-      ParameterLabel::P_OM_AP,   ParameterLabel::P_OM_BP,   ParameterLabel::P_OM_CP,   ParameterLabel::P_OM_SP,
-      ParameterLabel::P_OM_KP,   ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_OM_AL,   Parameters::P_OM_BL,   Parameters::P_OM_CL,   Parameters::P_OM_SL,
+      Parameters::P_OM_LVL,  Parameters::P_OM_DRV,  Parameters::P_OM_FLD,  Parameters::P_OM_ASM,
+      Parameters::P_OM_AP,   Parameters::P_OM_BP,   Parameters::P_OM_CP,   Parameters::P_OM_SP,
+      Parameters::P_OM_KP,   Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* COMB FILTER */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_CMB_AB,  ParameterLabel::P_CMB_P,    ParameterLabel::P_CMB_PKT,  ParameterLabel::P_CMB_PEC,
-      ParameterLabel::P_CMB_D,   ParameterLabel::P_CMB_DKT,  ParameterLabel::P_CMB_DG,   ParameterLabel::P_CMB_PM,
-      ParameterLabel::P_CMB_APT, ParameterLabel::P_CMB_APKT, ParameterLabel::P_CMB_APEC, ParameterLabel::P_CMB_APR,
-      ParameterLabel::P_CMB_LP,  ParameterLabel::P_CMB_LPKT, ParameterLabel::P_CMB_LPEC, ParameterLabel::P_CMB_PMAB,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID,
+      Parameters::P_CMB_AB,  Parameters::P_CMB_P,    Parameters::P_CMB_PKT,  Parameters::P_CMB_PEC,
+      Parameters::P_CMB_D,   Parameters::P_CMB_DKT,  Parameters::P_CMB_DG,   Parameters::P_CMB_PM,
+      Parameters::P_CMB_APT, Parameters::P_CMB_APKT, Parameters::P_CMB_APEC, Parameters::P_CMB_APR,
+      Parameters::P_CMB_LP,  Parameters::P_CMB_LPKT, Parameters::P_CMB_LPEC, Parameters::P_CMB_PMAB,
+      Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,  Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID,  Parameters::P_INVALID,
   },
   /* STATE VARIABLE FILTER */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_SVF_AB,  ParameterLabel::P_SVF_CUT, ParameterLabel::P_SVF_CKT, ParameterLabel::P_SVF_CEC,
-      ParameterLabel::P_INVALID, ParameterLabel::P_SVF_SPR, ParameterLabel::P_SVF_LBH, ParameterLabel::P_SVF_FM,
-      ParameterLabel::P_SVF_CMB, ParameterLabel::P_SVF_RES, ParameterLabel::P_SVF_RKT, ParameterLabel::P_SVF_REC,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_SVF_PAR, ParameterLabel::P_SVF_FMAB,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_SVF_AB,  Parameters::P_SVF_CUT, Parameters::P_SVF_CKT, Parameters::P_SVF_CEC,
+      Parameters::P_INVALID, Parameters::P_SVF_SPR, Parameters::P_SVF_LBH, Parameters::P_SVF_FM,
+      Parameters::P_SVF_CMB, Parameters::P_SVF_RES, Parameters::P_SVF_RKT, Parameters::P_SVF_REC,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_SVF_PAR, Parameters::P_SVF_FMAB,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* CABINET,     GAP FILTER */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_CAB_DRV, ParameterLabel::P_CAB_FLD, ParameterLabel::P_CAB_ASM, ParameterLabel::P_CAB_TILT,
-      ParameterLabel::P_CAB_LPF, ParameterLabel::P_CAB_HPF, ParameterLabel::P_CAB_LVL, ParameterLabel::P_CAB_MIX,
-      ParameterLabel::P_GAP_CNT, ParameterLabel::P_GAP_STE, ParameterLabel::P_GAP_GAP, ParameterLabel::P_GAP_RES,
-      ParameterLabel::P_GAP_BAL, ParameterLabel::P_GAP_MIX, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_CAB_DRV, Parameters::P_CAB_FLD, Parameters::P_CAB_ASM, Parameters::P_CAB_TILT,
+      Parameters::P_CAB_LPF, Parameters::P_CAB_HPF, Parameters::P_CAB_LVL, Parameters::P_CAB_MIX,
+      Parameters::P_GAP_CNT, Parameters::P_GAP_STE, Parameters::P_GAP_GAP, Parameters::P_GAP_RES,
+      Parameters::P_GAP_BAL, Parameters::P_GAP_MIX, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* FLANGER */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_FLA_TMOD, ParameterLabel::P_FLA_PHS, ParameterLabel::P_FLA_RTE, ParameterLabel::P_FLA_TIME,
-      ParameterLabel::P_FLA_STE,  ParameterLabel::P_FLA_FB,  ParameterLabel::P_FLA_CFB, ParameterLabel::P_FLA_MIX,
-      ParameterLabel::P_FLA_ENV,  ParameterLabel::P_FLA_APM, ParameterLabel::P_FLA_APT, ParameterLabel::P_FLA_LPF,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_FLA_TMOD, Parameters::P_FLA_PHS, Parameters::P_FLA_RTE, Parameters::P_FLA_TIME,
+      Parameters::P_FLA_STE,  Parameters::P_FLA_FB,  Parameters::P_FLA_CFB, Parameters::P_FLA_MIX,
+      Parameters::P_FLA_ENV,  Parameters::P_FLA_APM, Parameters::P_FLA_APT, Parameters::P_FLA_LPF,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* ECHO,     REVERB */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_DLY_SND, ParameterLabel::P_DLY_TIME, ParameterLabel::P_DLY_STE, ParameterLabel::P_DLY_FB,
-      ParameterLabel::P_DLY_CFB, ParameterLabel::P_DLY_LPF,  ParameterLabel::P_DLY_MIX, ParameterLabel::P_INVALID,
-      ParameterLabel::P_REV_SND, ParameterLabel::P_REV_SIZE, ParameterLabel::P_REV_PRE, ParameterLabel::P_REV_COL,
-      ParameterLabel::P_REV_CHO, ParameterLabel::P_REV_MIX,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,  ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_DLY_SND, Parameters::P_DLY_TIME, Parameters::P_DLY_STE, Parameters::P_DLY_FB,
+      Parameters::P_DLY_CFB, Parameters::P_DLY_LPF,  Parameters::P_DLY_MIX, Parameters::P_INVALID,
+      Parameters::P_REV_SND, Parameters::P_REV_SIZE, Parameters::P_REV_PRE, Parameters::P_REV_COL,
+      Parameters::P_REV_CHO, Parameters::P_REV_MIX,  Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID,  Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* FEEDBACK MIX */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_FBM_CMB, ParameterLabel::P_FBM_SVF, ParameterLabel::P_FBM_FX,  ParameterLabel::P_FBM_REV,
-      ParameterLabel::P_FBM_DRV, ParameterLabel::P_FBM_FLD, ParameterLabel::P_FBM_ASM, ParameterLabel::P_FBM_LVL,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_FBM_LKT,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_FBM_CMB, Parameters::P_FBM_SVF, Parameters::P_FBM_FX,  Parameters::P_FBM_REV,
+      Parameters::P_FBM_DRV, Parameters::P_FBM_FLD, Parameters::P_FBM_ASM, Parameters::P_FBM_LVL,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_FBM_LKT,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* MASTER,     UNISON */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_MA_V,    ParameterLabel::P_MA_T,    ParameterLabel::P_MA_SH,   ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_UN_V,    ParameterLabel::P_UN_DET,  ParameterLabel::P_UN_PHS,  ParameterLabel::P_UN_PAN,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_MA_V,    Parameters::P_MA_T,    Parameters::P_MA_SH,   Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_UN_V,    Parameters::P_UN_DET,  Parameters::P_UN_PHS,  Parameters::P_UN_PAN,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
   /* (none) */
   {
       /*  0             1             2             3             4             5             6             7            */
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
-      ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID, ParameterLabel::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
+      Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID, Parameters::P_INVALID,
   },
 };

--- a/audio-engine/src/synth/c15-audio-engine/pe_utilities.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_utilities.h
@@ -18,24 +18,24 @@
 #include "pe_defines_labels.h"
 
 /* improving code readability */
-enum class PARAM_CLOCK_TYPES
+enum class ClockTypes
 {
-  PARAM_SYNC = 0,
-  PARAM_AUDIO = 1,
-  PARAM_FAST = 2,
-  PARAM_SLOW = 3
+  Sync = 0,
+  Audio = 1,
+  Fast = 2,
+  Slow = 3
 };
 
-enum class PARAM_POLY_TYPES
+enum class PolyTypes
 {
-  PARAM_MONO = 0,
-  PARAM_POLY = 1
+  Mono = 0,
+  Poly = 1
 };
 
-enum class PARAM_SPREAD_TYPES
+enum class SpreadTypes
 {
-  PARAM_SINGLE = 0,
-  PARAM_SPREAD = 1
+  Single = 0,
+  Spread = 1
 };
 
 template <typename T> struct id_list
@@ -89,7 +89,7 @@ template <typename T> struct polyDual_id_list
     }
   }
 
-  void add(const PARAM_POLY_TYPES _polyId, const uint32_t _listId, const T _id)
+  void add(const PolyTypes _polyId, const uint32_t _listId, const T _id)
   {
     m_data[static_cast<uint32_t>(_polyId)].add(_listId, _id);
   }
@@ -109,7 +109,7 @@ template <typename T> struct poly_id_list
     }
   }
 
-  void add(const PARAM_POLY_TYPES _polyId, const T _id)
+  void add(const PolyTypes _polyId, const T _id)
   {
     m_data[static_cast<uint32_t>(_polyId)].add(_id);
   }
@@ -136,12 +136,12 @@ struct dual_env_id_list
 
 struct new_clock_id_list
 {
-  inline void add(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType, uint32_t _id)
+  inline void add(ClockTypes _clockType, PolyTypes _polyType, uint32_t _id)
   {
     m_data[static_cast<int>(_clockType)][static_cast<int>(_polyType)].push_back(_id);
   }
 
-  inline const std::vector<uint32_t> &get(PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType) const
+  inline const std::vector<uint32_t> &get(ClockTypes _clockType, PolyTypes _polyType) const
   {
     return m_data[static_cast<int>(_clockType)][static_cast<int>(_polyType)];
   }
@@ -152,19 +152,17 @@ struct new_clock_id_list
 
 struct new_dual_clock_id_list
 {
-  inline void add(PARAM_SPREAD_TYPES _spreadType, PARAM_CLOCK_TYPES _clockType, PARAM_POLY_TYPES _polyType,
-                  ParameterLabel _id)
+  inline void add(SpreadTypes _spreadType, ClockTypes _clockType, PolyTypes _polyType, Parameters _id)
   {
     m_data[static_cast<uint32_t>(_spreadType)][static_cast<int>(_clockType)][static_cast<int>(_polyType)].push_back(
         _id);
   }
 
-  inline const std::vector<ParameterLabel> &get(PARAM_SPREAD_TYPES _spreadType, PARAM_CLOCK_TYPES _clockType,
-                                                PARAM_POLY_TYPES _polyType) const
+  inline const std::vector<Parameters> &get(SpreadTypes _spreadType, ClockTypes _clockType, PolyTypes _polyType) const
   {
     return m_data[static_cast<uint32_t>(_spreadType)][static_cast<int>(_clockType)][static_cast<int>(_polyType)];
   }
 
  private:
-  std::vector<ParameterLabel> m_data[dsp_spread_types][dsp_clock_types][dsp_poly_types];
+  std::vector<Parameters> m_data[dsp_spread_types][dsp_clock_types][dsp_poly_types];
 };

--- a/audio-engine/src/synth/c15-audio-engine/tcd_decoder.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/tcd_decoder.cpp
@@ -86,7 +86,7 @@ uint32_t decoder::selectionEvent(const uint32_t _from, const uint32_t _to, const
 
 /* decoder list traversal                                                   -- recall, key event */
 
-ParameterLabel decoder::traverseRecall()
+Parameters decoder::traverseRecall()
 {
   /* monophonic implementation                                            -- compatible with current Reaktor5 Rendering Engine */
   const auto id = m_listTraversal[0].m_data[m_listIndex];         // get current
@@ -94,7 +94,7 @@ ParameterLabel decoder::traverseRecall()
   return id;                                                      // return current
 }
 
-ParameterLabel decoder::traverseKeyEvent()
+Parameters decoder::traverseKeyEvent()
 {
   /* polyphonic implementation                                            -- Voice selection needs to be done by sender for first Voice, then it automatically raises for Unison clusters */
   const auto id = m_listTraversal[1].m_data[m_listIndex];         // get current

--- a/audio-engine/src/synth/c15-audio-engine/tcd_decoder.h
+++ b/audio-engine/src/synth/c15-audio-engine/tcd_decoder.h
@@ -35,8 +35,8 @@ struct decoder
   int32_t m_event[5];                      // TCD Selection Event
 
   dual_id_list<uint32_t> m_selectedVoices;                       // ID List of selected Voices
-  polyDual_id_list<ParameterLabel> m_selectedParams;             // ID List of selected Parameters
-  id_list<ParameterLabel> m_listTraversal[lst_number_of_lists];  // ID Lists for Preset Recall and Key Events
+  polyDual_id_list<Parameters> m_selectedParams;             // ID List of selected Parameters
+  id_list<Parameters> m_listTraversal[lst_number_of_lists];  // ID Lists for Preset Recall and Key Events
 
   /* decoder functions */
 
@@ -55,6 +55,6 @@ struct decoder
   uint32_t selectionEvent(const uint32_t _from, const uint32_t _to,
                           const uint32_t _id);  // TCD Voice and Parameter selection event evaluation
 
-  ParameterLabel traverseRecall();    // TCD List traversal: Preset Recall Events
-  ParameterLabel traverseKeyEvent();  // TCD List traversal: Key Events
+  Parameters traverseRecall();    // TCD List traversal: Preset Recall Events
+  Parameters traverseKeyEvent();  // TCD List traversal: Key Events
 };


### PR DESCRIPTION
- Make parameter info type safe
- Rename PARAM_XYZ_TYPES::XYZ_FOO into Xyz::Foo to have less clutter and improve readability