### PR TITLE
Milestone 1.5 fix env glitch

### DIFF
--- a/audio-engine/src/Options.h
+++ b/audio-engine/src/Options.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <glibmm.h>
+#include "synth/c15-audio-engine/pe_defines_config.h"
 
 class Options
 {
@@ -26,7 +27,7 @@ class Options
  private:
   bool m_fatalXRuns = false;
   int m_rate = 48000;
-  int m_polyphony = 20;
+  int m_polyphony = dsp_number_of_voices;
   bool m_measurePerformance = false;
 
   Glib::ustring m_midiInputDeviceName;

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.cpp
@@ -23,6 +23,10 @@ void dsp_host::init(uint32_t _samplerate, uint32_t _polyphony)
   /* initialize components */
   m_params.init(_samplerate, _polyphony);
   m_decoder.init();
+  // new: env glitch suppression by fade point
+  m_params.m_new_envelopes.m_env_a.m_fadeValue = &m_fadeValue;
+  m_params.m_new_envelopes.m_env_b.m_fadeValue = &m_fadeValue;
+  m_params.m_new_envelopes.m_env_c.m_fadeValue = &m_fadeValue;
   /* init messages to terminal */
 
   Log::info("DSP_HOST::MILESTONE:\t\t", static_cast<float>(test_milestone) * 0.01f);
@@ -201,6 +205,8 @@ void dsp_host::tickMain()
   m_outputmixer.m_out_R = 0.f;
 
   /* this is the MAIN POLYPHONIC LOOP - rendering (and post processing) parameters, envelopes and the AUDIO_ENGINE */
+  // get fade value
+  m_fadeValue = m_raised_cos_table[m_table_indx];
   for(uint32_t v = 0; v < m_voices; v++)
   {
     /* render poly audio parameters */
@@ -1735,7 +1741,7 @@ void dsp_host::makePolySound(SignalStorage &signals)
 
 void dsp_host::makeMonoSound(SignalStorage &signals)
 {
-  float mst_gain = signals.get<Signals::MST_VOL>() * m_raised_cos_table[m_table_indx];
+  float mst_gain = signals.get<Signals::MST_VOL>() * m_fadeValue;
 
   //****************************** Mono Modules ****************************//
   m_outputmixer.filter_level(signals);

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.h
@@ -64,6 +64,8 @@ class dsp_host
   /* local data structures */
   decoder m_decoder;     // TCD command evaluation
   paramengine m_params;  // parameter and envelope rendering
+  //
+  float m_fadeValue;
   /* proper init (samplerate & polyphony) */
   void init(uint32_t _samplerate, uint32_t _polyphony);  // proper initialization
   void loadInitialPreset();  // load initial preset for valid values in signal array (before rendering begins)

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
@@ -24,9 +24,9 @@
       // - 156 (simplified TCD key sequence by new KeyVoice command, automatic internal unison loop)
 
 // +3dB clipping candidates (can be disabled for test and comparison purposes)
-#define test_env_ab_3db_clip 0          //
-#define test_env_c_3db_clip 0           //
-#define test_fbm_kt_3db_clip 0          //
+#define test_env_ab_3db_clip 0  //
+#define test_env_c_3db_clip 0   //
+#define test_fbm_kt_3db_clip 0  //
 
 #define test_tone_initial_freq 500.0f  // Test Tone initial Frequency
 #define test_tone_initial_gain -6.0f   // Test Tone initial Gain (in decibel)
@@ -74,7 +74,7 @@
 
 #endif
 
-/* Main Configuration                               (prepared for maximal 20 Voices) */
+/* Main Configuration                               (prepared for maximal 24 Voices) */
 
 #define dsp_poly_types 2         // two polyphony types (mono, poly) - (later, a dual type needs to be implemented)
 #define dsp_clock_types 4        // four different parameter types (sync, audio, fast, slow)

--- a/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.cpp
@@ -21,22 +21,30 @@
 
 void env_object_adbdsr_split::start(const uint32_t _voiceId)
 {
-    /* set the body reference according to the current voice */
+  /* set the body reference according to the current voice */
 
-    env_body_split* body = &m_body[_voiceId];                           // a temporary body variable is declared
+  env_body_split* body = &m_body[_voiceId];  // a temporary body variable is declared
 
-    /* prepare rendering variables for the imminent transition */
+  /* prepare rendering variables for the imminent transition */
 
-    body->m_x = m_segment[m_startIndex].m_dx[_voiceId];                 // x represents the transition progress [0 ... 1] for linear and polynomial transitions (x = dx)
-    body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];           // y represents the transition progress [1 ... 0] for exponential transitions (y = 1 - dx)
-    body->m_start_magnitude = body->m_signal_magnitude;                 // the signal startpoint is updated for the magnitude signal (startpoint = signal)
-    body->m_start_timbre = body->m_signal_timbre;                       // the signal startpoint is updated for the timbre signal (startpoint = signal)
+  body->m_x
+      = m_segment[m_startIndex].m_dx
+            [_voiceId];  // x represents the transition progress [0 ... 1] for linear and polynomial transitions (x = dx)
+  body->m_y = 1.f
+      - m_segment[m_startIndex]
+            .m_dx[_voiceId];  // y represents the transition progress [1 ... 0] for exponential transitions (y = 1 - dx)
+  body->m_start_magnitude
+      = body->m_signal_magnitude;  // the signal startpoint is updated for the magnitude signal (startpoint = signal)
+  body->m_start_timbre
+      = body->m_signal_timbre;  // the signal startpoint is updated for the timbre signal (startpoint = signal)
 
-    /* prepare state variables for the imminent transition */
+  /* prepare state variables for the imminent transition */
 
-    body->m_state = m_segment[m_startIndex].m_state;                    // the rendering state is updated according to the first segment (state = polynomial)
-    body->m_index = m_startIndex;                                       // the segment index is updated to the first segment (index = 1)
-    body->m_next = m_segment[m_startIndex].m_next;                      // the subsequent segment index is updated according to the first segment (next = linear)
+  body->m_state = m_segment[m_startIndex]
+                      .m_state;  // the rendering state is updated according to the first segment (state = polynomial)
+  body->m_index = m_startIndex;  // the segment index is updated to the first segment (index = 1)
+  body->m_next = m_segment[m_startIndex]
+                     .m_next;  // the subsequent segment index is updated according to the first segment (next = linear)
 }
 
 /*****************************************************************************/
@@ -49,22 +57,30 @@ void env_object_adbdsr_split::start(const uint32_t _voiceId)
 
 void env_object_adbdsr_split::stop(const uint32_t _voiceId)
 {
-    /* set the body reference according to the current voice */
+  /* set the body reference according to the current voice */
 
-    env_body_split* body = &m_body[_voiceId];                           // a temporary body variable is declared
+  env_body_split* body = &m_body[_voiceId];  // a temporary body variable is declared
 
-    /* prepare rendering variables for the imminent transition */
+  /* prepare rendering variables for the imminent transition */
 
-    body->m_x = m_segment[m_stopIndex].m_dx[_voiceId];                  // x represents the transition progress [0 ... 1] for linear and polynomial transitions (x = dx)
-    body->m_y = 1.f - m_segment[m_stopIndex].m_dx[_voiceId];            // y represents the transition progress [1 ... 0] for exponential transitions (y = 1 - dx)
-    body->m_start_magnitude = body->m_signal_magnitude;                 // the signal startpoint is updated for the magnitude signal (startpoint = signal)
-    body->m_start_timbre = body->m_signal_timbre;                       // the signal startpoint is updated for the timbre signal (startpoint = signal)
+  body->m_x
+      = m_segment[m_stopIndex].m_dx
+            [_voiceId];  // x represents the transition progress [0 ... 1] for linear and polynomial transitions (x = dx)
+  body->m_y = 1.f
+      - m_segment[m_stopIndex]
+            .m_dx[_voiceId];  // y represents the transition progress [1 ... 0] for exponential transitions (y = 1 - dx)
+  body->m_start_magnitude
+      = body->m_signal_magnitude;  // the signal startpoint is updated for the magnitude signal (startpoint = signal)
+  body->m_start_timbre
+      = body->m_signal_timbre;  // the signal startpoint is updated for the timbre signal (startpoint = signal)
 
-    /* prepare state variables for the imminent transition */
+  /* prepare state variables for the imminent transition */
 
-    body->m_state = m_segment[m_stopIndex].m_state;                     // the rendering state is updated according to the final segment (state = exponential)
-    body->m_index = m_stopIndex;                                        // the segment index is updated to the final segment (index = 4)
-    body->m_next = m_segment[m_stopIndex].m_next;                       // the subsequent segment index is updated according to the final segment (next = idle)
+  body->m_state = m_segment[m_stopIndex]
+                      .m_state;  // the rendering state is updated according to the final segment (state = exponential)
+  body->m_index = m_stopIndex;   // the segment index is updated to the final segment (index = 4)
+  body->m_next = m_segment[m_stopIndex]
+                     .m_next;  // the subsequent segment index is updated according to the final segment (next = idle)
 }
 
 /*****************************************************************************/
@@ -77,135 +93,148 @@ void env_object_adbdsr_split::stop(const uint32_t _voiceId)
 
 void env_object_adbdsr_split::tick(const uint32_t _voiceId)
 {
-    /* set the body and segment reference according to the current voice and body state */
+  /* set the body and segment reference according to the current voice and body state */
 
-    env_body_split* body = &m_body[_voiceId];                                                               // a temporary body variable is declared
-    const uint32_t segment = body->m_index;                                                                 // a temporary segment index variable is declared
+  env_body_split* body = &m_body[_voiceId];  // a temporary body variable is declared
+  const uint32_t segment = body->m_index;    // a temporary segment index variable is declared
 
-    /* calculate the current differences (signal to destination) */
+  /* calculate the current differences (signal to destination) */
 
-    const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;   // current transition difference for the magnitude signal
-    const float diff_timbre = m_segment[segment].m_dest_timbre[_voiceId] - body->m_start_timbre;            // current transition difference for the timbre signal
-                                                                                                            // (difference = destination - startpoint) (magnitude, timbre)
+  const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId]
+      - body->m_start_magnitude;  // current transition difference for the magnitude signal
+  const float diff_timbre = m_segment[segment].m_dest_timbre[_voiceId]
+      - body->m_start_timbre;  // current transition difference for the timbre signal
+                               // (difference = destination - startpoint) (magnitude, timbre)
 
-    /* render according to the current state */
+  /* render according to the current state */
 
-    switch(body->m_state)                                                                                   // (basic rendering instructions)
-    {
+  switch(body->m_state)  // (basic rendering instructions)
+  {
 
-    case 0:     /* idle - no rendering */
+    case 0: /* idle - no rendering */
 
-        break;
+      break;
 
-    case 1:     /* linear rendering (decay1 phase) - until transition is finished */
+    case 1: /* linear rendering (decay1 phase) - until transition is finished */
 
-        if(body->m_x < 1.f)                                                                                 // (if(x < 1))
-        {
-            /* while transition is unfinished, the signals are formed by the current transition progress */
+      if(body->m_x < 1.f)  // (if(x < 1))
+      {
+        /* while transition is unfinished, the signals are formed by the current transition progress */
 
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);              // (signal = startpoint + (difference * x)) (magnitude)
-            body->m_signal_timbre = body->m_start_timbre + (diff_timbre * body->m_x);                       // (signal = startpoint + (difference * x)) (timbre)
+        body->m_signal_magnitude = body->m_start_magnitude
+            + (diff_magnitude * body->m_x);  // (signal = startpoint + (difference * x)) (magnitude)
+        body->m_signal_timbre
+            = body->m_start_timbre + (diff_timbre * body->m_x);  // (signal = startpoint + (difference * x)) (timbre)
 
-            /* update the transition progress for the next clock tick */
+        /* update the transition progress for the next clock tick */
 
-            body->m_x += m_segment[segment].m_dx[_voiceId];                                                 // (x += dx)
-        }
-        else
-        {
-            /* when transition is finished, the signals are set to the corresponding segment destinations */
+        body->m_x += m_segment[segment].m_dx[_voiceId];  // (x += dx)
+      }
+      else
+      {
+        /* when transition is finished, the signals are set to the corresponding segment destinations */
 
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];                       // (signal = destination) (magnitude)
-            body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];                             // (signal = destination) (timbre)
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];  // (signal = destination) (magnitude)
+        body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];        // (signal = destination) (timbre)
 
-            /* issue subsequent segment */
+        /* issue subsequent segment */
 
-            nextSegment(_voiceId);
-        }
-        break;
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 2:     /* exponential, quasi-infinite rendering (decay2 phase) - until transition is finished */
+    case 2: /* exponential, quasi-infinite rendering (decay2 phase) - until transition is finished */
 
