### PR TITLE
added more detailed log functionality, better (temporary) initialization

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -27,14 +27,16 @@ inline constexpr bool LOG_MISSING = true;
 inline constexpr bool LOG_FAIL = true;
 inline constexpr bool LOG_INIT = true;
 inline constexpr bool LOG_MIDI = false;
+inline constexpr bool LOG_MIDI_DETAIL = true;
 inline constexpr bool LOG_DISPATCH = false;
 inline constexpr bool LOG_EDITS = true;
 inline constexpr bool LOG_TIMES = true;
 inline constexpr bool LOG_SETTINGS = true;
 inline constexpr bool LOG_RECALL = true;
 inline constexpr bool LOG_RECALL_COMPARE_INITIAL = false;
+inline constexpr bool LOG_RECALL_LEVELS = true;
 inline constexpr bool LOG_KEYS = true;
-inline constexpr bool LOG_KEYS_POLY = false;
+inline constexpr bool LOG_KEYS_POLY = true;
 inline constexpr bool LOG_TRANSITIONS = false;
 inline constexpr bool LOG_RESET = true;
 inline constexpr bool LOG_HW = true;
@@ -110,7 +112,7 @@ class dsp_host_dual
   MonoSection m_mono[2];
   LayerSignalCollection m_z_layers[2];
   // helper values
-  const float m_format_vel = 4095.0f / 127.0f, m_format_hw = 8000.0f / 127.0f, m_format_pb = 8000.0f / 16383.0f,
+  const float m_format_vel = 4095.0f / 127.0f, m_format_hw = 8000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
               m_norm_vel = 1.0f / 4095.0f, m_norm_hw = 1.0f / 8000.0f;
   uint32_t m_key_pos = 0, m_tone_state = 0;
   bool m_key_valid = false, m_layer_changed = false, m_glitch_suppression = false;
@@ -126,7 +128,7 @@ class dsp_host_dual
   void keyUp(const float _vel);
   float scale(const Scale_Aspect _scl, float _value);
   // inner event flow
-  void updateHW(const uint32_t _id, const uint32_t _raw);
+  void updateHW(const uint32_t _id, const float _raw);
   void updateTime(Time_Aspect *_param, const float _ms);
   void hwModChain(HW_Src_Param *_src, const uint32_t _id, const float _inc);
   void globalModChain(Macro_Param *_mc);
@@ -151,4 +153,5 @@ class dsp_host_dual
   void globalTimeRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter &_param);
   void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::ModulateableParameter &_param);
   void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnmodulateableParameter &_param);
+  void debugLevels();
 };


### PR DESCRIPTION
- better log capabilities in order to monitor hw sources, keys, presets (and their single/split/layer conversions) more closely
- engine now initializes splitpoint (currently constant middle key) and both voice groups (parameters and smoothers), which leads to the engine being able to produce sound for all three dual modes