### PR TITLE
Add dynamic labels

### DIFF
--- a/playground/src/parameters/Parameter.cpp
+++ b/playground/src/parameters/Parameter.cpp
@@ -304,12 +304,12 @@ void Parameter::invalidate()
 
 Glib::ustring Parameter::getLongName() const
 {
-  return ParameterDB::get().getLongName(getID().getNumber());
+  return ParameterDB::get().getLongName(getID());
 }
 
 Glib::ustring Parameter::getShortName() const
 {
-  return ParameterDB::get().getShortName(getID().getNumber());
+  return ParameterDB::get().getShortName(getID());
 }
 
 Glib::ustring Parameter::getMiniParameterEditorName() const

--- a/playground/src/parameters/names/ParameterDB.cpp
+++ b/playground/src/parameters/names/ParameterDB.cpp
@@ -57,6 +57,7 @@ Glib::ustring ParameterDB::getShortName(int id) const
     nltools::Log::error("there is no short name entry in parameter list for parameter", id);
     return "MISSING!!!";
   }
+
   return replaceVoiceGroupInDynamicLabels(d.m_pg.m_param_label_short);
 }
 

--- a/playground/src/parameters/names/ParameterDB.h
+++ b/playground/src/parameters/names/ParameterDB.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nltools/Types.h>
+#include <ParameterId.h>
 #include "playground.h"
 
 class Parameter;
@@ -11,8 +13,8 @@ class ParameterDB
 
   virtual ~ParameterDB();
 
-  Glib::ustring getLongName(int id) const;
-  Glib::ustring getShortName(int id) const;
+  Glib::ustring getLongName(const ParameterId& id) const;
+  Glib::ustring getShortName(const ParameterId& id) const;
   tControlPositionValue getSignalPathIndication(int id) const;
 
   static constexpr tControlPositionValue getInvalidSignalPathIndication()
@@ -24,6 +26,6 @@ class ParameterDB
 
  private:
 
-  Glib::ustring replaceVoiceGroupInDynamicLabels(Glib::ustring name) const;
+  Glib::ustring replaceVoiceGroupInDynamicLabels(Glib::ustring name, VoiceGroup originGroup) const;
   ParameterDB();
 };

--- a/playground/src/parameters/names/ParameterDB.h
+++ b/playground/src/parameters/names/ParameterDB.h
@@ -23,5 +23,7 @@ class ParameterDB
   bool isActive(const Parameter *p) const;
 
  private:
+
+  Glib::ustring replaceVoiceGroupInDynamicLabels(Glib::ustring name) const;
   ParameterDB();
 };

--- a/playground/src/testing/unit-tests/parameters/ParameterNameSaneTest.cpp
+++ b/playground/src/testing/unit-tests/parameters/ParameterNameSaneTest.cpp
@@ -1,0 +1,14 @@
+#include "testing/TestHelper.h"
+#include "third-party/include/catch.hpp"
+#include "presets/EditBuffer.h"
+
+TEST_CASE("No Parameter Name Contains '@VG' placeholder")
+{
+  for(auto vg : { VoiceGroup::I, VoiceGroup::II, VoiceGroup::Global })
+    for(auto& g : TestHelper::getEditBuffer()->getParameterGroups(vg))
+      for(auto& p : g->getParameters())
+      {
+        REQUIRE(p->getLongName().find("@VG") == std::string::npos);
+        REQUIRE(p->getShortName().find("@VG") == std::string::npos);
+      }
+}


### PR DESCRIPTION
replace '@VG' in parameter name, with inverted current voice group:
eg: A/B @VG -> to A/B II on VoiceGroup I Select and A/B I on selected Voicegroup II 