-        if(body->m_y > dsp_render_min)                                                                      // (if(y > 1e-9))
-        {
-            /* while transition is unfinished, the signals are formed by the current transition progress */
+      if(body->m_y > dsp_render_min)  // (if(y > 1e-9))
+      {
+        /* while transition is unfinished, the signals are formed by the current transition progress */
 
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));      // (signal = startpoint + (difference * (1 - y))) (magnitude)
-            body->m_signal_timbre = body->m_start_timbre + (diff_timbre * (1.f - body->m_y));               // (signal = startpoint + (difference * (1 - y))) (timbre)
+        body->m_signal_magnitude = body->m_start_magnitude
+            + (diff_magnitude * (1.f - body->m_y));  // (signal = startpoint + (difference * (1 - y))) (magnitude)
+        body->m_signal_timbre = body->m_start_timbre
+            + (diff_timbre * (1.f - body->m_y));  // (signal = startpoint + (difference * (1 - y))) (timbre)
 
-            /* update the transition progress for the next clock tick */
+        /* update the transition progress for the next clock tick */
 
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];                                           // (y *= 1 - dx)
-        }
-        else
-        {
-            /* when transition is finished, the signals are formed without the transition progress (but still according to the segment destinations) */
+        body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];  // (y *= 1 - dx)
+      }
+      else
+      {
+        /* when transition is finished, the signals are formed without the transition progress (but still according to the segment destinations) */
 
-            body->m_signal_magnitude = body->m_start_magnitude + diff_magnitude;                            // (signal = startpoint + difference) (magnitude)
-            body->m_signal_timbre = body->m_start_timbre + diff_timbre;                                     // (signal = startpoint + difference) (timbre)
+        body->m_signal_magnitude
+            = body->m_start_magnitude + diff_magnitude;              // (signal = startpoint + difference) (magnitude)
+        body->m_signal_timbre = body->m_start_timbre + diff_timbre;  // (signal = startpoint + difference) (timbre)
 
-            /* no subsequent segment will be issued (until a key down happens and triggers the final segment) */
-        }
-        break;
+        /* no subsequent segment will be issued (until a key down happens and triggers the final segment) */
+      }
+      break;
 
