### PR TITLE
Mock Send FX Params properly

### DIFF
--- a/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
+++ b/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
@@ -114,8 +114,8 @@ template <typename tMsg> void insertMockedParameters(tMsg &msg, size_t &unmod, s
                            { 352, 0.5 },
                            { 354, 0.5 },
                            { 389, 0.0 },
-                           { 342, 0.0 },
-                           { 344, 0.0 } })
+                           { 342, 1.0 },
+                           { 344, 1.0 } })
   {
     auto &item = msg.modulateables[mod++];
     item.id = p.first;


### PR DESCRIPTION
set cp value of mocked send reverb / send echo parameters to 1.0 as required by parameterDB
fixes #1184 