### PR TITLE
avoid z-delay for fx signals by #define

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/dsp_host.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host.h
@@ -155,6 +155,7 @@ class dsp_host
 
   void initAudioEngine();
   void makePolySound(SignalStorage &signals);
+  void makePolyFB(SignalStorage &signals);
   void makeMonoSound(SignalStorage &signals);
 
   // inline?

--- a/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
+++ b/audio-engine/src/synth/c15-audio-engine/pe_defines_config.h
@@ -12,6 +12,9 @@
 
 #include <stdint.h>
 
+// switch signal processing modes: 0 - FX have z-delay (Linux Engine up to now), 1 - FX have no z-delay (like R5 Prototype)
+#define REWORK_POLY_DSP 1
+
 /* Param Interface Testing */
 #define PARAM_ITERATOR 1  // 0: render param bodies by clockIds; 1: render param bodies by direct iteration (default)
 


### PR DESCRIPTION
In pe_definines_config.h, a new flag determines the z-delay behavior of the FX signals for the Feedback Mixer:
- disabled (0): LinuxEngine behavior up to now - one-sample z-delay on FX dry/wet
- enabled (1): R5 Prototype behavior and new default - no z-delay on FX dry/wet