-    case 3:     /* exponential, quasi-finite rendering (release phase) - until transition is finished */
+    case 3: /* exponential, quasi-finite rendering (release phase) - until transition is finished */
 
-        if(body->m_y > dsp_render_min)                                                                      // (if(y > 1e-9))
-        {
-            /* while transition is unfinished, the signals are formed by the current transition progress */
+      if(body->m_y > dsp_render_min)  // (if(y > 1e-9))
+      {
+        /* while transition is unfinished, the signals are formed by the current transition progress */
 
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));      // (signal = startpoint + (difference * (1 - y))) (magnitude)
-            body->m_signal_timbre = body->m_start_timbre + (diff_timbre * (1.f - body->m_y));               // (signal = startpoint + (difference * (1 - y))) (timbre)
+        body->m_signal_magnitude = body->m_start_magnitude
+            + (diff_magnitude * (1.f - body->m_y));  // (signal = startpoint + (difference * (1 - y))) (magnitude)
+        body->m_signal_timbre = body->m_start_timbre
+            + (diff_timbre * (1.f - body->m_y));  // (signal = startpoint + (difference * (1 - y))) (timbre)
 
-            /* update the transition progress for the next clock tick */
+        /* update the transition progress for the next clock tick */
 
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];                                           // (y *= 1 - dx)
-        }
-        else
-        {
-            /* when transition is finished, the signals are set to the corresponding segment destinations */
+        body->m_y *= 1.f - (1.0f - *m_fadeValue + (*m_fadeValue * m_segment[segment].m_dx[_voiceId]));  // (y *= 1 - dx)
+        // now including glitch suppression
+      }
+      else
+      {
+        /* when transition is finished, the signals are set to the corresponding segment destinations */
 
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];                       // (signal = destination) (magnitude)
-            body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];                             // (signal = destination) (timbre)
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];  // (signal = destination) (magnitude)
+        body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];        // (signal = destination) (timbre)
 
-            /* issue subsequent segment */
+        /* issue subsequent segment */
 
-            nextSegment(_voiceId);
-        }
-        break;
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 4:     /* polynomial rendering (attack phase) - until transition is finished */
+    case 4: /* polynomial rendering (attack phase) - until transition is finished */
 
-        if(body->m_x < 1.f)                                                                                 // (if(x < 1))
-        {
-            /* while transition is unfinished, the transition polynomial is formed according to the curvature */
+      if(body->m_x < 1.f)  // (if(x < 1))
+      {
+        /* while transition is unfinished, the transition polynomial is formed according to the curvature */
 
-            float x = NlToolbox::Curves::SquaredCurvature(body->m_x, m_segment[segment].m_curve);           // (polynomical curvature, 2nd degree)
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);                         // (polynomical curvature, 4th degree)
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);                         // (polynomical curvature, 8th degree)
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);                         // (polynomical curvature, 16th degree)
+        float x = NlToolbox::Curves::SquaredCurvature(
+            body->m_x, m_segment[segment].m_curve);                              // (polynomical curvature, 2nd degree)
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);  // (polynomical curvature, 4th degree)
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);  // (polynomical curvature, 8th degree)
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);  // (polynomical curvature, 16th degree)
 
-            /* the signals are formed by the current transition progress (more precise: the polynomial formed by the progress) */
+        /* the signals are formed by the current transition progress (more precise: the polynomial formed by the progress) */
 
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * x);                      // (signal = startpoint + (difference * f(x))) (magnitude)
-            body->m_signal_timbre = body->m_start_timbre + (diff_timbre * x);                               // (signal = startpoint + (difference * f(x))) (timbre)
+        body->m_signal_magnitude = body->m_start_magnitude
+            + (diff_magnitude * x);  // (signal = startpoint + (difference * f(x))) (magnitude)
+        body->m_signal_timbre
+            = body->m_start_timbre + (diff_timbre * x);  // (signal = startpoint + (difference * f(x))) (timbre)
 
-            /* update the transition progress for the next clock tick */
+        /* update the transition progress for the next clock tick */
 
-            body->m_x += m_segment[segment].m_dx[_voiceId];                                                 // (x += dx)
-        }
-        else
-        {
-            /* when transition is finished, the signals are set to the corresponding segment destinations */
+        body->m_x += m_segment[segment].m_dx[_voiceId];  // (x += dx)
+      }
+      else
+      {
+        /* when transition is finished, the signals are set to the corresponding segment destinations */
 
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];                       // (signal = destination) (magnitude)
-            body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];                             // (signal = destination) (timbre)
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];  // (signal = destination) (magnitude)
+        body->m_signal_timbre = m_segment[segment].m_dest_timbre[_voiceId];        // (signal = destination) (timbre)
 
-            /* issue subsequent segment */
+        /* issue subsequent segment */
 
-            nextSegment(_voiceId);
-        }
-        break;
-    }
+        nextSegment(_voiceId);
+      }
+      break;
+  }
 }
 
 /*****************************************************************************/
@@ -219,22 +248,27 @@ void env_object_adbdsr_split::tick(const uint32_t _voiceId)
 
 void env_object_adbdsr_split::nextSegment(const uint32_t _voiceId)
 {
-    /* set the body reference according to the current voice */
+  /* set the body reference according to the current voice */
 
-    env_body_split* body = &m_body[_voiceId];                           // a temporary body variable is declared
+  env_body_split* body = &m_body[_voiceId];  // a temporary body variable is declared
 
-    /* prepare rendering variables for the imminent transition */
+  /* prepare rendering variables for the imminent transition */
 
-    body->m_x = m_segment[body->m_next].m_dx[_voiceId];                 // x represents the transition progress [0 ... 1] for linear and polynomial transitions
-    body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];           // y represents the transition progress [1 ... 0] for exponential transitions
-    body->m_start_magnitude = body->m_signal_magnitude;                 // the signal startpoint is updated for the magnitude signal
-    body->m_start_timbre = body->m_signal_timbre;                       // the signal startpoint is updated for the timbre signal
+  body->m_x
+      = m_segment[body->m_next]
+            .m_dx[_voiceId];  // x represents the transition progress [0 ... 1] for linear and polynomial transitions
+  body->m_y = 1.f
+      - m_segment[body->m_next]
+            .m_dx[_voiceId];  // y represents the transition progress [1 ... 0] for exponential transitions
+  body->m_start_magnitude = body->m_signal_magnitude;  // the signal startpoint is updated for the magnitude signal
+  body->m_start_timbre = body->m_signal_timbre;        // the signal startpoint is updated for the timbre signal
 
-    /* prepare state variables for the imminent transition */
+  /* prepare state variables for the imminent transition */
 
-    body->m_state = m_segment[body->m_next].m_state;                    // the rendering state is updated according to the first segment
-    body->m_index = body->m_next;                                       // the segment index is updated to the first segment
-    body->m_next = m_segment[body->m_index].m_next;                     // the subsequent segment index is updated according to the first segment
+  body->m_state = m_segment[body->m_next].m_state;  // the rendering state is updated according to the first segment
+  body->m_index = body->m_next;                     // the segment index is updated to the first segment
+  body->m_next
+      = m_segment[body->m_index].m_next;  // the subsequent segment index is updated according to the first segment
 }
 
 /*****************************************************************************/
