### PR TITLE
change parameter copyTo to presetParam to take quantized clipped valu…

### DIFF
--- a/playground/src/parameters/Parameter.cpp
+++ b/playground/src/parameters/Parameter.cpp
@@ -181,7 +181,7 @@ void Parameter::copyFrom(UNDO::Transaction *transaction, const PresetParameter *
 
 void Parameter::copyTo(UNDO::Transaction *transaction, PresetParameter *other) const
 {
-  other->setValue(transaction, getValue().getRawValue());
+  other->setValue(transaction, getValue().getQuantizedClipped());
 }
 
 void Parameter::undoableSetDefaultValue(UNDO::Transaction *transaction, const PresetParameter *value)


### PR DESCRIPTION
…e instead of raw value to prevent saving invalid values into recall.

#909 