### PR TITLE
[dsp_optimization] fixed glitchy pitch behavior for key down and note shift

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -823,6 +823,7 @@ void dsp_host::keyApply(uint32_t _voiceId)
 
 void dsp_host::keyUp156(const float _velocity)
 {
+#if test_preload_update != 2
   uint32_t voiceId = m_decoder.m_voiceFrom;
   const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
 
@@ -833,10 +834,44 @@ void dsp_host::keyUp156(const float _velocity)
   }
 
   preloadUpdate(2, 0);
+#else
+    // preparation
+    uint32_t voiceId = m_decoder.m_voiceFrom;
+    const uint32_t uVoice = static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
+    const uint32_t unisonVoices = 1 + uVoice;
+    uint32_t index = m_params.getHead(Parameters::P_KEY_BP).m_index + voiceId;
+    const float velocity = m_params.scale(
+                            m_params.m_utilities[0].m_scaleId,
+                            m_params.m_utilities[0].m_scaleArg,
+                            _velocity * m_params.m_utilities[0].m_normalize);
+    m_params.m_event.m_mono.m_velocity = velocity;
+    m_params.m_event.m_mono.m_type = 0;
+    // disable preload
+    m_params.getBody(index).m_preload = 0;
+    m_params.m_preload = 0;
+    m_decoder.m_listId = 0;
+    // unison loop
+    for(uint32_t v = 0; v < unisonVoices; v++)
+    {
+        m_params.m_event.m_poly[voiceId].m_velocity = velocity;
+        m_params.m_event.m_poly[voiceId].m_type = 0;
+        float notePitch = m_params.getBody(index).m_value
+            + (m_params.getParameterValue(Parameters::P_UN_DET) * m_params.m_unison_detune[uVoice][v])
+            + m_params.getParameterValue(Parameters::P_MA_T) + m_params.m_note_shift[voiceId];
+        m_params.newEnvUpdateStop(voiceId, notePitch, velocity);
+        // increment voice id
+        voiceId++;
+        index++;
+    }
+#if test_flanger_env_legato == 1
+    m_params.m_event.m_active--;
+#endif
+#endif
 }
 
 void dsp_host::keyDown156(const float _velocity)
 {
+#if test_preload_update != 2
   uint32_t voiceId = m_decoder.m_voiceFrom;
   const uint32_t unisonVoices = 1 + static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
   const uint32_t index = m_params.getHead(Parameters::P_KEY_BP).m_index + voiceId;
@@ -855,6 +890,83 @@ void dsp_host::keyDown156(const float _velocity)
   }
 
   preloadUpdate(2, 0);