@@ -249,9 +283,9 @@ void env_object_adbdsr_split::nextSegment(const uint32_t _voiceId)
 
 void env_object_adbdsr_split::setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* access desired segment by segmentId, access dx in desired voice by voiceId, update by value */
+  /* access desired segment by segmentId, access dx in desired voice by voiceId, update by value */
 
-    m_segment[_segmentId].m_dx[_voiceId] = _value;                      // dx [0 ... 1] represents the transition time (infinite ... zero)
+  m_segment[_segmentId].m_dx[_voiceId] = _value;  // dx [0 ... 1] represents the transition time (infinite ... zero)
 }
 
 /*****************************************************************************/
@@ -265,24 +299,27 @@ void env_object_adbdsr_split::setSegmentDx(const uint32_t _voiceId, const uint32
  *  @param      value, the destination argument
 ******************************************************************************/
 
-void env_object_adbdsr_split::setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const bool _splitMode, const float _value)
+void env_object_adbdsr_split::setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const bool _splitMode,
+                                             const float _value)
 {
-    /* updates destinations (for magnitude, timbre) according to splitMode (either splitted or unifomrly) */
+  /* updates destinations (for magnitude, timbre) according to splitMode (either splitted or unifomrly) */
 
-    if(_splitMode)
-    {
-        /* splitMode update: destinations are determined according to split setting (by crossfades) - intended for breakpoint and sustain updates */
+  if(_splitMode)
+  {
+    /* splitMode update: destinations are determined according to split setting (by crossfades) - intended for breakpoint and sustain updates */
 
-        m_segment[_segmentId].m_dest_magnitude[_voiceId] = NlToolbox::Crossfades::unipolarCrossFade(_value, m_peakLevels[_voiceId], m_splitValues[0]);
-        m_segment[_segmentId].m_dest_timbre[_voiceId] = NlToolbox::Crossfades::unipolarCrossFade(_value, m_peakLevels[_voiceId], m_splitValues[1]);
-    }
-    else
-    {
-        /* uniform update: destinations are updated by value directly - intended for peak velocity */
+    m_segment[_segmentId].m_dest_magnitude[_voiceId]
+        = NlToolbox::Crossfades::unipolarCrossFade(_value, m_peakLevels[_voiceId], m_splitValues[0]);
+    m_segment[_segmentId].m_dest_timbre[_voiceId]
+        = NlToolbox::Crossfades::unipolarCrossFade(_value, m_peakLevels[_voiceId], m_splitValues[1]);
+  }
+  else
+  {
+    /* uniform update: destinations are updated by value directly - intended for peak velocity */
 
-        m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
-        m_segment[_segmentId].m_dest_timbre[_voiceId] = _value;
-    }
+    m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
+    m_segment[_segmentId].m_dest_timbre[_voiceId] = _value;
+  }
 }
 
 /*****************************************************************************/
@@ -295,10 +332,10 @@ void env_object_adbdsr_split::setSegmentDest(const uint32_t _voiceId, const uint
 
 void env_object_adbdsr_split::setSplitValue(const float _value)
 {
-    /* two separate crossfade values are determined */
+  /* two separate crossfade values are determined */
 
-    m_splitValues[0] = std::max(0.f, _value);           // magnitude xfade (param, 1)
-    m_splitValues[1] = std::max(0.f, -_value);          // timbre xfade (param, 1)
+  m_splitValues[0] = std::max(0.f, _value);   // magnitude xfade (param, 1)
+  m_splitValues[1] = std::max(0.f, -_value);  // timbre xfade (param, 1)
 }
 
 /*****************************************************************************/
@@ -314,8 +351,8 @@ void env_object_adbdsr_split::setSplitValue(const float _value)
 
 void env_object_adbdsr_split::setAttackCurve(const float _value)
 {
-    /* update the curvature of the attack segment */
-    m_segment[1].m_curve = _value;
+  /* update the curvature of the attack segment */
+  m_segment[1].m_curve = _value;
 }
 
 /*****************************************************************************/
@@ -329,8 +366,8 @@ void env_object_adbdsr_split::setAttackCurve(const float _value)
 
 void env_object_adbdsr_split::setPeakLevel(const uint32_t _voiceId, const float _value)
 {
-    /* update the peak level according to voiceId */
-    m_peakLevels[_voiceId] = _value;
+  /* update the peak level according to voiceId */
+  m_peakLevels[_voiceId] = _value;
 }
 
 /********************************************** Retrigger Envelope Object Functionality **********************************************/
@@ -338,165 +375,165 @@ void env_object_adbdsr_split::setPeakLevel(const uint32_t _voiceId, const float 
 /* */
 void env_object_adbdsr_retrig::start(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_start_magnitude = (1.f - m_retriggerHardness) * body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[m_startIndex].m_state;
-    body->m_index = m_startIndex;
-    body->m_next = m_segment[m_startIndex].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_start_magnitude = (1.f - m_retriggerHardness) * body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[m_startIndex].m_state;
+  body->m_index = m_startIndex;
+  body->m_next = m_segment[m_startIndex].m_next;
 }
 
 /* */
 void env_object_adbdsr_retrig::stop(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[m_stopIndex].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[m_stopIndex].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[m_stopIndex].m_state;
-    body->m_index = m_stopIndex;
-    body->m_next = m_segment[m_stopIndex].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[m_stopIndex].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[m_stopIndex].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[m_stopIndex].m_state;
+  body->m_index = m_stopIndex;
+  body->m_next = m_segment[m_stopIndex].m_next;
 }
 
 /* */
 void env_object_adbdsr_retrig::tick(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    const uint32_t segment = body->m_index;
-    const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
-    /* */
-    switch(body->m_state)
-    {
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  const uint32_t segment = body->m_index;
+  const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
+  /* */
+  switch(body->m_state)
+  {
 
-    case 0:     /* idle */
+    case 0: /* idle */
 
-        break;
+      break;
 
-    case 1:     /* linear rendering (decay1 phase) */
+    case 1: /* linear rendering (decay1 phase) */
 
-        if(body->m_x < 1.f)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
-            /* */
-            body->m_x += m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
+      if(body->m_x < 1.f)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
+        /* */
+        body->m_x += m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 2:     /* exponential, quasi-infinite rendering (decay2 phase) */
+    case 2: /* exponential, quasi-infinite rendering (decay2 phase) */
 
-        if(body->m_y > dsp_render_min)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
-            /* */
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + diff_magnitude;
-        }
-        break;
+      if(body->m_y > dsp_render_min)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
+        /* */
+        body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + diff_magnitude;
+      }
+      break;
 
-    case 3:     /* exponential, quasi-finite rendering (release phase) */
+    case 3: /* exponential, quasi-finite rendering (release phase) */
 
-        if(body->m_y > dsp_render_min)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
-            /* */
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
+      if(body->m_y > dsp_render_min)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
+        /* */
+        body->m_y *= 1.f - (1.0f - *m_fadeValue + (*m_fadeValue * m_segment[segment].m_dx[_voiceId]));
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 4:     /* polynomial rendering (attack phase) */
+    case 4: /* polynomial rendering (attack phase) */
 
-        if(body->m_x < 1.f)
-        {
-            /* */
-            float x = NlToolbox::Curves::SquaredCurvature(body->m_x, m_segment[segment].m_curve);
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
-            x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * x);
-            /* */
-            body->m_x += m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
-    }
+      if(body->m_x < 1.f)
+      {
+        /* */
+        float x = NlToolbox::Curves::SquaredCurvature(body->m_x, m_segment[segment].m_curve);
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
+        x = NlToolbox::Curves::SquaredCurvature(x, m_segment[segment].m_curve);
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * x);
+        /* */
+        body->m_x += m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
+  }
 }
 
 /* */
 void env_object_adbdsr_retrig::nextSegment(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[body->m_next].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[body->m_next].m_state;
-    body->m_index = body->m_next;
-    body->m_next = m_segment[body->m_index].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[body->m_next].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[body->m_next].m_state;
+  body->m_index = body->m_next;
+  body->m_next = m_segment[body->m_index].m_next;
 }
 
 /* */
 void env_object_adbdsr_retrig::setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dx[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dx[_voiceId] = _value;
 }
 
 /* */
 void env_object_adbdsr_retrig::setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
 }
 
 /* */
 void env_object_adbdsr_retrig::setAttackCurve(const float _value)
 {
-    /* update the curvature of the attack segment */
-    m_segment[1].m_curve = _value;
+  /* update the curvature of the attack segment */
+  m_segment[1].m_curve = _value;
 }
 
 /* */
 void env_object_adbdsr_retrig::setRetriggerHardness(const float _value)
 {
-    m_retriggerHardness = _value;
+  m_retriggerHardness = _value;
 }
 
 /********************************************** Gate Envelope Object Functionality **********************************************/
