### PR TITLE
Fix fileversion reaktor to 1.5

### DIFF
--- a/playground/src/parameters/ParameterImportConversions.cpp
+++ b/playground/src/parameters/ParameterImportConversions.cpp
@@ -173,6 +173,8 @@ void ParameterImportConversions::registerTests()
 
     a.registerConverter(10, 7, [](tControlPositionValue v) { return v * 4; });
 
+    a.registerConverter(249, 5, [](tControlPositionValue v) { return v * 0.5; });
+
     g_assert(a.convert(9, 0.5, 2) == 0.5);
     g_assert(a.convert(9, 0.5, 4) == 0.5);
     g_assert(a.convert(9, 0.5, 7) == 0.5);
@@ -187,5 +189,9 @@ void ParameterImportConversions::registerTests()
     g_assert(a.convert(10, 0.5, 7) == 0.5 * 4);
     g_assert(a.convert(10, 0.5, 8) == 0.5);
     g_assert(a.convert(10, 0.5, 9) == 0.5);
+
+    g_assert(a.convert(249, 0.5, 5) == 0.25);
+    g_assert(a.convert(249, 0, 5) == 0);
+    g_assert(a.convert(249, 1, 5) == 0.5);
   });
 }

--- a/playground/src/parameters/names/ParameterDB.cpp
+++ b/playground/src/parameters/names/ParameterDB.cpp
@@ -5,6 +5,7 @@
 #include <tools/StringTools.h>
 #include "RowStream.h"
 #include <parameters/Parameter.h>