+#else
+    // preparation
+    uint32_t voiceId = m_decoder.m_voiceFrom;
+    const uint32_t uVoice = static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_UN_V));
+    const uint32_t unisonVoices = 1 + uVoice;
+    uint32_t index = m_params.getHead(Parameters::P_KEY_BP).m_index + voiceId;
+    const float pitch = m_params.getBody(index).m_dest;
+    const float velocity = m_params.scale(
+                            m_params.m_utilities[0].m_scaleId,
+                            m_params.m_utilities[0].m_scaleArg,
+                            _velocity * m_params.m_utilities[0].m_normalize);
+    m_params.m_event.m_mono.m_velocity = velocity;
+    m_params.m_event.m_mono.m_type = 1;
+    // disable preload
+    m_params.getBody(index).m_preload = 0;
+    m_params.m_preload = 0;
+    m_decoder.m_listId = 0;
+    // unison loop
+    for(uint32_t v = 0; v < unisonVoices; v++)
+    {
+        m_params.m_note_shift[voiceId] = m_params.getParameterValue(Parameters::P_MA_SH);
+        m_params.getBody(index).m_value = pitch;
+        m_params.m_unison_index[voiceId] = v;
+        m_params.m_event.m_poly[voiceId].m_velocity = velocity;
+        m_params.m_event.m_poly[voiceId].m_type = 1;
+        float notePitch = pitch
+            + (m_params.getParameterValue(Parameters::P_UN_DET) * m_params.m_unison_detune[uVoice][v])
+            + m_params.getParameterValue(Parameters::P_MA_T) + m_params.m_note_shift[voiceId];
+        m_params.postProcessPoly_key(m_parameters, voiceId);
+        setPolySlowFilterCoeffs(m_parameters, voiceId);
+        m_combfilter.setDelaySmoother(voiceId);
+
+        //
+#if test_milestone < 156
+        if(static_cast<uint32_t>(m_params.getParameterValue(Parameters::P_KEY_VS)) == 1)
+        {
+          /* AUDIO_ENGINE: trigger voice-steal */
+        }
+        else
+        {
+          /* AUDIO_ENGINE: trigger non-voice-steal */
+        }
+#if test_milestone == 150
+        const float startPhase = m_params.getParameterValue(Parameters::P_KEY_PH, voiceId);
+#else
+        const float startPhase = 0.f;
+#endif
+#elif test_milestone == 156
+        if(m_stolen == 1)
+        {
+          /* AUDIO_ENGINE: trigger voice-steal */
+        }
+        else
+        {
+          /* AUDIO_ENGINE: trigger non-voice-steal */
+        }
+        const float startPhase = 0.f;
+#endif
+        m_soundgenerator.resetPhase(startPhase, voiceId);
+        m_params.newEnvUpdateStart(voiceId, notePitch, velocity);
+        // increment voice id
+        voiceId++;
+        index++;
+    }
+    // keyApplyMono
+#if test_flanger_env_legato == 0
+    m_params.m_new_envelopes.m_env_f.setSegmentDest(0, 1, velocity);
+    m_params.m_new_envelopes.m_env_f.start(0);
+#elif test_flanger_env_legato == 1
+    if(m_params.m_event.m_active == 0)
+    {
+        m_params.m_new_envelopes.m_env_f.setSegmentDest(0, 1, velocity);
+        m_params.m_new_envelopes.m_env_f.start(0);
+    }
+    m_params.m_event.m_active++;
+#endif
+#endif
 }
 
 #endif

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -861,12 +861,13 @@ void dsp_host::keyUp156(const float _velocity)
      * !! !! !! **/
     for(uint32_t v = 0; v < unisonVoices; v++)
     {
-        //m_params.m_event.m_poly[voiceId].m_velocity = velocity;
-        //m_params.m_event.m_poly[voiceId].m_type = 0;
+        const uint32_t voicePos = voiceId + v;
+        //m_params.m_event.m_poly[voicePos].m_velocity = velocity;
+        //m_params.m_event.m_poly[voicePos].m_type = 0;
         float notePitch = m_params.getBody(index + v).m_value
             + (uniDetune * m_params.m_unison_detune[uVoice][v])
-            + masterTune + m_params.m_note_shift[voiceId + v];
-        m_params.newEnvUpdateStop(voiceId + v, notePitch, velocity);
+            + masterTune + m_params.m_note_shift[voicePos];
+        m_params.newEnvUpdateStop(voicePos, notePitch, velocity);
     }
 #if test_flanger_env_legato == 1
     m_params.m_event.m_active--;
@@ -924,17 +925,18 @@ void dsp_host::keyDown156(const float _velocity)
      * !! !! !! **/
     for(uint32_t v = 0; v < unisonVoices; v++)
     {
-        m_params.m_note_shift[voiceId + v] = noteShift;
+        const uint32_t voicePos = voiceId + v;
+        m_params.m_note_shift[voicePos] = noteShift;
         m_params.getBody(index + v).m_value = pitch;
-        m_params.m_unison_index[voiceId + v] = v;
-        //m_params.m_event.m_poly[voiceId].m_velocity = velocity;
-        //m_params.m_event.m_poly[voiceId].m_type = 1;
+        m_params.m_unison_index[voicePos] = v;
+        //m_params.m_event.m_poly[voicePos].m_velocity = velocity;
+        //m_params.m_event.m_poly[voicePos].m_type = 1;
         float notePitch = pitch
             + (uniDetune * m_params.m_unison_detune[uVoice][v])
-            + masterTune + m_params.m_note_shift[voiceId + v];
-        m_params.postProcessPoly_key(m_parameters, voiceId + v);
-        setPolySlowFilterCoeffs(m_parameters, voiceId + v);
-        m_combfilter.setDelaySmoother(voiceId + v);
+            + masterTune + m_params.m_note_shift[voicePos];
+        m_params.postProcessPoly_key(m_parameters, voicePos);
+        setPolySlowFilterCoeffs(m_parameters, voicePos);
+        m_combfilter.setDelaySmoother(voicePos);
 
         //
 #if test_milestone < 156
@@ -947,7 +949,7 @@ void dsp_host::keyDown156(const float _velocity)
           /* AUDIO_ENGINE: trigger non-voice-steal */
         }
 #if test_milestone == 150
-        const float startPhase = m_params.getParameterValue(Parameters::P_KEY_PH, voiceId + v);
+        const float startPhase = m_params.getParameterValue(Parameters::P_KEY_PH, voicePos);
 #else
         const float startPhase = 0.f;
 #endif