@@ -504,113 +541,113 @@ void env_object_adbdsr_retrig::setRetriggerHardness(const float _value)
 /* */
 void env_object_gate::start(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[m_startIndex].m_state;
-    body->m_index = m_startIndex;
-    body->m_next = m_segment[m_startIndex].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[m_startIndex].m_state;
+  body->m_index = m_startIndex;
+  body->m_next = m_segment[m_startIndex].m_next;
 }
 
 /* */
 void env_object_gate::stop(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[m_stopIndex].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[m_stopIndex].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[m_stopIndex].m_state;
-    body->m_index = m_stopIndex;
-    body->m_next = m_segment[m_stopIndex].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[m_stopIndex].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[m_stopIndex].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[m_stopIndex].m_state;
+  body->m_index = m_stopIndex;
+  body->m_next = m_segment[m_stopIndex].m_next;
 }
 
 /* */
 void env_object_gate::tick(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    const uint32_t segment = body->m_index;
-    const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
-    /* */
-    switch(body->m_state)
-    {
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  const uint32_t segment = body->m_index;
+  const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
+  /* */
+  switch(body->m_state)
+  {
 
-    case 0:     /* idle */
+    case 0: /* idle */
 
-        break;
+      break;
 
-    case 1:     /* linear rendering (attack phase) */
+    case 1: /* linear rendering (attack phase) */
 
-        if(body->m_x < 1.f)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
-            /* */
-            body->m_x += m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
+      if(body->m_x < 1.f)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
+        /* */
+        body->m_x += m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 2:     /* exponential, quasi-finite rendering (release phase) */
+    case 2: /* exponential, quasi-finite rendering (release phase) */
 
-        if(body->m_y > dsp_render_min)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
-            /* */
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
-    }
+      if(body->m_y > dsp_render_min)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
+        /* */
+        body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
+  }
 }
 
 /* */
 void env_object_gate::nextSegment(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[body->m_next].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[body->m_next].m_state;
-    body->m_index = body->m_next;
-    body->m_next = m_segment[body->m_index].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[body->m_next].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[body->m_next].m_state;
+  body->m_index = body->m_next;
+  body->m_next = m_segment[body->m_index].m_next;
 }
 
 /* */
 void env_object_gate::setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dx[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dx[_voiceId] = _value;
 }
 
 /* */
 void env_object_gate::setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
 }
 
 /********************************************** Decay Envelope Object Functionality **********************************************/
@@ -618,98 +655,98 @@ void env_object_gate::setSegmentDest(const uint32_t _voiceId, const uint32_t _se
 /* */
 void env_object_decay::start(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[m_startIndex].m_state;
-    body->m_index = m_startIndex;
-    body->m_next = m_segment[m_startIndex].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[m_startIndex].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[m_startIndex].m_state;
+  body->m_index = m_startIndex;
+  body->m_next = m_segment[m_startIndex].m_next;
 }
 
 /* */
 void env_object_decay::tick(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    const uint32_t segment = body->m_index;
-    const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
-    /* */
-    switch(body->m_state)
-    {
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  const uint32_t segment = body->m_index;
+  const float diff_magnitude = m_segment[segment].m_dest_magnitude[_voiceId] - body->m_start_magnitude;
+  /* */
+  switch(body->m_state)
+  {
 
-    case 0:     /* idle */
+    case 0: /* idle */
 
-        break;
+      break;
 
-    case 1:     /* linear rendering (attack phase) */
+    case 1: /* linear rendering (attack phase) */
 
-        if(body->m_x < 1.f)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
-            /* */
-            body->m_x += m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
+      if(body->m_x < 1.f)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * body->m_x);
+        /* */
+        body->m_x += m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
 
-    case 2:     /* exponential, quasi-finite rendering (release phase) */
+    case 2: /* exponential, quasi-finite rendering (release phase) */
 
-        if(body->m_y > dsp_render_min)
-        {
-            /* */
-            body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
-            /* */
-            body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
-        }
-        else
-        {
-            /* */
-            body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
-            /* */
-            nextSegment(_voiceId);
-        }
-        break;
-    }
+      if(body->m_y > dsp_render_min)
+      {
+        /* */
+        body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
+        /* */
+        body->m_y *= 1.f - m_segment[segment].m_dx[_voiceId];
+      }
+      else
+      {
+        /* */
+        body->m_signal_magnitude = m_segment[segment].m_dest_magnitude[_voiceId];
+        /* */
+        nextSegment(_voiceId);
+      }
+      break;
+  }
 }
 
 /* */
 void env_object_decay::nextSegment(const uint32_t _voiceId)
 {
-    /* */
-    env_body_single* body = &m_body[_voiceId];
-    /* */
-    body->m_x = m_segment[body->m_next].m_dx[_voiceId];
-    body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
-    body->m_start_magnitude = body->m_signal_magnitude;
-    /* */
-    body->m_state = m_segment[body->m_next].m_state;
-    body->m_index = body->m_next;
-    body->m_next = m_segment[body->m_index].m_next;
+  /* */
+  env_body_single* body = &m_body[_voiceId];
+  /* */
+  body->m_x = m_segment[body->m_next].m_dx[_voiceId];
+  body->m_y = 1.f - m_segment[body->m_next].m_dx[_voiceId];
+  body->m_start_magnitude = body->m_signal_magnitude;
+  /* */
+  body->m_state = m_segment[body->m_next].m_state;
+  body->m_index = body->m_next;
+  body->m_next = m_segment[body->m_index].m_next;
 }
 
 /* */
 void env_object_decay::setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dx[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dx[_voiceId] = _value;
 }
 
 /* */
 void env_object_decay::setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value)
 {
-    /* */
-    m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
+  /* */
+  m_segment[_segmentId].m_dest_magnitude[_voiceId] = _value;
 }
 
 /********************************************** Envelope Engine Object Functionality **********************************************/