+#include <device-settings/DebugLevel.h>
 
 ParameterDB &ParameterDB::get()
 {
@@ -77,17 +78,41 @@ tControlPositionValue ParameterDB::parseSignalPathIndication(const std::string &
 
 ustring ParameterDB::getLongName(int id) const
 {
-  return m_spec.at(id).longName;
+  try
+  {
+    return m_spec.at(id).longName;
+  }
+  catch(...)
+  {
+    DebugLevel::error("ParameterDB: ", id, ": long name not found!");
+    return "";
+  }
 }
 
 ustring ParameterDB::getShortName(int id) const
 {
-  return m_spec.at(id).shortName;
+  try
+  {
+    return m_spec.at(id).shortName;
+  }
+  catch(...)
+  {
+    DebugLevel::error("ParameterDB: ", id, ": short name not found!");
+    return "";
+  }
 }
 
 tControlPositionValue ParameterDB::getSignalPathIndication(int id) const
 {
-  return m_spec.at(id).signalPathIndication;
+  try
+  {
+    return m_spec.at(id).signalPathIndication;
+  }
+  catch(...)
+  {
+    DebugLevel::error("ParameterDB: ", id, ": signal path indication not found!");
+    return 0;
+  }
 }
 
 bool ParameterDB::isActive(const Parameter *p) const

--- a/playground/src/presets/PresetManagerActions.cpp
+++ b/playground/src/presets/PresetManagerActions.cpp
@@ -209,7 +209,7 @@ PresetManagerActions::~PresetManagerActions()
 }
 
 void PresetManagerActions::handleImportBackupFile(UNDO::Transaction *transaction, SoupBuffer *buffer,
-                                                  std::shared_ptr<HTTPRequest> http)
+                                                  const std::shared_ptr<HTTPRequest> &http)
 {
   if(auto lock = m_presetManager.getLoadingLock())
   {

--- a/playground/src/presets/PresetManagerActions.h
+++ b/playground/src/presets/PresetManagerActions.h
@@ -22,7 +22,7 @@ class PresetManagerActions : public RPCActionManager
   bool handleRequest(const Glib::ustring& path, std::shared_ptr<NetworkRequest> request) override;
 
  private:
-  void handleImportBackupFile(UNDO::Transaction* transaction, SoupBuffer* buffer, std::shared_ptr<HTTPRequest> http);
+  void handleImportBackupFile(UNDO::Transaction* transaction, SoupBuffer* buffer, const std::shared_ptr<HTTPRequest>& http);
 
   typedef Preset* tPresetPtr;
 };

--- a/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
+++ b/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
@@ -75,8 +75,6 @@ void PanelUnitParameterEditMode::setupFocusAndMode(FocusAndMode focusAndMode)
 void PanelUnitParameterEditMode::assertAllButtonsAssigned()
 {
 #if _TESTS
-#warning "FIXME"
-  return;
   if(Application::get().getPresetManager()->getEditBuffer()->countParameters() != assignedAudioIDs.size())
   {
     int lastOne = -1;

--- a/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
+++ b/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
@@ -75,6 +75,8 @@ void PanelUnitParameterEditMode::setupFocusAndMode(FocusAndMode focusAndMode)
 void PanelUnitParameterEditMode::assertAllButtonsAssigned()
 {
 #if _TESTS
+#warning "FIXME"
+  return;
   if(Application::get().getPresetManager()->getEditBuffer()->countParameters() != assignedAudioIDs.size())
   {
     int lastOne = -1;

--- a/playground/src/serialization/PresetParameterGroupSerializer.cpp
+++ b/playground/src/serialization/PresetParameterGroupSerializer.cpp
@@ -32,11 +32,18 @@ void PresetParameterGroupSerializer::readTagContent(Reader &reader) const
   if(m_paramGroup)
   {
     reader.onTag(PresetParameterSerializer::getTagName(), [&](const Attributes &attr) mutable {
-      auto id = std::stoi(attr.get("id"));
-      auto param = std::make_unique<PresetParameter>(id);
-      auto serializer = new PresetParameterSerializer(param.get());
-      m_paramGroup->m_parameters[id] = std::move(param);
-      return serializer;
+      try
+      {
+        auto id = std::stoi(attr.get("id"));
+        auto param = std::make_unique<PresetParameter>(id);
+        auto serializer = new PresetParameterSerializer(param.get());
+        m_paramGroup->m_parameters[id] = std::move(param);
+        return serializer;
+      }
+      catch(...)
+      {
+        return static_cast<PresetParameterSerializer *>(nullptr);
+      }
     });
   }
 }

--- a/playground/src/serialization/PresetParameterGroupsSerializer.cpp
+++ b/playground/src/serialization/PresetParameterGroupsSerializer.cpp
@@ -26,10 +26,17 @@ void PresetParameterGroupsSerializer::writeTagContent(Writer &writer) const
 void PresetParameterGroupsSerializer::readTagContent(Reader &reader) const
 {
   reader.onTag(PresetParameterGroupSerializer::getTagName(), [&](const Attributes &attr) mutable {
-    auto id = attr.get("id");
-    auto group = std::make_unique<PresetParameterGroup>();
-    auto serializer = new PresetParameterGroupSerializer(group.get());
-    m_preset->m_parameterGroups[id] = std::move(group);
-    return serializer;
+    try
+    {
+      auto id = attr.get("id");
+      auto group = std::make_unique<PresetParameterGroup>();
+      auto serializer = new PresetParameterGroupSerializer(group.get());
+      m_preset->m_parameterGroups[id] = std::move(group);
+      return serializer;
+    }
+    catch(...)
+    {
+      return static_cast<PresetParameterGroupSerializer *>(nullptr);
+    }
   });
 }

--- a/playground/src/xml/VersionAttribute.cpp
+++ b/playground/src/xml/VersionAttribute.cpp
@@ -17,5 +17,5 @@ VersionAttribute &VersionAttribute::get()
 
 int VersionAttribute::getCurrentFileVersion()
 {
-  return 5;
+  return 6;
 }


### PR DESCRIPTION
Reaktor Version-attribute: 5
Fixes 1.5 Version-attribute to 6

import conversion from reaktor halves CP to match number of unison voices. Converter was already implemented (L.74) 

and 

fixes #1286 