### PR TITLE
fixes #1527

### DIFF
--- a/projects/playground/src/presets/EditBuffer.cpp
+++ b/projects/playground/src/presets/EditBuffer.cpp
@@ -676,6 +676,8 @@ void EditBuffer::undoableConvertDualToSingle(UNDO::Transaction *transaction, Voi
 
 void EditBuffer::undoableConvertToDual(UNDO::Transaction *transaction, SoundType type)
 {
+  const auto oldType = m_type;
+
   if(m_type == type)
     return;
 
@@ -685,7 +687,10 @@ void EditBuffer::undoableConvertToDual(UNDO::Transaction *transaction, SoundType
   initToFX(transaction);
 
   undoableSetType(transaction, type);
-  copyVoiceGroup(transaction, VoiceGroup::I, VoiceGroup::II);
+  
+  if(oldType == SoundType::Single)
+    copyVoiceGroup(transaction, VoiceGroup::I, VoiceGroup::II);
+
   copyAndInitGlobalMasterGroupToPartMasterGroups(transaction);
 
   initSplitPoint(transaction);

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/ConvertDualToDual.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/ConvertDualToDual.cpp
@@ -45,3 +45,32 @@ TEST_CASE("Convert Layer to Split works for parameter Groups", "[EditBuffer][Con
     }
   }
 }
+
+TEST_CASE("Converting Layer to Split/Single resets Mute Parameter", "[EditBuffer][Convert]")
+{
+  auto eb = TestHelper::getEditBuffer();
+  auto muteI = eb->findParameterByID({ 395, VoiceGroup::I });
+  auto muteII = eb->findParameterByID({ 395, VoiceGroup::II });
+
+  WHEN("Mute is enabled in Layer")
+  {
+    TestHelper::initDualEditBuffer<SoundType::Layer>();
+    auto scope = TestHelper::createTestScope();
+    muteI->setCPFromHwui(scope->getTransaction(), 1);
+    muteII->setCPFromHwui(scope->getTransaction(), 1);
+
+    CHECK_PARAMETER_CP_EQUALS_FICTION(muteI, 1);
+    CHECK_PARAMETER_CP_EQUALS_FICTION(muteII, 1);
+
+    WHEN("Converted to Split")
+    {
+      eb->undoableConvertToDual(scope->getTransaction(), SoundType::Split);
+
+      THEN("Mute is disabled!")
+      {
+        CHECK_PARAMETER_CP_EQUALS_FICTION(muteI, 0);
+        CHECK_PARAMETER_CP_EQUALS_FICTION(muteII, 0);
+      }
+    }
+  }
+}

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/ConvertDualToDual.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/ConvertDualToDual.cpp
@@ -1,6 +1,6 @@
 #include <testing/TestHelper.h>
 
-TEST_CASE("Convert Layer to Split Sound", "[EditBuffer][Convert]")
+TEST_CASE("Convert Layer to Split Sound Resets Split", "[EditBuffer][Convert]")
 {
   auto eb = TestHelper::getEditBuffer();
   auto splitPoint = eb->findParameterByID({ 356, VoiceGroup::Global });
@@ -21,4 +21,27 @@ TEST_CASE("Convert Layer to Split Sound", "[EditBuffer][Convert]")
   }
 
   CHECK_PARAMETER_CP_EQUALS_FICTION(splitPoint, 0.5);
+}
+
+TEST_CASE("Convert Layer to Split works for parameter Groups", "[EditBuffer][Convert]")
+{
+  auto eb = TestHelper::getEditBuffer();
+
+  auto paramI = eb->findParameterByID({ 0, VoiceGroup::I });
+  auto paramII = eb->findParameterByID({ 0, VoiceGroup::II });
+
+  WHEN("Parameters I / II have different values")
+  {
+    auto scope = TestHelper::createTestScope();
+    TestHelper::initDualEditBuffer<SoundType::Layer>();
+    paramI->setCPFromHwui(scope->getTransaction(), 0);
+    paramII->setCPFromHwui(scope->getTransaction(), 1);
+
+    THEN("Converted to Split Sound the Values still differ")
+    {
+      eb->undoableConvertToDual(scope->getTransaction(), SoundType::Split);
+      REQUIRE(eb->getType() == SoundType::Split);
+      REQUIRE(paramI->getValue().getRawValue() != paramII->getValue().getRawValue());
+    }
+  }
 }


### PR DESCRIPTION
check if the old type is single, only then copy the first voice group to voice group I
if not single we are converting dual to dual and the voice groups will remain untouched