@@ -717,68 +754,68 @@ void env_object_decay::setSegmentDest(const uint32_t _voiceId, const uint32_t _s
 /* */
 void env_engine2::init(const uint32_t _voices, const float _gateRelease)
 {
+  /* */
+  uint32_t segment, s, v;
+  /* */
+  for(s = 1; s <= sig_number_of_env_segments; s++)
+  {
     /* */
-    uint32_t segment, s, v;
+    segment = s - 1;
     /* */
-    for(s = 1; s <= sig_number_of_env_segments; s++)
-    {
-        /* */
-        segment = s - 1;
-        /* */
-        m_env_a.m_segment[s].m_state = envelope2_definition[0][segment][0];
-        m_env_a.m_segment[s].m_next = envelope2_definition[0][segment][1];
-        /* */
-        m_env_b.m_segment[s].m_state = envelope2_definition[0][segment][0];
-        m_env_b.m_segment[s].m_next = envelope2_definition[0][segment][1];
-        /* */
-        m_env_c.m_segment[s].m_state = envelope2_definition[0][segment][0];
-        m_env_c.m_segment[s].m_next = envelope2_definition[0][segment][1];
-        /* */
-        m_env_g.m_segment[s].m_state = envelope2_definition[1][segment][0];
-        m_env_g.m_segment[s].m_next = envelope2_definition[1][segment][1];
-        /* */
-        m_env_f.m_segment[s].m_state = envelope2_definition[2][segment][0];
-        m_env_f.m_segment[s].m_next = envelope2_definition[2][segment][1];
-        m_env_f.setSegmentDx(0, s, static_cast<float>(envelope2_definition[2][segment][2]));
-        m_env_f.setSegmentDest(0, s, static_cast<float>(envelope2_definition[2][segment][3]));
-        /* */
-        for(v = 0; v < _voices; v++)
-        {
-            /* */
-            m_env_a.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
-            m_env_a.setSegmentDest(v, s, false, static_cast<float>(envelope2_definition[0][segment][3]));
-            /* */
-            m_env_b.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
-            m_env_b.setSegmentDest(v, s, false, static_cast<float>(envelope2_definition[0][segment][3]));
-            /* */
-            m_env_c.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
-            m_env_c.setSegmentDest(v, s, static_cast<float>(envelope2_definition[0][segment][3]));
-            /* */
-            m_env_g.setSegmentDx(v, s, static_cast<float>(envelope2_definition[1][segment][2]));
-            m_env_g.setSegmentDest(v, s, static_cast<float>(envelope2_definition[1][segment][3]));
-        }
-    }
+    m_env_a.m_segment[s].m_state = envelope2_definition[0][segment][0];
+    m_env_a.m_segment[s].m_next = envelope2_definition[0][segment][1];
+    /* */
+    m_env_b.m_segment[s].m_state = envelope2_definition[0][segment][0];
+    m_env_b.m_segment[s].m_next = envelope2_definition[0][segment][1];
+    /* */
+    m_env_c.m_segment[s].m_state = envelope2_definition[0][segment][0];
+    m_env_c.m_segment[s].m_next = envelope2_definition[0][segment][1];
+    /* */
+    m_env_g.m_segment[s].m_state = envelope2_definition[1][segment][0];
+    m_env_g.m_segment[s].m_next = envelope2_definition[1][segment][1];
+    /* */
+    m_env_f.m_segment[s].m_state = envelope2_definition[2][segment][0];
+    m_env_f.m_segment[s].m_next = envelope2_definition[2][segment][1];
+    m_env_f.setSegmentDx(0, s, static_cast<float>(envelope2_definition[2][segment][2]));
+    m_env_f.setSegmentDest(0, s, static_cast<float>(envelope2_definition[2][segment][3]));
     /* */
     for(v = 0; v < _voices; v++)
     {
-        /* */
-        m_env_g.setSegmentDx(v, 2, _gateRelease);
+      /* */
+      m_env_a.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
+      m_env_a.setSegmentDest(v, s, false, static_cast<float>(envelope2_definition[0][segment][3]));
+      /* */
+      m_env_b.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
+      m_env_b.setSegmentDest(v, s, false, static_cast<float>(envelope2_definition[0][segment][3]));
+      /* */
+      m_env_c.setSegmentDx(v, s, static_cast<float>(envelope2_definition[0][segment][2]));
+      m_env_c.setSegmentDest(v, s, static_cast<float>(envelope2_definition[0][segment][3]));
+      /* */
+      m_env_g.setSegmentDx(v, s, static_cast<float>(envelope2_definition[1][segment][2]));
+      m_env_g.setSegmentDest(v, s, static_cast<float>(envelope2_definition[1][segment][3]));
     }
+  }
+  /* */
+  for(v = 0; v < _voices; v++)
+  {
+    /* */
+    m_env_g.setSegmentDx(v, 2, _gateRelease);
+  }
 }
 
 /* */
 void env_engine2::tickMono()
 {
-    /* */
-    m_env_f.tick(0);
+  /* */
+  m_env_f.tick(0);
 }
 
 /* */
 void env_engine2::tickPoly(const uint32_t _voiceId)
 {
-    /* */
-    m_env_a.tick(_voiceId);
-    m_env_b.tick(_voiceId);
-    m_env_c.tick(_voiceId);
-    m_env_g.tick(_voiceId);
+  /* */
+  m_env_a.tick(_voiceId);
+  m_env_b.tick(_voiceId);
+  m_env_c.tick(_voiceId);
+  m_env_g.tick(_voiceId);
 }

--- a/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.cpp
@@ -183,7 +183,7 @@ void env_object_adbdsr_split::tick(const uint32_t _voiceId)
 
         /* update the transition progress for the next clock tick */
 
-        body->m_y *= 1.f - (1.0f - *m_fadeValue + (*m_fadeValue * m_segment[segment].m_dx[_voiceId]));  // (y *= 1 - dx)
+        body->m_y *= *m_fadeValue * (1.0f - m_segment[segment].m_dx[_voiceId]);  // (y *= 1 - dx)
         // now including glitch suppression
       }
       else
@@ -458,7 +458,7 @@ void env_object_adbdsr_retrig::tick(const uint32_t _voiceId)
         /* */
         body->m_signal_magnitude = body->m_start_magnitude + (diff_magnitude * (1.f - body->m_y));
         /* */