@@ -962,8 +964,8 @@ void dsp_host::keyDown156(const float _velocity)
         }
         const float startPhase = 0.f;
 #endif
-        m_soundgenerator.resetPhase(startPhase, voiceId + v);
-        m_params.newEnvUpdateStart(voiceId + v, notePitch, velocity);
+        m_soundgenerator.resetPhase(startPhase, voicePos);
+        m_params.newEnvUpdateStart(voicePos, notePitch, velocity);
     }
     // keyApplyMono
 #if test_flanger_env_legato == 0

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -844,8 +844,8 @@ void dsp_host::keyUp156(const float _velocity)
                             m_params.m_utilities[0].m_scaleId,
                             m_params.m_utilities[0].m_scaleArg,
                             _velocity * m_params.m_utilities[0].m_normalize);
-    m_params.m_event.m_mono.m_velocity = velocity;
-    m_params.m_event.m_mono.m_type = 0;
+    //m_params.m_event.m_mono.m_velocity = velocity;
+    //m_params.m_event.m_mono.m_type = 0;
     // disable preload
     m_params.getBody(index).m_preload = 0;
     m_params.m_preload = 0;
@@ -853,8 +853,8 @@ void dsp_host::keyUp156(const float _velocity)
     // unison loop
     for(uint32_t v = 0; v < unisonVoices; v++)
     {
-        m_params.m_event.m_poly[voiceId].m_velocity = velocity;
-        m_params.m_event.m_poly[voiceId].m_type = 0;
+        //m_params.m_event.m_poly[voiceId].m_velocity = velocity;
+        //m_params.m_event.m_poly[voiceId].m_type = 0;
         float notePitch = m_params.getBody(index).m_value
             + (m_params.getParameterValue(Parameters::P_UN_DET) * m_params.m_unison_detune[uVoice][v])
             + m_params.getParameterValue(Parameters::P_MA_T) + m_params.m_note_shift[voiceId];
@@ -901,8 +901,8 @@ void dsp_host::keyDown156(const float _velocity)
                             m_params.m_utilities[0].m_scaleId,
                             m_params.m_utilities[0].m_scaleArg,
                             _velocity * m_params.m_utilities[0].m_normalize);
-    m_params.m_event.m_mono.m_velocity = velocity;
-    m_params.m_event.m_mono.m_type = 1;
+    //m_params.m_event.m_mono.m_velocity = velocity;
+    //m_params.m_event.m_mono.m_type = 1;
     // disable preload
     m_params.getBody(index).m_preload = 0;
     m_params.m_preload = 0;
@@ -913,8 +913,8 @@ void dsp_host::keyDown156(const float _velocity)
         m_params.m_note_shift[voiceId] = m_params.getParameterValue(Parameters::P_MA_SH);
         m_params.getBody(index).m_value = pitch;
         m_params.m_unison_index[voiceId] = v;
-        m_params.m_event.m_poly[voiceId].m_velocity = velocity;
-        m_params.m_event.m_poly[voiceId].m_type = 1;
+        //m_params.m_event.m_poly[voiceId].m_velocity = velocity;
+        //m_params.m_event.m_poly[voiceId].m_type = 1;
         float notePitch = pitch
             + (m_params.getParameterValue(Parameters::P_UN_DET) * m_params.m_unison_detune[uVoice][v])
             + m_params.getParameterValue(Parameters::P_MA_T) + m_params.m_note_shift[voiceId];

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
@@ -33,7 +33,7 @@
 #define test_svf_types 1        // 0: SVF first Proto NAN, 1: SVF noFIR, 2: SVF FIR, 3: SVF Original Primary (later)
 #define test_svf_fm_limit 1.5f  // SVF fm clipping maximum
 
-#define test_preload_update 1  // 0: non-optimized preload update, 1: optimized preload update (recommended)
+#define test_preload_update 2  // 0: non-optimized preload update, 1: optimized preload update (but key glitches), 2: fixed preload update (recommended)
 #define test_inputModeFlag 0   // 0: receive TCD MIDI, 1: receive Remote MIDI (and produce TCD internally)
 
 #define test_reverbParams 1    // 0: fast rendering (like Reaktor), 1: slow rendering (experimental)


### PR DESCRIPTION
- glitchy pitch issues seem fixed now
- simpler event logic for key events , avoided (most) redundant calculations (less cpu spike intensity is expected)
- fix is implemented via #define and can be disabled
- a similar fix will follow soon for the master branch (but because of large structural differences between master and dsp_optimization, cherry picking will not be helpful - so the fix will be made from scratch)