### PR TITLE
Rework change detection

### DIFF
--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -187,11 +187,6 @@ void dsp_host_dual::init(const uint32_t _samplerate, const uint32_t _polyphony)
         break;
     }
   }
-#warning "Audio Engine: loading initial preset internally should be avoided, but currently solves missing sound..."
-  if(RECALL_INITIAL_ONINIT)
-  {
-    onSettingInitialSinglePreset();
-  }
   if(LOG_INIT)
   {
     nltools::Log::info("dsp_host_dual::init - engine dsp status: global");

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1687,76 +1687,30 @@ void dsp_host_dual::recallSingle()
   for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
   {
     auto param = m_params.get_global_direct(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   // start transitions: global modulateables
   for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
   {
     auto param = m_params.get_global_target(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   // start transitions: local unmodulateables
   for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
   {
     auto param = m_params.get_local_direct(0, i);
-    if(RECALL_TRANSITION_ONCHANGE)
+    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
     {
-      if(param->m_changed)
-      {
-        for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-    }
-    else
-    {
-      for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
   }
   // start transitions: local modulateables
   for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
   {
     auto param = m_params.get_local_target(0, i);
-    if(RECALL_TRANSITION_ONCHANGE)
+    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
     {
-      if(param->m_changed)
-      {
-        for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-    }
-    else
-    {
-      for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
   }
   // logging levels after recall for debugging switching dual modes
@@ -1869,33 +1823,13 @@ void dsp_host_dual::recallSplit()
   for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
   {
     auto param = m_params.get_global_direct(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   // start transitions: global modulateables
   for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
   {
     auto param = m_params.get_global_target(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
@@ -1903,33 +1837,13 @@ void dsp_host_dual::recallSplit()
     for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
     {
       auto param = m_params.get_local_direct(layerId, i);
-      if(RECALL_TRANSITION_ONCHANGE)
-      {
-        if(param->m_changed)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-      else
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
     // start transitions: local modulateables
     for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
     {
       auto param = m_params.get_local_target(layerId, i);
-      if(RECALL_TRANSITION_ONCHANGE)
-      {
-        if(param->m_changed)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-      else
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
   }
   // logging levels after recall for debugging switching dual modes
@@ -2044,33 +1958,13 @@ void dsp_host_dual::recallLayer()
   for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
   {
     auto param = m_params.get_global_direct(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   // start transitions: global modulateables
   for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
   {
     auto param = m_params.get_global_target(i);
-    if(RECALL_TRANSITION_ONCHANGE)
-    {
-      if(param->m_changed)
-      {
-        globalTransition(param, m_transition_time.m_dx);
-      }
-    }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
-    }
+    globalTransition(param, m_transition_time.m_dx);
   }
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
@@ -2078,33 +1972,13 @@ void dsp_host_dual::recallLayer()
     for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
     {
       auto param = m_params.get_local_direct(layerId, i);
-      if(RECALL_TRANSITION_ONCHANGE)
-      {
-        if(param->m_changed)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-      else
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
     // start transitions: local modulateables
     for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
     {
       auto param = m_params.get_local_target(layerId, i);
-      if(RECALL_TRANSITION_ONCHANGE)
-      {
-        if(param->m_changed)
-        {
-          localTransition(layerId, param, m_transition_time.m_dx);
-        }
-      }
-      else
-      {
-        localTransition(layerId, param, m_transition_time.m_dx);
-      }
+      localTransition(layerId, param, m_transition_time.m_dx);
     }
   }
   // logging levels after recall for debugging switching dual modes
@@ -2168,14 +2042,10 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::Modulateab
                          ", initial:", element.m_initial, ")");
     }
     auto param = m_params.get_global_target(element.m_param.m_index);
-    param->m_changed = false;
     param->update_source(getMacro(_param.mc));
     param->update_amount(static_cast<float>(_param.modulationAmount));
-    if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
-    {
-      param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-      param->m_changed = true;
-    }
+    param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
+    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
     const uint32_t macroId = getMacroId(_param.mc);
     m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
     param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
@@ -2198,12 +2068,8 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::Unmodulate
                          ", initial:", element.m_initial, ")");
     }
     auto param = m_params.get_global_direct(element.m_param.m_index);
-    param->m_changed = false;
-    if(param->update_position(static_cast<float>(_param.controlPosition)))
-    {
-      param->m_scaled = scale(param->m_scaling, param->m_position);
-      param->m_changed = true;
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
+    param->m_scaled = scale(param->m_scaling, param->m_position);
   }
   else if(LOG_FAIL)
   {
@@ -2223,12 +2089,8 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::GlobalPara
                          ", initial:", element.m_initial, ")");
     }
     auto param = m_params.get_global_direct(element.m_param.m_index);
-    param->m_changed = false;
-    if(param->update_position(static_cast<float>(_param.controlPosition)))
-    {
-      param->m_scaled = scale(param->m_scaling, param->m_position);
-      param->m_changed = true;
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
+    param->m_scaled = scale(param->m_scaling, param->m_position);
   }
   else if(LOG_FAIL)
   {
@@ -2242,10 +2104,8 @@ void dsp_host_dual::globalTimeRcl(const nltools::msg::ParameterGroups::Unmodulat
   if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Time)
   {
     auto param = m_params.get_macro_time(element.m_param.m_index);
-    if(param->update_position(static_cast<float>(_param.controlPosition)))
-    {
-      updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
+    updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
   }
   else if(LOG_FAIL)
   {
@@ -2265,14 +2125,10 @@ void dsp_host_dual::localParRcl(const uint32_t _layerId,
                          ", initial:", element.m_initial, ")");
     }
     auto param = m_params.get_local_target(_layerId, element.m_param.m_index);
-    param->m_changed = false;
     param->update_source(getMacro(_param.mc));
     param->update_amount(static_cast<float>(_param.modulationAmount));
-    if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
-    {
-      param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-      param->m_changed = true;
-    }
+    param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
+    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
     const uint32_t macroId = getMacroId(_param.mc);
     m_params.m_layer[_layerId].m_assignment.reassign(element.m_param.m_index, macroId);
     param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
@@ -2296,12 +2152,8 @@ void dsp_host_dual::localParRcl(const uint32_t _layerId,
                          ", initial:", element.m_initial, ")");
     }
     auto param = m_params.get_local_direct(_layerId, element.m_param.m_index);
-    param->m_changed = false;
-    if(param->update_position(static_cast<float>(_param.controlPosition)))
-    {
-      param->m_scaled = scale(param->m_scaling, param->m_position);
-      param->m_changed = true;
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
+    param->m_scaled = scale(param->m_scaling, param->m_position);
   }
   else if(LOG_FAIL)
   {

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -287,7 +287,7 @@ void dsp_host_dual::onMidiMessage(const uint32_t _status, const uint32_t _data0,
         {
           nltools::Log::info("midiMsg(source:Bender, raw:", arg, ")");
         }
-        updateHW(4, static_cast<float>(arg) * 0.5f);
+        updateHW(4, static_cast<float>(arg));
         break;
       case 5:
         // Aftertouch

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2120,11 +2120,8 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareSo
   if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Source)
   {
     auto param = m_params.get_hw_src(element.m_param.m_index);
-    if(!_param.locked)
-    {
-      param->update_behavior(getBehavior(_param.returnMode));
-      param->update_position(static_cast<float>(_param.controlPosition));
-    }
+    param->update_behavior(getBehavior(_param.returnMode));
+    param->update_position(static_cast<float>(_param.controlPosition));
   }
   else if(LOG_FAIL)
   {
@@ -2137,10 +2134,7 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareAm
   if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Amount)
   {
     auto param = m_params.get_hw_amt(element.m_param.m_index);
-    if(!_param.locked)
-    {
-      param->update_position(static_cast<float>(_param.controlPosition));
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
   }
   else if(LOG_FAIL)
   {
@@ -2154,10 +2148,7 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::MacroParam
   if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Control)
   {
     auto param = m_params.get_macro(element.m_param.m_index);
-    if(!_param.locked)
-    {
-      param->update_position(static_cast<float>(_param.controlPosition));
-    }
+    param->update_position(static_cast<float>(_param.controlPosition));
   }
   else if(LOG_FAIL)
   {
@@ -2178,15 +2169,12 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::Modulateab
     }
     auto param = m_params.get_global_target(element.m_param.m_index);
     param->m_changed = false;
-    if(!_param.locked)
+    param->update_source(getMacro(_param.mc));
+    param->update_amount(static_cast<float>(_param.modulationAmount));
+    if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
     {
-      param->update_source(getMacro(_param.mc));
-      param->update_amount(static_cast<float>(_param.modulationAmount));
-      if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
-      {
-        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-        param->m_changed = true;
-      }
+      param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+      param->m_changed = true;
     }
     const uint32_t macroId = getMacroId(_param.mc);
     m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
@@ -2211,13 +2199,10 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::Unmodulate
     }
     auto param = m_params.get_global_direct(element.m_param.m_index);
     param->m_changed = false;
-    if(!_param.locked)
+    if(param->update_position(static_cast<float>(_param.controlPosition)))
     {
-      if(param->update_position(static_cast<float>(_param.controlPosition)))
-      {
-        param->m_scaled = scale(param->m_scaling, param->m_position);
-        param->m_changed = true;
-      }
+      param->m_scaled = scale(param->m_scaling, param->m_position);
+      param->m_changed = true;
     }
   }
   else if(LOG_FAIL)
@@ -2239,13 +2224,10 @@ void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::GlobalPara
     }
     auto param = m_params.get_global_direct(element.m_param.m_index);
     param->m_changed = false;
-    if(!_param.locked)
+    if(param->update_position(static_cast<float>(_param.controlPosition)))
     {
-      if(param->update_position(static_cast<float>(_param.controlPosition)))
-      {
-        param->m_scaled = scale(param->m_scaling, param->m_position);
-        param->m_changed = true;
-      }
+      param->m_scaled = scale(param->m_scaling, param->m_position);
+      param->m_changed = true;
     }
   }
   else if(LOG_FAIL)
@@ -2260,12 +2242,9 @@ void dsp_host_dual::globalTimeRcl(const nltools::msg::ParameterGroups::Unmodulat
   if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Time)
   {
     auto param = m_params.get_macro_time(element.m_param.m_index);
-    if(!_param.locked)
+    if(param->update_position(static_cast<float>(_param.controlPosition)))
     {
-      if(param->update_position(static_cast<float>(_param.controlPosition)))
-      {
-        updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
-      }
+      updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
     }
   }
   else if(LOG_FAIL)
@@ -2287,15 +2266,12 @@ void dsp_host_dual::localParRcl(const uint32_t _layerId,
     }
     auto param = m_params.get_local_target(_layerId, element.m_param.m_index);
     param->m_changed = false;
-    if(!_param.locked)
+    param->update_source(getMacro(_param.mc));
+    param->update_amount(static_cast<float>(_param.modulationAmount));
+    if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
     {
-      param->update_source(getMacro(_param.mc));
-      param->update_amount(static_cast<float>(_param.modulationAmount));
-      if(param->update_position(param->depolarize(static_cast<float>(_param.controlPosition))))
-      {
-        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-        param->m_changed = true;
-      }
+      param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+      param->m_changed = true;
     }
     const uint32_t macroId = getMacroId(_param.mc);
     m_params.m_layer[_layerId].m_assignment.reassign(element.m_param.m_index, macroId);
@@ -2321,13 +2297,10 @@ void dsp_host_dual::localParRcl(const uint32_t _layerId,
     }
     auto param = m_params.get_local_direct(_layerId, element.m_param.m_index);
     param->m_changed = false;
-    if(!_param.locked)
+    if(param->update_position(static_cast<float>(_param.controlPosition)))
     {
-      if(param->update_position(static_cast<float>(_param.controlPosition)))
-      {
-        param->m_scaled = scale(param->m_scaling, param->m_position);
-        param->m_changed = true;
-      }
+      param->m_scaled = scale(param->m_scaling, param->m_position);
+      param->m_changed = true;
     }
   }
   else if(LOG_FAIL)

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -40,8 +40,6 @@ inline constexpr bool LOG_KEYS_POLY = true;
 inline constexpr bool LOG_TRANSITIONS = false;
 inline constexpr bool LOG_RESET = true;
 inline constexpr bool LOG_HW = true;
-// modifiers/settings
-inline constexpr bool RECALL_INITIAL_ONINIT = false;
 
 class dsp_host_dual
 {

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -41,8 +41,7 @@ inline constexpr bool LOG_TRANSITIONS = false;
 inline constexpr bool LOG_RESET = true;
 inline constexpr bool LOG_HW = true;
 // modifiers/settings
-inline constexpr bool RECALL_INITIAL_ONINIT = true;
-inline constexpr bool RECALL_TRANSITION_ONCHANGE = false;
+inline constexpr bool RECALL_INITIAL_ONINIT = false;
 
 class dsp_host_dual
 {

--- a/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -109,8 +109,8 @@ class dsp_host_dual
   MonoSection m_mono[2];
   LayerSignalCollection m_z_layers[2];
   // helper values
-  const float m_format_vel = 4095.0f / 127.0f, m_format_hw = 8000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
-              m_norm_vel = 1.0f / 4095.0f, m_norm_hw = 1.0f / 8000.0f;
+  const float m_format_vel = 4095.0f / 127.0f, m_format_hw = 16000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
+              m_norm_vel = 1.0f / 4095.0f, m_norm_hw = 1.0f / 16000.0f;
   uint32_t m_key_pos = 0, m_tone_state = 0;
   bool m_key_valid = false, m_layer_changed = false, m_glitch_suppression = false;
   // handles for inconvenient stuff

--- a/audio-engine/src/synth/c15-audio-engine/parameter_storage.h
+++ b/audio-engine/src/synth/c15-audio-engine/parameter_storage.h
@@ -124,7 +124,7 @@ namespace Engine
       C15::Parameters::Macro_Controls m_source = C15::Parameters::Macro_Controls::None;
       Scale_Aspect m_scaling;
       Render_Aspect m_render;
-      bool m_polarity = false, m_changed = false;
+      bool m_polarity = false;
       inline bool update_source(const C15::Parameters::Macro_Controls _source)
       {
         if(_source != m_source)
@@ -176,7 +176,6 @@ namespace Engine
       float m_scaled = 0.0f;
       Scale_Aspect m_scaling;
       Render_Aspect m_render;
-      bool m_changed = false;
     };
 
   }  // namespace Engine::Parameters

--- a/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -272,7 +272,7 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
         break;
       case LayerMode::Split:
         // determine split target
-        if(m_splitPoint > _keyPos)
+        if(_keyPos <= m_splitPoint)
         {
           _keyState->m_origin = AllocatorId::Local_I;
           _keyState->m_voiceId = m_local[0].keyDown();


### PR DESCRIPTION
- removed change detection from recall procedures (no internal preset loading necessary on application start)
- removed lock from recall procedures (can be completely removed from nltools/message now)
- fixed hw source ranges [0 ... 16000]
- fixed split point application in voice allocation (parameter messages follow soon..)