-        body->m_y *= 1.f - (1.0f - *m_fadeValue + (*m_fadeValue * m_segment[segment].m_dx[_voiceId]));
+        body->m_y *= *m_fadeValue * (1.0f - m_segment[segment].m_dx[_voiceId]);
       }
       else
       {

--- a/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_env_engine2.h
@@ -24,29 +24,32 @@
 
 const uint32_t envelope2_definition[sig_number_of_env_types][sig_number_of_env_segments][4] = {
 
-    {   // ADBDSR Types:
-        //  State   Next    Dx      Dest                        Description
-        {   4,      2,      0,      0       },              //  polynomial attack phase
-        {   1,      3,      0,      0       },              //  linear decay1 phase
-        {   2,      0,      0,      0       },              //  quasi-infinite exponential decay2 phase
-        {   3,      0,      0,      0       }               //  quasi-finite exponential release phase
-    },
+  {
+      // ADBDSR Types:
+      //  State   Next    Dx      Dest                        Description
+      { 4, 2, 0, 0 },  //  polynomial attack phase
+      { 1, 3, 0, 0 },  //  linear decay1 phase
+      { 2, 0, 0, 0 },  //  quasi-infinite exponential decay2 phase
+      { 3, 0, 0, 0 }   //  quasi-finite exponential release phase
+  },
 
-    {   // GATE Types:
-        //  State   Next    Dx      Dest                        Description
-        {   1,      0,      1,      1       },              //  linear attack phase
-        {   2,      0,      0,      0       },              //  quasi-finite exponential release phase
-        {   0,      0,      0,      0       },              //  n/a
-        {   0,      0,      0,      0       }               //  n/a
-    },
+  {
+      // GATE Types:
+      //  State   Next    Dx      Dest                        Description
+      { 1, 0, 1, 1 },  //  linear attack phase
+      { 2, 0, 0, 0 },  //  quasi-finite exponential release phase
+      { 0, 0, 0, 0 },  //  n/a
+      { 0, 0, 0, 0 }   //  n/a
+  },
 
-    {   // DECAY Types:
-        //  State   Next    Dx      Dest                        Description
-        {   1,      2,      1,      1       },              //  linear attack phase
-        {   2,      0,      0,      0       },              //  quasi-finite exponential release phase
-        {   0,      0,      0,      0       },              //  n/a
-        {   0,      0,      0,      0       }               //  n/a
-    }
+  {
+      // DECAY Types:
+      //  State   Next    Dx      Dest                        Description
+      { 1, 2, 1, 1 },  //  linear attack phase
+      { 2, 0, 0, 0 },  //  quasi-finite exponential release phase
+      { 0, 0, 0, 0 },  //  n/a
+      { 0, 0, 0, 0 }   //  n/a
+  }
 
 };
 
@@ -56,40 +59,40 @@ const uint32_t envelope2_definition[sig_number_of_env_types][sig_number_of_env_s
 
 struct env_segment_single
 {
-    /* local segment pseudo-pointers */
+  /* local segment pseudo-pointers */
 
-    uint32_t m_state = 0;                                   // segment rendering state and curve type
-    uint32_t m_next = 0;                                    // subsequent segment index (following segment)
+  uint32_t m_state = 0;  // segment rendering state and curve type
+  uint32_t m_next = 0;   // subsequent segment index (following segment)
 
-    /* local rendering variables */
+  /* local rendering variables */
 
-    float m_dx[dsp_number_of_voices] = {};                  // transition times as incremental values [0 ... 1] (infinite ... zero)
-    float m_dest_magnitude[dsp_number_of_voices] = {};      // transition destinations for the magnitude signal
-    float m_curve = 0.f;                                    // curvature (of the attack segment)
+  float m_dx[dsp_number_of_voices] = {};  // transition times as incremental values [0 ... 1] (infinite ... zero)
+  float m_dest_magnitude[dsp_number_of_voices] = {};  // transition destinations for the magnitude signal
+  float m_curve = 0.f;                                // curvature (of the attack segment)
 };
 
 /* Single Monophonic Segment Object (handling only magnitude signal) */
 
 struct env_segment_single_mono
 {
-    /* local segment pseudo-pointers */
+  /* local segment pseudo-pointers */
 
-    uint32_t m_state = 0;                                   // segment rendering state and curve type
-    uint32_t m_next = 0;                                    // subsequent segment index (following segment)
+  uint32_t m_state = 0;  // segment rendering state and curve type
+  uint32_t m_next = 0;   // subsequent segment index (following segment)
 
-    /* local rendering variables */
+  /* local rendering variables */
 
-    float m_dx[1] = {};                                     // transition times as incremental values [0 ... 1] (infinite ... zero)
-    float m_dest_magnitude[1] = {};                         // transition destinations for the magnitude signal
+  float m_dx[1] = {};              // transition times as incremental values [0 ... 1] (infinite ... zero)
+  float m_dest_magnitude[1] = {};  // transition destinations for the magnitude signal
 };
 
 /* Split Segment Object (handling magnitude and timbre signals) */
 
 struct env_segment_split : env_segment_single
 {
-    /* additional local rendering variables */
+  /* additional local rendering variables */
 
-    float m_dest_timbre[dsp_number_of_voices] = {};         // additional transition destinations for the timbre signal
+  float m_dest_timbre[dsp_number_of_voices] = {};  // additional transition destinations for the timbre signal
 };
 
 /********************************************** Envelope Rendering Body Structures **********************************************/
@@ -98,28 +101,28 @@ struct env_segment_split : env_segment_single
 
 struct env_body_single
 {
-    /* local state variables */
+  /* local state variables */
 
-    uint32_t m_state = 0;                                   // current rendering state and curve type
-    uint32_t m_next = 0;                                    // subsequent segment index (following segment)
-    uint32_t m_index = 0;                                   // current segment index
+  uint32_t m_state = 0;  // current rendering state and curve type
+  uint32_t m_next = 0;   // subsequent segment index (following segment)
+  uint32_t m_index = 0;  // current segment index
 
-    /* local rendering variables */
+  /* local rendering variables */
 
-    float m_x = 0.f;                                        // transition curve progress (linear and polynomial curves)
-    float m_y = 0.f;                                        // transition curve progress (exponential curves)
-    float m_start_magnitude = 0.f;                          // transition signal startpoint (magnitude)
-    float m_signal_magnitude = 0.f;                         // rendering signal (magnitude)
+  float m_x = 0.f;                 // transition curve progress (linear and polynomial curves)
+  float m_y = 0.f;                 // transition curve progress (exponential curves)
+  float m_start_magnitude = 0.f;   // transition signal startpoint (magnitude)
+  float m_signal_magnitude = 0.f;  // rendering signal (magnitude)
 };
 
 /* Split Body Object (rendering magnitude and timbre signals) */
 
 struct env_body_split : env_body_single
 {
-    /* additional local rendering variables */
+  /* additional local rendering variables */
 
-    float m_start_timbre = 0.f;                             // transition signal startpoint (timbre)
-    float m_signal_timbre = 0.f;                            // rendering signal (timbre)
+  float m_start_timbre = 0.f;   // transition signal startpoint (timbre)
+  float m_signal_timbre = 0.f;  // rendering signal (timbre)
 };
 
 /********************************************** Envelope Object Structures **********************************************/
@@ -128,108 +131,110 @@ struct env_body_split : env_body_single
 
 struct env_object_adbdsr_split
 {
-    /* predefined segment indices */
+  /* predefined segment indices */
 
-    const uint32_t m_startIndex = 1;                        // segment index of the first segment on key down
-    const uint32_t m_stopIndex = 4;                         // segment index of the final segment on key up
+  const uint32_t m_startIndex = 1;  // segment index of the first segment on key down
+  const uint32_t m_stopIndex = 4;   // segment index of the final segment on key up
 
-    /* split handling variables */
+  /* split handling variables */
 
-    float m_peakLevels[dsp_number_of_voices] = {};          // holding current peak levels
-    float m_splitValues[2] = {};                            // holding crossfade values [0 ... 1] for magnitude and timbre
+  float m_peakLevels[dsp_number_of_voices] = {};  // holding current peak levels
+  float m_splitValues[2] = {};                    // holding crossfade values [0 ... 1] for magnitude and timbre
+  float *m_fadeValue;
 
-    /* local data structures: rendering body, segment array */
+  /* local data structures: rendering body, segment array */
 
-    env_body_split m_body[dsp_number_of_voices];
-    env_segment_split m_segment[sig_number_of_env_segments + 1];
+  env_body_split m_body[dsp_number_of_voices];
+  env_segment_split m_segment[sig_number_of_env_segments + 1];
 
-    /* object functionality */
+  /* object functionality */
 
-    void start(const uint32_t _voiceId);
-    void stop(const uint32_t _voiceId);
-    void tick(const uint32_t _voiceId);
-    void nextSegment(const uint32_t _voiceId);
-    void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
-    void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const bool _splitMode, const float _value);
-    void setSplitValue(const float _value);
-    void setAttackCurve(const float _value);
-    void setPeakLevel(const uint32_t _voiceId, const float _value);
+  void start(const uint32_t _voiceId);
+  void stop(const uint32_t _voiceId);
+  void tick(const uint32_t _voiceId);
+  void nextSegment(const uint32_t _voiceId);
+  void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const bool _splitMode, const float _value);
+  void setSplitValue(const float _value);
+  void setAttackCurve(const float _value);
+  void setPeakLevel(const uint32_t _voiceId, const float _value);
 };
 
 /* ADBDSR Retrigger Envelope Object (currently intended for Env C) */
 
 struct env_object_adbdsr_retrig
 {
-    /* predefined segment indices */
+  /* predefined segment indices */
 
-    const uint32_t m_startIndex = 1;                        // segment index of the first segment on key down
-    const uint32_t m_stopIndex = 4;                         // segment index of the final segment on key up
+  const uint32_t m_startIndex = 1;  // segment index of the first segment on key down
+  const uint32_t m_stopIndex = 4;   // segment index of the final segment on key up
 
-    /* retrigger handling variable */
+  /* retrigger handling variable */
 
-    float m_retriggerHardness = 0.f;                        // crossfade value [0 ... 1] for retrigger behavior
+  float m_retriggerHardness = 0.f;  // crossfade value [0 ... 1] for retrigger behavior
+  float *m_fadeValue;
 
-    /* local data structures: rendering body, segment array */
+  /* local data structures: rendering body, segment array */
 
-    env_body_single m_body[dsp_number_of_voices];
-    env_segment_single m_segment[sig_number_of_env_segments + 1];
+  env_body_single m_body[dsp_number_of_voices];
+  env_segment_single m_segment[sig_number_of_env_segments + 1];
 
-    /* object functionality */
+  /* object functionality */
 
-    void start(const uint32_t _voiceId);
-    void stop(const uint32_t _voiceId);
-    void tick(const uint32_t _voiceId);
-    void nextSegment(const uint32_t _voiceId);
-    void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
-    void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
-    void setAttackCurve(const float _value);
-    void setRetriggerHardness(const float _value);
+  void start(const uint32_t _voiceId);
+  void stop(const uint32_t _voiceId);
+  void tick(const uint32_t _voiceId);
+  void nextSegment(const uint32_t _voiceId);
+  void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void setAttackCurve(const float _value);
+  void setRetriggerHardness(const float _value);
 };
 
 /* Gate Envelope Object (currently intended for Gate) */
 
 struct env_object_gate
 {
-    /* predefined segment indices */
+  /* predefined segment indices */
 
-    const uint32_t m_startIndex = 1;                        // segment index of the first segment on key down
-    const uint32_t m_stopIndex = 2;                         // segment index of the final segment on key up
+  const uint32_t m_startIndex = 1;  // segment index of the first segment on key down
+  const uint32_t m_stopIndex = 2;   // segment index of the final segment on key up
 
-    /* local data structures: rendering body, segment array */
+  /* local data structures: rendering body, segment array */
 
-    env_body_single m_body[dsp_number_of_voices];
-    env_segment_single m_segment[sig_number_of_env_segments + 1];
+  env_body_single m_body[dsp_number_of_voices];
+  env_segment_single m_segment[sig_number_of_env_segments + 1];
 
-    /* object functionality */
+  /* object functionality */
 
-    void start(const uint32_t _voiceId);
-    void stop(const uint32_t _voiceId);
-    void tick(const uint32_t _voiceId);
-    void nextSegment(const uint32_t _voiceId);
-    void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
-    void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void start(const uint32_t _voiceId);
+  void stop(const uint32_t _voiceId);
+  void tick(const uint32_t _voiceId);
+  void nextSegment(const uint32_t _voiceId);
+  void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
 };
 
 /* Decay Envelope Object (forcably monophonic, currently intended for Flanger Decay) */
 
 struct env_object_decay
 {
-    /* predefined segment indices */
+  /* predefined segment indices */
 
-    const uint32_t m_startIndex = 1;                        // segment index of the first segment on key down
+  const uint32_t m_startIndex = 1;  // segment index of the first segment on key down
 
-    /* local data structures: rendering body, segment array */
+  /* local data structures: rendering body, segment array */
 
-    env_body_single m_body[1];
-    env_segment_single_mono m_segment[sig_number_of_env_segments + 1];
+  env_body_single m_body[1];
+  env_segment_single_mono m_segment[sig_number_of_env_segments + 1];
 
-    /* object functionality */
+  /* object functionality */
 
-    void start(const uint32_t _voiceId);
-    void tick(const uint32_t _voiceId);
-    void nextSegment(const uint32_t _voiceId);
-    void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
-    void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void start(const uint32_t _voiceId);
+  void tick(const uint32_t _voiceId);
+  void nextSegment(const uint32_t _voiceId);
+  void setSegmentDx(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
+  void setSegmentDest(const uint32_t _voiceId, const uint32_t _segmentId, const float _value);
 };
 
 /********************************************** Envelope Engine Structure **********************************************/
@@ -238,20 +243,20 @@ struct env_object_decay
 
 struct env_engine2
 {
-    /* local data structures: each individual envelope */
+  /* local data structures: each individual envelope */
 
-    env_object_adbdsr_split m_env_a;                                // Envelope A
-    env_object_adbdsr_split m_env_b;                                // Envelope B
-    env_object_adbdsr_retrig m_env_c;                               // Envelope C
-    env_object_gate m_env_g;                                        // Envelope G (Gate)
-    env_object_decay m_env_f;                                       // Envelope F (Flanger)
+  env_object_adbdsr_split m_env_a;   // Envelope A
+  env_object_adbdsr_split m_env_b;   // Envelope B
+  env_object_adbdsr_retrig m_env_c;  // Envelope C
+  env_object_gate m_env_g;           // Envelope G (Gate)
+  env_object_decay m_env_f;          // Envelope F (Flanger)
 
-    /* object functionality (init) */
+  /* object functionality (init) */
 
-    void init(const uint32_t _voices, const float _gateRelease);    // proper initialization
+  void init(const uint32_t _voices, const float _gateRelease);  // proper initialization
 
-    /* object functionality (rendering) */
+  /* object functionality (rendering) */
 
-    void tickMono();                                                // rendering function for monophonic Envelopes
-    void tickPoly(const uint32_t _voiceId);                         // rendering function for polyphonic Envelopes
+  void tickMono();                         // rendering function for monophonic Envelopes
+  void tickPoly(const uint32_t _voiceId);  // rendering function for polyphonic Envelopes
 };


### PR DESCRIPTION
- fixed recall glitch (when previous preset has long release times, unwanted sounds can appear after recalling another preset)
- release times now are influenced by fade point (which is triggered on glitch suppression)
- Options.h now gets polyphony from pe_defines_config.h (so, the maximal number of voices only needs to be set once in the pe_defines_config.h file)