### PR TITLE
Audio engine implement fade params on recall

### DIFF
--- a/projects/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/audio-engine/src/synth/C15Synth.cpp
@@ -1,281 +1,272 @@
 #include "C15Synth.h"
+#include "Options.h"
 #include "c15-audio-engine/dsp_host_dual.h"
 #include "main.h"
-#include "Options.h"
 
-#include <nltools/messaging/Message.h>
 #include <nltools/logging/Log.h>
+#include <nltools/messaging/Message.h>
 
 C15Synth::C15Synth()
     : m_dsp(std::make_unique<dsp_host_dual>())
 {
-  m_dsp->init(getOptions()->getSampleRate(), getOptions()->getPolyphony());
+    m_dsp->init(getOptions()->getSampleRate(), getOptions()->getPolyphony());
 
-  using namespace nltools::msg;
+    using namespace nltools::msg;
 
-  receive<SinglePresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onSinglePresetMessage));
-  receive<LayerPresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onLayerPresetMessage));
-  receive<SplitPresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onSplitPresetMessage));
+    receive<SinglePresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onSinglePresetMessage));
+    receive<LayerPresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onLayerPresetMessage));
+    receive<SplitPresetMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onSplitPresetMessage));
 
-  receive<UnmodulateableParameterChangedMessage>(EndPoint::AudioEngine,
-                                                 sigc::mem_fun(this, &C15Synth::onUnmodulateableParameterMessage));
-  receive<ModulateableParameterChangedMessage>(EndPoint::AudioEngine,
-                                               sigc::mem_fun(this, &C15Synth::onModulateableParameterMessage));
-  receive<MacroControlChangedMessage>(EndPoint::AudioEngine,
-                                      sigc::mem_fun(this, &C15Synth::onMacroControlParameterMessage));
-  receive<HWSourceChangedMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onHWSourceMessage));
-  receive<HWAmountChangedMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onHWAmountMessage));
+    receive<UnmodulateableParameterChangedMessage>(EndPoint::AudioEngine,
+        sigc::mem_fun(this, &C15Synth::onUnmodulateableParameterMessage));
+    receive<ModulateableParameterChangedMessage>(EndPoint::AudioEngine,
+        sigc::mem_fun(this, &C15Synth::onModulateableParameterMessage));
+    receive<MacroControlChangedMessage>(EndPoint::AudioEngine,
+        sigc::mem_fun(this, &C15Synth::onMacroControlParameterMessage));
+    receive<HWSourceChangedMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onHWSourceMessage));
+    receive<HWAmountChangedMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onHWAmountMessage));
 
-  //Settings
-  receive<Setting::NoteShiftMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onNoteShiftMessage));
-  receive<Setting::PresetGlitchMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onPresetGlitchMessage));
-  receive<Setting::TransitionTimeMessage>(EndPoint::AudioEngine,
-                                          sigc::mem_fun(this, &C15Synth::onTransitionTimeMessage));
-  receive<Setting::EditSmoothingTimeMessage>(EndPoint::AudioEngine,
-                                             sigc::mem_fun(this, &C15Synth::onEditSmoothingTimeMessage));
+    //Settings
+    receive<Setting::NoteShiftMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onNoteShiftMessage));
+    receive<Setting::PresetGlitchMessage>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onPresetGlitchMessage));
+    receive<Setting::TransitionTimeMessage>(EndPoint::AudioEngine,
+        sigc::mem_fun(this, &C15Synth::onTransitionTimeMessage));
+    receive<Setting::EditSmoothingTimeMessage>(EndPoint::AudioEngine,
+        sigc::mem_fun(this, &C15Synth::onEditSmoothingTimeMessage));
 
-  receive<Setting::TuneReference>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onTuneReferenceMessage));
+    receive<Setting::TuneReference>(EndPoint::AudioEngine, sigc::mem_fun(this, &C15Synth::onTuneReferenceMessage));
 
-  receive<Keyboard::NoteUp>(EndPoint::AudioEngine, [this](const Keyboard::NoteUp &noteUp) {
-    MidiEvent keyUp;
-    keyUp.raw[0] = 0;
-    keyUp.raw[1] = noteUp.m_keyPos;
-    keyUp.raw[2] = 0;
-    doMidi(keyUp);
-  });
+    receive<Keyboard::NoteUp>(EndPoint::AudioEngine, [this](const Keyboard::NoteUp& noteUp) {
+        MidiEvent keyUp;
+        keyUp.raw[0] = 0;
+        keyUp.raw[1] = noteUp.m_keyPos;
+        keyUp.raw[2] = 0;
+        doMidi(keyUp);
+    });
 
-  receive<Keyboard::NoteDown>(EndPoint::AudioEngine, [this](const Keyboard::NoteDown &noteDown) {
-    MidiEvent keyDown;
-    keyDown.raw[0] = 1 << 4;
-    keyDown.raw[1] = noteDown.m_keyPos;
-    keyDown.raw[2] = 127;
-    doMidi(keyDown);
-  });
+    receive<Keyboard::NoteDown>(EndPoint::AudioEngine, [this](const Keyboard::NoteDown& noteDown) {
+        MidiEvent keyDown;
+        keyDown.raw[0] = 1 << 4;
+        keyDown.raw[1] = noteDown.m_keyPos;
+        keyDown.raw[2] = 127;
+        doMidi(keyDown);
+    });
 }
 
 C15Synth::~C15Synth() = default;
 
-void C15Synth::doMidi(const MidiEvent &event)
+void C15Synth::doMidi(const MidiEvent& event)
 {
 #if test_inputModeFlag
-  m_dsp->onRawMidiMessage(event.raw[0], event.raw[1], event.raw[2]);
+    m_dsp->onRawMidiMessage(event.raw[0], event.raw[1], event.raw[2]);
 #else
-  m_dsp->onMidiMessage(event.raw[0], event.raw[1], event.raw[2]);
+    m_dsp->onMidiMessage(event.raw[0], event.raw[1], event.raw[2]);
 #endif
 }
 
-void C15Synth::doAudio(SampleFrame *target, size_t numFrames)
+void C15Synth::doAudio(SampleFrame* target, size_t numFrames)
 {
-  for(size_t i = 0; i < numFrames; i++)
-  {
-    m_dsp->render();
-    target[i].left = m_dsp->m_mainOut_L;
-    target[i].right = m_dsp->m_mainOut_R;
-  }
+    for (size_t i = 0; i < numFrames; i++) {
+        m_dsp->render();
+        target[i].left = m_dsp->m_mainOut_L;
+        target[i].right = m_dsp->m_mainOut_R;
+    }
 }
 
 void C15Synth::logStatus()
 {
-  m_dsp->logStatus();
+    m_dsp->logStatus();
 }
 
 void C15Synth::resetDSP()
 {
-  m_dsp->reset();
+    m_dsp->reset();
 }
 
 void C15Synth::toggleTestTone()
 {
-  switch(m_dsp->onSettingToneToggle())
-  {
+    switch (m_dsp->onSettingToneToggle()) {
     case 0:
-      nltools::Log::info("toggle TestTone: C15 only");
-      break;
+        nltools::Log::info("toggle TestTone: C15 only");
+        break;
     case 1:
-      nltools::Log::info("toggle TestTone: Tone only");
-      break;
+        nltools::Log::info("toggle TestTone: Tone only");
+        break;
     case 2:
-      nltools::Log::info("toggle TestTone: C15 and Tone");
-      break;
-  }
-  //nltools::Log::info("TestTone is implemented before soft clipper and switches via Fadepoint now");
+        nltools::Log::info("toggle TestTone: C15 and Tone");
+        break;
+    }
+    //nltools::Log::info("TestTone is implemented before soft clipper and switches via Fadepoint now");
 }
 
 void C15Synth::selectTestToneFrequency()
 {
-  nltools::Log::info("currently disabled");
+    nltools::Log::info("currently disabled");
 }
 
 void C15Synth::selectTestToneAmplitude()
 {
-  nltools::Log::info("currently disabled");
+    nltools::Log::info("currently disabled");
 }
 
 void C15Synth::increase()
 {
-  changeSelectedValueBy(1);
+    changeSelectedValueBy(1);
 }
 
 void C15Synth::decrease()
 {
-  changeSelectedValueBy(-1);
+    changeSelectedValueBy(-1);
 }
 
 double C15Synth::measurePerformance(std::chrono::seconds time)
 {
-  for(int i = 0; i < getOptions()->getPolyphony(); i++)
-  {
-    m_dsp->onMidiMessage(1, 0, 53);
-    m_dsp->onMidiMessage(5, 62, 64);
-    m_dsp->onMidiMessage(1, 0, 83);
-    m_dsp->onMidiMessage(5, 62, 64);
-  }
-  return Synth::measurePerformance(time);
+    for (int i = 0; i < getOptions()->getPolyphony(); i++) {
+        m_dsp->onMidiMessage(1, 0, 53);
+        m_dsp->onMidiMessage(5, 62, 64);
+        m_dsp->onMidiMessage(1, 0, 83);
+        m_dsp->onMidiMessage(5, 62, 64);
+    }
+    return Synth::measurePerformance(time);
 }
 
 void C15Synth::changeSelectedValueBy(int i)
 {
-  nltools::Log::info("currently disabled");
+    nltools::Log::info("currently disabled");
 }
 
-void C15Synth::onModulateableParameterMessage(const nltools::msg::ModulateableParameterChangedMessage &msg)
+void C15Synth::onModulateableParameterMessage(const nltools::msg::ModulateableParameterChangedMessage& msg)
 {
-  // (fail-safe) dispatch by ParameterList
-  auto element = m_dsp->getParameter(msg.parameterId);
-  switch(element.m_param.m_type)
-  {
+    // (fail-safe) dispatch by ParameterList
+    auto element = m_dsp->getParameter(msg.parameterId);
+    switch (element.m_param.m_type) {
     case C15::Descriptors::ParameterType::Global_Modulateable:
-      m_dsp->globalParChg(element.m_param.m_index, msg);
-      return;
+        m_dsp->globalParChg(element.m_param.m_index, msg);
+        return;
     case C15::Descriptors::ParameterType::Local_Modulateable:
-      m_dsp->localParChg(element.m_param.m_index, msg);
-      return;
-  }
+        m_dsp->localParChg(element.m_param.m_index, msg);
+        return;
+    }
 #if LOG_FAIL
-  nltools::Log::warning("invalid Modulateable_Parameter ID:", msg.parameterId);
+    nltools::Log::warning("invalid Modulateable_Parameter ID:", msg.parameterId);
 #endif
 }
 
-void C15Synth::onUnmodulateableParameterMessage(const nltools::msg::UnmodulateableParameterChangedMessage &msg)
+void C15Synth::onUnmodulateableParameterMessage(const nltools::msg::UnmodulateableParameterChangedMessage& msg)
 {
-  // (fail-safe) dispatch by ParameterList
-  auto element = m_dsp->getParameter(msg.parameterId);
-  // further (subtype) distinction
-  switch(element.m_param.m_type)
-  {
+    // (fail-safe) dispatch by ParameterList
+    auto element = m_dsp->getParameter(msg.parameterId);
+    // further (subtype) distinction
+    switch (element.m_param.m_type) {
     case C15::Descriptors::ParameterType::Global_Unmodulateable:
-      m_dsp->globalParChg(element.m_param.m_index, msg);
-      return;
+        m_dsp->globalParChg(element.m_param.m_index, msg);
+        return;
     case C15::Descriptors::ParameterType::Macro_Time:
-      m_dsp->globalTimeChg(element.m_param.m_index, msg);
-      return;
+        m_dsp->globalTimeChg(element.m_param.m_index, msg);
+        return;
     case C15::Descriptors::ParameterType::Local_Unmodulateable:
-      // poly detection
-      switch(static_cast<C15::Parameters::Local_Unmodulateables>(element.m_param.m_index))
-      {
+        // poly detection
+        switch (static_cast<C15::Parameters::Local_Unmodulateables>(element.m_param.m_index)) {
         case C15::Parameters::Local_Unmodulateables::Unison_Voices:
-          m_dsp->localUnisonVoicesChg(msg);
-          break;
+            m_dsp->localUnisonVoicesChg(msg);
+            break;
         case C15::Parameters::Local_Unmodulateables::Mono_Grp_Enable:
-          m_dsp->localMonoEnableChg(msg);
-          break;
+            m_dsp->localMonoEnableChg(msg);
+            break;
         case C15::Parameters::Local_Unmodulateables::Mono_Grp_Prio:
-          m_dsp->localMonoPriorityChg(msg);
-          break;
+            m_dsp->localMonoPriorityChg(msg);
+            break;
         case C15::Parameters::Local_Unmodulateables::Mono_Grp_Legato:
-          m_dsp->localMonoLegatoChg(msg);
-          break;
+            m_dsp->localMonoLegatoChg(msg);
+            break;
         default:
-          m_dsp->localParChg(element.m_param.m_index, msg);
-          break;
-      }
-      return;
+            m_dsp->localParChg(element.m_param.m_index, msg);
+            break;
+        }
+        return;
     default:
-      break;
-  }
+        break;
+    }
 #if LOG_FAIL
-  nltools::Log::warning("invalid Unmodulateable_Parameter ID:", msg.parameterId);
+    nltools::Log::warning("invalid Unmodulateable_Parameter ID:", msg.parameterId);
 #endif
 }
 
-void C15Synth::onMacroControlParameterMessage(const nltools::msg::MacroControlChangedMessage &msg)
+void C15Synth::onMacroControlParameterMessage(const nltools::msg::MacroControlChangedMessage& msg)
 {
-  // (fail-safe) dispatch by ParameterList
-  auto element = m_dsp->getParameter(msg.parameterId);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Control)
-  {
-    m_dsp->globalParChg(element.m_param.m_index, msg);
-    return;
-  }
+    // (fail-safe) dispatch by ParameterList
+    auto element = m_dsp->getParameter(msg.parameterId);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Control) {
+        m_dsp->globalParChg(element.m_param.m_index, msg);
+        return;
+    }
 #if LOG_FAIL
-  nltools::Log::warning("invalid Macro_Control ID:", msg.parameterId);
+    nltools::Log::warning("invalid Macro_Control ID:", msg.parameterId);
 #endif
 }
 
-void C15Synth::onHWAmountMessage(const nltools::msg::HWAmountChangedMessage &msg)
+void C15Synth::onHWAmountMessage(const nltools::msg::HWAmountChangedMessage& msg)
 {
-  // (fail-safe) dispatch by ParameterList
-  auto element = m_dsp->getParameter(msg.parameterId);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Amount)
-  {
-    m_dsp->globalParChg(element.m_param.m_index, msg);
-    return;
-  }
+    // (fail-safe) dispatch by ParameterList
+    auto element = m_dsp->getParameter(msg.parameterId);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Amount) {
+        m_dsp->globalParChg(element.m_param.m_index, msg);
+        return;
+    }
 #if LOG_FAIL
-  nltools::Log::warning("invalid HW_Amount ID:", msg.parameterId);
+    nltools::Log::warning("invalid HW_Amount ID:", msg.parameterId);
 #endif
 }
 
-void C15Synth::onHWSourceMessage(const nltools::msg::HWSourceChangedMessage &msg)
+void C15Synth::onHWSourceMessage(const nltools::msg::HWSourceChangedMessage& msg)
 {
-  // (fail-safe) dispatch by ParameterList
-  auto element = m_dsp->getParameter(msg.parameterId);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Source)
-  {
-    m_dsp->globalParChg(element.m_param.m_index, msg);
-    return;
-  }
+    // (fail-safe) dispatch by ParameterList
+    auto element = m_dsp->getParameter(msg.parameterId);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Source) {
+        m_dsp->globalParChg(element.m_param.m_index, msg);
+        return;
+    }
 #if LOG_FAIL
-  nltools::Log::warning("invalid HW_Source ID:", msg.parameterId);
+    nltools::Log::warning("invalid HW_Source ID:", msg.parameterId);
 #endif
 }
 
-void C15Synth::onSplitPresetMessage(const nltools::msg::SplitPresetMessage &msg)
+void C15Synth::onSplitPresetMessage(const nltools::msg::SplitPresetMessage& msg)
 {
-  m_dsp->onPresetMessage(msg);
+    m_dsp->onPresetMessage(msg);
 }
 
-void C15Synth::onSinglePresetMessage(const nltools::msg::SinglePresetMessage &msg)
+void C15Synth::onSinglePresetMessage(const nltools::msg::SinglePresetMessage& msg)
 {
-  m_dsp->onPresetMessage(msg);
+    m_dsp->onPresetMessage(msg);
 }
 
-void C15Synth::onLayerPresetMessage(const nltools::msg::LayerPresetMessage &msg)
+void C15Synth::onLayerPresetMessage(const nltools::msg::LayerPresetMessage& msg)
 {
-  m_dsp->onPresetMessage(msg);
+    m_dsp->onPresetMessage(msg);
 }
 
-void C15Synth::onNoteShiftMessage(const nltools::msg::Setting::NoteShiftMessage &msg)
+void C15Synth::onNoteShiftMessage(const nltools::msg::Setting::NoteShiftMessage& msg)
 {
-  m_dsp->onSettingNoteShift(static_cast<float>(msg.m_shift));
+    m_dsp->onSettingNoteShift(static_cast<float>(msg.m_shift));
 }
 
-void C15Synth::onPresetGlitchMessage(const nltools::msg::Setting::PresetGlitchMessage &msg)
+void C15Synth::onPresetGlitchMessage(const nltools::msg::Setting::PresetGlitchMessage& msg)
 {
-  m_dsp->onSettingGlitchSuppr(msg.m_enabled);
+    m_dsp->onSettingGlitchSuppr(msg.m_enabled);
 }
 
-void C15Synth::onTransitionTimeMessage(const nltools::msg::Setting::TransitionTimeMessage &msg)
+void C15Synth::onTransitionTimeMessage(const nltools::msg::Setting::TransitionTimeMessage& msg)
 {
-  m_dsp->onSettingTransitionTime(msg.m_value);
+    m_dsp->onSettingTransitionTime(msg.m_value);
 }
 
-void C15Synth::onEditSmoothingTimeMessage(const nltools::msg::Setting::EditSmoothingTimeMessage &msg)
+void C15Synth::onEditSmoothingTimeMessage(const nltools::msg::Setting::EditSmoothingTimeMessage& msg)
 {
-  m_dsp->onSettingEditTime(msg.m_time);
+    m_dsp->onSettingEditTime(msg.m_time);
 }
 
-void C15Synth::onTuneReferenceMessage(const nltools::msg::Setting::TuneReference &msg)
+void C15Synth::onTuneReferenceMessage(const nltools::msg::Setting::TuneReference& msg)
 {
-  m_dsp->onSettingTuneReference(static_cast<float>(msg.m_tuneReference));
+    m_dsp->onSettingTuneReference(static_cast<float>(msg.m_tuneReference));
 }

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -15,967 +15,915 @@ PolySection::PolySection()
 {
 }
 
-void PolySection::init(GlobalSignals *_globalsignals, exponentiator *_convert, Engine::Handle::Time_Handle *_time,
-                       LayerSignalCollection *_z_self, float *_reference, const float _ms, const float _gateRelease,
-                       const float _samplerate)
+void PolySection::init(GlobalSignals* _globalsignals, exponentiator* _convert, Engine::Handle::Time_Handle* _time,
+    LayerSignalCollection* _z_self, float* _reference, const float _ms, const float _gateRelease,
+    const float _samplerate)
 {
-  // pointer linking (from dsp_host_dual)
-  m_globalsignals = _globalsignals;
-  m_convert = _convert;
-  m_time = _time;
-  m_z_self = _z_self;
-  // init crucial variables
-  m_reference = _reference;
-  m_millisecond = _ms;
-  m_samplerate = _samplerate;
-  m_nyquist = 0.5f * _samplerate;
-  // init control shapers
-  m_comb_decayCurve.setCurve(0.0f, 0.25f, 1.0f);
-  m_svf_LBH1Curve.setCurve(-1.0f, -1.0f, 1.0f);
-  m_svf_LBH2Curve.setCurve(-1.0f, 1.0f, 1.0f);
-  m_svf_resCurve.setCurve(0.0f, 0.49f, 0.79f, 0.94f);
-  // init dsp components
-  m_env_g.init(1.0f / ((_ms * _gateRelease) + 1.0f));
-  m_soundgenerator.init(m_voices, _samplerate);
-  m_combfilter.init(_samplerate, 1);  // todo: upsample factor currently not dynamic ...
-  m_svfilter.init(_samplerate);
-  m_feedbackmixer.init(_samplerate);
-  m_outputmixer.init(_samplerate, C15::Config::local_polyphony);
-  //
-  resetVoiceFade();
+    // pointer linking (from dsp_host_dual)
+    m_globalsignals = _globalsignals;
+    m_convert = _convert;
+    m_time = _time;
+    m_z_self = _z_self;
+    // init crucial variables
+    m_reference = _reference;
+    m_millisecond = _ms;
+    m_samplerate = _samplerate;
+    m_nyquist = 0.5f * _samplerate;
+    // init control shapers
+    m_comb_decayCurve.setCurve(0.0f, 0.25f, 1.0f);
+    m_svf_LBH1Curve.setCurve(-1.0f, -1.0f, 1.0f);
+    m_svf_LBH2Curve.setCurve(-1.0f, 1.0f, 1.0f);
+    m_svf_resCurve.setCurve(0.0f, 0.49f, 0.79f, 0.94f);
+    // init dsp components
+    m_env_g.init(1.0f / ((_ms * _gateRelease) + 1.0f));
+    m_soundgenerator.init(m_voices, _samplerate);
+    m_combfilter.init(_samplerate, 1); // todo: upsample factor currently not dynamic ...
+    m_svfilter.init(_samplerate);
+    m_feedbackmixer.init(_samplerate);
+    m_outputmixer.init(_samplerate, C15::Config::local_polyphony);
+    //
+    resetVoiceFade();
 }
 
 void PolySection::add_copy_sync_id(const uint32_t _smootherId, const uint32_t _signalId)
 {
-  m_smoothers.m_copy_sync.add_copy_id(_smootherId, _signalId);
+    m_smoothers.m_copy_sync.add_copy_id(_smootherId, _signalId);
 }
 
 void PolySection::add_copy_audio_id(const uint32_t _smootherId, const uint32_t _signalId)
 {
-  m_smoothers.m_copy_audio.add_copy_id(_smootherId, _signalId);
+    m_smoothers.m_copy_audio.add_copy_id(_smootherId, _signalId);
 }
 
 void PolySection::add_copy_fast_id(const uint32_t _smootherId, const uint32_t _signalId)
 {
-  m_smoothers.m_copy_fast.add_copy_id(_smootherId, _signalId);
+    m_smoothers.m_copy_fast.add_copy_id(_smootherId, _signalId);
 }
 
 void PolySection::add_copy_slow_id(const uint32_t _smootherId, const uint32_t _signalId)
 {
-  m_smoothers.m_copy_slow.add_copy_id(_smootherId, _signalId);
+    m_smoothers.m_copy_slow.add_copy_id(_smootherId, _signalId);
 }
 
 void PolySection::start_sync(const uint32_t _id, const float _dest)
 {
-  m_smoothers.start_sync(_id, _dest);
-  if(m_smoothers.m_copy_sync.m_smootherId[_id])
-  {
-    m_signals.set_mono(m_smoothers.m_copy_sync.m_signalId[_id], _dest);
-  }
+    m_smoothers.start_sync(_id, _dest);
+    if (m_smoothers.m_copy_sync.m_smootherId[_id]) {
+        m_signals.set_mono(m_smoothers.m_copy_sync.m_signalId[_id], _dest);
+    }
 }
 
 void PolySection::start_audio(const uint32_t _id, const float _dx, const float _dest)
 {
-  m_smoothers.start_audio(_id, _dx, _dest);
+    m_smoothers.start_audio(_id, _dx, _dest);
 }
 
 void PolySection::start_fast(const uint32_t _id, const float _dx, const float _dest)
 {
-  m_smoothers.start_fast(_id, _dx, _dest);
+    m_smoothers.start_fast(_id, _dx, _dest);
 }
 
 void PolySection::start_slow(const uint32_t _id, const float _dx, const float _dest)
 {
-  m_smoothers.start_slow(_id, _dx, _dest);
+    m_smoothers.start_slow(_id, _dx, _dest);
 }
 
 void PolySection::render_audio(const float _mute)
 {
-  m_smoothers.render_audio();
-  auto traversal = &m_smoothers.m_copy_audio;
-  for(uint32_t i = 0; i < traversal->m_length; i++)
-  {
-    m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_audio(traversal->m_smootherId[i]));
-  }
-  for(uint32_t v = 0; v < m_voices; v++)
-  {
-    postProcess_poly_audio(v, _mute);
-  }
-  // render dsp components (former makepolysound)
-  m_soundgenerator.generate(m_signals, m_feedbackmixer.m_out);
-  m_combfilter.apply(m_signals, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B);
-  m_svfilter.apply(m_signals, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B, m_combfilter.m_out);
-  m_outputmixer.combine(m_signals, m_voice_level, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B,
-                        m_combfilter.m_out, m_svfilter.m_out);
-  m_outputmixer.filter_level(m_signals);
-  // capture z samples
-  m_z_self->m_osc_a = m_soundgenerator.m_out_A;
-  m_z_self->m_osc_b = m_soundgenerator.m_out_B;
-  m_z_self->m_comb = m_combfilter.m_out;
-  m_z_self->m_svf = m_svfilter.m_out;
-  // eval sends
-  float send = 1.0f - m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_To_FX);
-  m_send_self_l = m_outputmixer.m_out_l * send;
-  m_send_self_r = m_outputmixer.m_out_r * send;
-  send = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_To_FX)
-      * m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Mute);
-  m_send_other_l = m_outputmixer.m_out_l * send;
-  m_send_other_r = m_outputmixer.m_out_r * send;
+    m_smoothers.render_audio();
+    auto traversal = &m_smoothers.m_copy_audio;
+    for (uint32_t i = 0; i < traversal->m_length; i++) {
+        m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_audio(traversal->m_smootherId[i]));
+    }
+    for (uint32_t v = 0; v < m_voices; v++) {
+        postProcess_poly_audio(v, _mute);
+    }
+    // render dsp components (former makepolysound)
+    m_soundgenerator.generate(m_signals, m_feedbackmixer.m_out);
+    m_combfilter.apply(m_signals, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B);
+    m_svfilter.apply(m_signals, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B, m_combfilter.m_out);
+    m_outputmixer.combine(m_signals, m_voice_level, m_soundgenerator.m_out_A, m_soundgenerator.m_out_B,
+        m_combfilter.m_out, m_svfilter.m_out);
+    m_outputmixer.filter_level(m_signals);
+    // capture z samples
+    m_z_self->m_osc_a = m_soundgenerator.m_out_A;
+    m_z_self->m_osc_b = m_soundgenerator.m_out_B;
+    m_z_self->m_comb = m_combfilter.m_out;
+    m_z_self->m_svf = m_svfilter.m_out;
+    // eval sends
+    float send = 1.0f - m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_To_FX);
+    m_send_self_l = m_outputmixer.m_out_l * send;
+    m_send_self_r = m_outputmixer.m_out_r * send;
+    send = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_To_FX)
+        * m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Mute);
+    m_send_other_l = m_outputmixer.m_out_l * send;
+    m_send_other_r = m_outputmixer.m_out_r * send;
 }
 
-void PolySection::render_feedback(const LayerSignalCollection &_z_other)
+void PolySection::render_feedback(const LayerSignalCollection& _z_other)
 {
-  m_feedbackmixer.apply(m_signals, *m_z_self, _z_other);
-  m_soundgenerator.m_feedback_phase_A = m_soundgenerator.m_feedback_phase_B = m_feedbackmixer.m_out;
+    m_feedbackmixer.apply(m_signals, *m_z_self, _z_other);
+    m_soundgenerator.m_feedback_phase_A = m_soundgenerator.m_feedback_phase_B = m_feedbackmixer.m_out;
 }
 
 void PolySection::render_fast()
 {
-  m_smoothers.render_fast();
-  auto traversal = &m_smoothers.m_copy_fast;
-  for(uint32_t i = 0; i < traversal->m_length; i++)
-  {
-    m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_fast(traversal->m_smootherId[i]));
-  }
-  postProcess_mono_fast();
-  for(uint32_t v = 0; v < m_voices; v++)
-  {
-    postProcess_poly_fast(v);
-  }
+    m_smoothers.render_fast();
+    auto traversal = &m_smoothers.m_copy_fast;
+    for (uint32_t i = 0; i < traversal->m_length; i++) {
+        m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_fast(traversal->m_smootherId[i]));
+    }
+    postProcess_mono_fast();
+    for (uint32_t v = 0; v < m_voices; v++) {
+        postProcess_poly_fast(v);
+    }
 }
 
 void PolySection::render_slow()
 {
-  m_smoothers.render_slow();
-  // update glide time and render glide smoother
-  m_mono_glide.m_dx = m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide));
-  m_mono_glide.render();
-  auto traversal = &m_smoothers.m_copy_slow;
-  for(uint32_t i = 0; i < traversal->m_length; i++)
-  {
-    m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_slow(traversal->m_smootherId[i]));
-  }
-  postProcess_mono_slow();
-  for(uint32_t v = 0; v < m_voices; v++)
-  {
-    updateNotePitch(v);
-    postProcess_poly_slow(v);
-    setSlowFilterCoefs(v);
-  }
-}
-
-bool PolySection::keyDown(PolyKeyEvent *_event)
-{
-  const bool retrigger_mono
-      = (m_key_active == 0),
-      rstA = _event->m_trigger_env && static_cast<bool>(m_signals.get(C15::Signals::Quasipoly_Signals::Osc_A_Reset)),
-      rstB = _event->m_trigger_env && static_cast<bool>(m_signals.get(C15::Signals::Quasipoly_Signals::Osc_B_Reset));
-  m_voice_level[_event->m_voiceId] = m_key_levels[_event->m_position];
-  m_shift[_event->m_voiceId] = m_note_shift;
-  m_unison_index[_event->m_voiceId] = _event->m_unisonIndex;
-  m_last_key_tune[_event->m_voiceId] = m_base_pitch[_event->m_voiceId];
-  m_key_tune[_event->m_voiceId] = _event->m_tune;
-  m_key_position[_event->m_voiceId] = _event->m_position;
-  if(_event->m_unisonIndex == 0)
-  {
-    if(_event->m_trigger_glide)
-    {
-      m_mono_glide.sync(0.0f);
-      m_mono_glide.start(m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide)), 1.0f);
-    }
-    else
-    {
-      m_mono_glide.sync(1.0f);
+    m_smoothers.render_slow();
+    // update glide time and render glide smoother
+    m_mono_glide.m_dx = m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide));
+    m_mono_glide.render();
+    auto traversal = &m_smoothers.m_copy_slow;
+    for (uint32_t i = 0; i < traversal->m_length; i++) {
+        m_signals.set_mono(traversal->m_signalId[i], m_smoothers.get_slow(traversal->m_smootherId[i]));
     }
     postProcess_mono_slow();
-  }
-  if(_event->m_stolen)
-  {
-    // case NoteSteal (currently nothing)
-  }
-  m_soundgenerator.resetPhase(_event->m_voiceId, rstA, rstB);
-  updateNotePitch(_event->m_voiceId);
-  postProcess_poly_key(_event->m_voiceId);
-  setSlowFilterCoefs(_event->m_voiceId);
-  if(_event->m_trigger_env)
-  {
-    m_combfilter.setDelaySmoother(_event->m_voiceId);
-    startEnvelopes(_event->m_voiceId, m_note_pitch[_event->m_voiceId], _event->m_velocity);
-  }
-  m_key_active++;
-  return retrigger_mono;
+    for (uint32_t v = 0; v < m_voices; v++) {
+        updateNotePitch(v);
+        postProcess_poly_slow(v);
+        setSlowFilterCoefs(v);
+    }
 }
 
-void PolySection::keyUp(PolyKeyEvent *_event)
+bool PolySection::keyDown(PolyKeyEvent* _event)
 {
-  m_last_key_tune[_event->m_voiceId] = m_base_pitch[_event->m_voiceId];
-  m_key_tune[_event->m_voiceId] = _event->m_tune;
-  m_key_position[_event->m_voiceId] = _event->m_position;
-  if(_event->m_unisonIndex == 0)
-  {
-    if(_event->m_trigger_glide)
-    {
-      m_mono_glide.sync(0.0f);
-      m_mono_glide.start(m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide)), 1.0f);
+    const bool retrigger_mono
+        = (m_key_active == 0),
+        rstA = _event->m_trigger_env && static_cast<bool>(m_signals.get(C15::Signals::Quasipoly_Signals::Osc_A_Reset)),
+        rstB = _event->m_trigger_env && static_cast<bool>(m_signals.get(C15::Signals::Quasipoly_Signals::Osc_B_Reset));
+    m_voice_level[_event->m_voiceId] = m_key_levels[_event->m_position];
+    m_shift[_event->m_voiceId] = m_note_shift;
+    m_unison_index[_event->m_voiceId] = _event->m_unisonIndex;
+    m_last_key_tune[_event->m_voiceId] = m_base_pitch[_event->m_voiceId];
+    m_key_tune[_event->m_voiceId] = _event->m_tune;
+    m_key_position[_event->m_voiceId] = _event->m_position;
+    if (_event->m_unisonIndex == 0) {
+        if (_event->m_trigger_glide) {
+            m_mono_glide.sync(0.0f);
+            m_mono_glide.start(m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide)), 1.0f);
+        } else {
+            m_mono_glide.sync(1.0f);
+        }
+        postProcess_mono_slow();
     }
-    else
-    {
-      m_mono_glide.sync(1.0f);
+    if (_event->m_stolen) {
+        // case NoteSteal (currently nothing)
     }
-  }
-  updateNotePitch(_event->m_voiceId);
-  if(_event->m_trigger_env)
-  {
-    stopEnvelopes(_event->m_voiceId, m_note_pitch[_event->m_voiceId], _event->m_velocity);
-  }
-  m_key_active--;
+    m_soundgenerator.resetPhase(_event->m_voiceId, rstA, rstB);
+    updateNotePitch(_event->m_voiceId);
+    postProcess_poly_key(_event->m_voiceId);
+    setSlowFilterCoefs(_event->m_voiceId);
+    if (_event->m_trigger_env) {
+        m_combfilter.setDelaySmoother(_event->m_voiceId);
+        startEnvelopes(_event->m_voiceId, m_note_pitch[_event->m_voiceId], _event->m_velocity);
+    }
+    m_key_active++;
+    return retrigger_mono;
+}
+
+void PolySection::keyUp(PolyKeyEvent* _event)
+{
+    m_last_key_tune[_event->m_voiceId] = m_base_pitch[_event->m_voiceId];
+    m_key_tune[_event->m_voiceId] = _event->m_tune;
+    m_key_position[_event->m_voiceId] = _event->m_position;
+    if (_event->m_unisonIndex == 0) {
+        if (_event->m_trigger_glide) {
+            m_mono_glide.sync(0.0f);
+            m_mono_glide.start(m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide)), 1.0f);
+        } else {
+            m_mono_glide.sync(1.0f);
+        }
+    }
+    updateNotePitch(_event->m_voiceId);
+    if (_event->m_trigger_env) {
+        stopEnvelopes(_event->m_voiceId, m_note_pitch[_event->m_voiceId], _event->m_velocity);
+    }
+    m_key_active--;
 }
 
 void PolySection::resetEnvelopes()
 {
-  m_env_a.reset();
-  m_env_b.reset();
-  m_env_c.reset();
-  m_env_g.reset();
+    m_env_a.reset();
+    m_env_b.reset();
+    m_env_c.reset();
+    m_env_g.reset();
 }
 
 void PolySection::flushDSP()
 {
-  m_soundgenerator.resetDSP();
-  m_combfilter.resetDSP();
-  m_svfilter.resetDSP();
-  m_feedbackmixer.resetDSP();
-  m_outputmixer.resetDSP();
+    m_soundgenerator.resetDSP();
+    m_combfilter.resetDSP();
+    m_svfilter.resetDSP();
+    m_feedbackmixer.resetDSP();
+    m_outputmixer.resetDSP();
 }
 
 void PolySection::resetDSP()
 {
-  resetEnvelopes();
-  flushDSP();
-  m_send_self_l = m_send_self_r = m_send_other_l = m_send_other_r = 0.0f;
+    resetEnvelopes();
+    flushDSP();
+    m_send_self_l = m_send_self_r = m_send_other_l = m_send_other_r = 0.0f;
 }
 
 float PolySection::getVoiceGroupVolume()
 {
-  return m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Volume)
-      * m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Mute);
+    return m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Volume)
+        * m_smoothers.get(C15::Smoothers::Poly_Fast::Voice_Grp_Mute);
 }
 
 void PolySection::evalVoiceFade(const float _from, const float _range)
 {
-  const int32_t start = m_fadeStart;
-  const int32_t fadeStart
-      = start + (m_fadeIncrement * (1 + (m_fadeStart + (m_fadeIncrement * static_cast<int32_t>(_from)))));
-  const int32_t fadeEnd = fadeStart + (m_fadeIncrement * static_cast<int32_t>(_range));
-  const float slope = 1.0f / (_range + 1.0f);
-  float fade = 1.0f;
+    const int32_t start = m_fadeStart;
+    const int32_t fadeStart
+        = start + (m_fadeIncrement * (1 + (m_fadeStart + (m_fadeIncrement * static_cast<int32_t>(_from)))));
+    const int32_t fadeEnd = fadeStart + (m_fadeIncrement * static_cast<int32_t>(_range));
+    const float slope = 1.0f / (_range + 1.0f);
+    float fade = 1.0f;
 
-  //nltools::Log::info("(from:", _from, ", range:", _range, ")");
-  // phase 1: 100%
-  for(int32_t i = start; i != fadeStart; i += m_fadeIncrement)
-  {
-    if((i < 0) || (i >= C15::Config::key_count))
-      break;  // safety mechanism
-    //nltools::Log::info("[", i, "]:", 1.0f);
-    m_key_levels[i] = 1.0f;
-  }
-  // phase 2: fade out
-
-  for(int32_t i = fadeStart; i != fadeEnd; i += m_fadeIncrement)
-  {
-    if((i < 0) || (i >= C15::Config::key_count))
-      break;  // safety mechanism
-    fade -= slope;
-    // linear implementation (not smooth enough):
-    //fadeValue = fade;
-
-    // sine implementation (keep for further testing):
-    //fadeValue = 0.5f - (0.5f * NlToolbox::Math::sinP3_wrap(0.5f * (fade - 0.5f)));
-
-    // parabolic implementation (currently favourite):
-    auto fadeValue = fade * fade;
-    if(fade < 0.5f)
-    {
-      fadeValue = 2.0f * fadeValue;
+    //nltools::Log::info("(from:", _from, ", range:", _range, ")");
+    // phase 1: 100%
+    for (int32_t i = start; i != fadeStart; i += m_fadeIncrement) {
+        if ((i < 0) || (i >= C15::Config::key_count))
+            break; // safety mechanism
+        //nltools::Log::info("[", i, "]:", 1.0f);
+        m_key_levels[i] = 1.0f;
     }
-    else
-    {
-      fadeValue = (-2.0f * fadeValue) + (4.0f * fade) - 1.0f;
+    // phase 2: fade out
+
+    for (int32_t i = fadeStart; i != fadeEnd; i += m_fadeIncrement) {
+        if ((i < 0) || (i >= C15::Config::key_count))
+            break; // safety mechanism
+        fade -= slope;
+        // linear implementation (not smooth enough):
+        //float fadeValue = fade;
+
+        // sine implementation (keep for further testing):
+        //float fadeValue = 0.5f - (0.5f * NlToolbox::Math::sinP3_wrap(0.5f * (fade - 0.5f)));
+
+        // parabolic implementation (currently favourite):
+        float fadeValue = fade * fade;
+        if (fade < 0.5f) {
+            fadeValue = 2.0f * fadeValue;
+        } else {
+            fadeValue = (-2.0f * fadeValue) + (4.0f * fade) - 1.0f;
+        }
+        //nltools::Log::info("[", i, "]:", fadeValue);
+        m_key_levels[i] = fadeValue;
     }
-    //nltools::Log::info("[", i, "]:", fadeValue);
-    m_key_levels[i] = fadeValue;
-  }
-  // phase 3: 0%
-  for(int32_t i = fadeEnd; i != m_fadeEnd + m_fadeIncrement; i += m_fadeIncrement)
-  {
-    if((i < 0) || (i >= C15::Config::key_count))
-      break;  // safety mechanism
-    //nltools::Log::info("[", i, "]:", 0.0f);
-    m_key_levels[i] = 0.0f;
-  }
+    // phase 3: 0%
+    for (int32_t i = fadeEnd; i != m_fadeEnd + m_fadeIncrement; i += m_fadeIncrement) {
+        if ((i < 0) || (i >= C15::Config::key_count))
+            break; // safety mechanism
+        //nltools::Log::info("[", i, "]:", 0.0f);
+        m_key_levels[i] = 0.0f;
+    }
 }
 
 void PolySection::resetVoiceFade()
 {
-  for(uint32_t i = 0; i < C15::Config::key_count; i++)
-  {
-    m_key_levels[i] = 1.0f;
-  }
+    for (uint32_t i = 0; i < C15::Config::key_count; i++) {
+        m_key_levels[i] = 1.0f;
+    }
 }
 
 float PolySection::evalNyquist(const float _value)
 {
-  return _value > m_nyquist ? m_nyquist : _value;
+    return _value > m_nyquist ? m_nyquist : _value;
 }
 
 float PolySection::evalScale(const uint32_t _voiceId)
 {
-  // adding one octave offset in order to avoid negative numbers
-  const int32_t pos = static_cast<int32_t>(m_key_position[_voiceId] + 12);
-  // subtract base key -- twice
-  const int32_t pos_start
-      = pos - static_cast<int32_t>(m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Start));
-  const int32_t pos_dest
-      = pos - static_cast<int32_t>(m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Dest));
-  // form scale offset index by signal offset + cyclic index -- twice
-  const uint32_t index_start
-      = static_cast<uint32_t>(C15::Signals::Global_Signals::Scale_Offset_0) + (static_cast<uint32_t>(pos_start) % 12);
-  const uint32_t index_dest
-      = static_cast<uint32_t>(C15::Signals::Global_Signals::Scale_Offset_0) + (static_cast<uint32_t>(pos_dest) % 12);
-  // retrieve base key smoother fade position and crossfade offsets
-  const float fade = m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Pos);
-  return ((1.0f - fade) * m_globalsignals->get(index_start)) + (fade * m_globalsignals->get(index_dest));
+    // adding one octave offset in order to avoid negative numbers
+    const int32_t pos = static_cast<int32_t>(m_key_position[_voiceId] + 12);
+    // subtract base key -- twice
+    const int32_t pos_start
+        = pos - static_cast<int32_t>(m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Start));
+    const int32_t pos_dest
+        = pos - static_cast<int32_t>(m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Dest));
+    // form scale offset index by signal offset + cyclic index -- twice
+    const uint32_t index_start
+        = static_cast<uint32_t>(C15::Signals::Global_Signals::Scale_Offset_0) + (static_cast<uint32_t>(pos_start) % 12);
+    const uint32_t index_dest
+        = static_cast<uint32_t>(C15::Signals::Global_Signals::Scale_Offset_0) + (static_cast<uint32_t>(pos_dest) % 12);
+    // retrieve base key smoother fade position and crossfade offsets
+    const float fade = m_globalsignals->get(C15::Signals::Global_Signals::Scale_Base_Key_Pos);
+    return ((1.0f - fade) * m_globalsignals->get(index_start)) + (fade * m_globalsignals->get(index_dest));
 }
 
 void PolySection::postProcess_poly_audio(const uint32_t _voiceId, const float _mute)
 {
-  // env rendering
-  m_env_a.tick(_voiceId, _mute);
-  m_env_b.tick(_voiceId, _mute);
-  m_env_c.tick(_voiceId, _mute);
-  m_env_g.tick(_voiceId);
-  // provide poly env signals
-  float gain = m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Gain);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_A_Mag, _voiceId,
-                     gain * m_env_a.m_body[_voiceId].m_signal_magnitude);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId,
-                     gain * m_env_a.m_body[_voiceId].m_signal_timbre);
-  gain = m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Gain);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_B_Mag, _voiceId,
-                     gain * m_env_b.m_body[_voiceId].m_signal_magnitude);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId,
-                     gain * m_env_b.m_body[_voiceId].m_signal_timbre);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId, m_env_c.m_body[_voiceId].m_signal_magnitude);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId,
-                     m_env_c.m_body[_voiceId].m_signal_magnitude * m_env_c.m_clipFactor[_voiceId]);
-  m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId, m_env_g.m_body[_voiceId].m_signal_magnitude);
-  // temporary variables
-  float tmp_amt, tmp_env;
-  // poly osc a signals
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_Self);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_Self_Env_A);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_Self_Env_A, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
-                    * tmp_amt);
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_B);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_B_Env_B);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_B_Env_B, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
-                    * tmp_amt);
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_FB);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_FB_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_FB_Env_C, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env)
-                    * tmp_amt);
-  // poly shp a signals
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Shp_A_Drive);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_A_Drive_Env_A);
-  m_signals.set(C15::Signals::Truepoly_Signals::Shp_A_Drive_Env_A, _voiceId,
-                (NlToolbox::Crossfades::unipolarCrossFade(
-                     1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
-                 * tmp_amt)
-                    + 0.18f);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_A_FB_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Shp_A_FB_Env_C, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId),
-                    m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env));
-  // poly osc b signals
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_Self);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_Self_Env_B);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_Self_Env_B, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
-                    * tmp_amt);
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_A);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_A_Env_A);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_A_Env_A, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
-                    * tmp_amt);
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_FB);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_FB_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_FB_Env_C, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env)
-                    * tmp_amt);
-  // poly shp b signals
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Shp_B_Drive);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_B_Drive_Env_B);
-  m_signals.set(C15::Signals::Truepoly_Signals::Shp_B_Drive_Env_B, _voiceId,
-                (NlToolbox::Crossfades::unipolarCrossFade(
-                     1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
-                 * tmp_amt)
-                    + 0.18f);
-  tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_B_FB_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Shp_B_FB_Env_C, _voiceId,
-                NlToolbox::Crossfades::unipolarCrossFade(
-                    m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId),
-                    m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env));
-  // comb filter
-  tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_Env_C);
-  tmp_env = m_convert->eval_lin_pitch(
-      69.0f - (tmp_amt * m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)));
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq_Env_C, _voiceId, tmp_env);
-  tmp_env = m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig,
-                          _voiceId);  // application of gate signal (with 10ms release)
-  tmp_amt = NlToolbox::Crossfades::unipolarCrossFade(m_comb_decay_times[0][_voiceId], m_comb_decay_times[1][_voiceId],
-                                                     tmp_env);
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Decay, _voiceId,
-                tmp_amt);  // decay now fully formed as min/max
-  // unison (phase)
-  const float phase = m_smoothers.get(C15::Smoothers::Poly_Audio::Unison_Phase)
-      * m_spread.m_phase[m_uVoice][m_unison_index[_voiceId]];
-  m_signals.set(C15::Signals::Truepoly_Signals::Unison_PolyPhase, _voiceId, phase);
+    // env rendering
+    m_env_a.tick(_voiceId, _mute);
+    m_env_b.tick(_voiceId, _mute);
+    m_env_c.tick(_voiceId, _mute);
+    m_env_g.tick(_voiceId);
+    // provide poly env signals
+    float gain = m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Gain);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_A_Mag, _voiceId,
+        gain * m_env_a.m_body[_voiceId].m_signal_magnitude);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId,
+        gain * m_env_a.m_body[_voiceId].m_signal_timbre);
+    gain = m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Gain);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_B_Mag, _voiceId,
+        gain * m_env_b.m_body[_voiceId].m_signal_magnitude);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId,
+        gain * m_env_b.m_body[_voiceId].m_signal_timbre);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId, m_env_c.m_body[_voiceId].m_signal_magnitude);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId,
+        m_env_c.m_body[_voiceId].m_signal_magnitude * m_env_c.m_clipFactor[_voiceId]);
+    m_signals.set_poly(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId, m_env_g.m_body[_voiceId].m_signal_magnitude);
+    // temporary variables
+    float tmp_amt, tmp_env;
+    // poly osc a signals
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_Self);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_Self_Env_A);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_Self_Env_A, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
+            * tmp_amt);
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_B);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_B_Env_B);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_B_Env_B, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
+            * tmp_amt);
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_A_PM_FB);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_PM_FB_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_PM_FB_Env_C, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env)
+            * tmp_amt);
+    // poly shp a signals
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Shp_A_Drive);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_A_Drive_Env_A);
+    m_signals.set(C15::Signals::Truepoly_Signals::Shp_A_Drive_Env_A, _voiceId,
+        (NlToolbox::Crossfades::unipolarCrossFade(
+             1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
+            * tmp_amt)
+            + 0.18f);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_A_FB_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Shp_A_FB_Env_C, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId),
+            m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env));
+    // poly osc b signals
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_Self);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_Self_Env_B);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_Self_Env_B, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
+            * tmp_amt);
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_A);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_A_Env_A);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_A_Env_A, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_A_Tmb, _voiceId), tmp_env)
+            * tmp_amt);
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Osc_B_PM_FB);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_PM_FB_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_PM_FB_Env_C, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env)
+            * tmp_amt);
+    // poly shp b signals
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Fast::Shp_B_Drive);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_B_Drive_Env_B);
+    m_signals.set(C15::Signals::Truepoly_Signals::Shp_B_Drive_Env_B, _voiceId,
+        (NlToolbox::Crossfades::unipolarCrossFade(
+             1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_B_Tmb, _voiceId), tmp_env)
+            * tmp_amt)
+            + 0.18f);
+    tmp_env = m_smoothers.get(C15::Smoothers::Poly_Slow::Shp_B_FB_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Shp_B_FB_Env_C, _voiceId,
+        NlToolbox::Crossfades::unipolarCrossFade(
+            m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig, _voiceId),
+            m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), tmp_env));
+    // comb filter
+    tmp_amt = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_Env_C);
+    tmp_env = m_convert->eval_lin_pitch(
+        69.0f - (tmp_amt * m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)));
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq_Env_C, _voiceId, tmp_env);
+    tmp_env = m_signals.get(C15::Signals::Truepoly_Signals::Env_G_Sig,
+        _voiceId); // application of gate signal (with 10ms release)
+    tmp_amt = NlToolbox::Crossfades::unipolarCrossFade(m_comb_decay_times[0][_voiceId], m_comb_decay_times[1][_voiceId],
+        tmp_env);
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Decay, _voiceId,
+        tmp_amt); // decay now fully formed as min/max
+    // unison (phase)
+    const float phase = m_smoothers.get(C15::Smoothers::Poly_Audio::Unison_Phase)
+        * m_spread.m_phase[m_uVoice][m_unison_index[_voiceId]];
+    m_signals.set(C15::Signals::Truepoly_Signals::Unison_PolyPhase, _voiceId, phase);
 }
 
 void PolySection::postProcess_poly_fast(const uint32_t _voiceId)
 {
-  updateEnvLevels(_voiceId);
-  // temporary variables
-  const uint32_t uIndex = m_unison_index[_voiceId];
-  const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
-  float tmp_lvl, tmp_pan;
-  // feedback mixer
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::FB_Mix_Lvl);
-  tmp_pan = std::min(m_convert->eval_level(m_smoothers.get(C15::Smoothers::Poly_Slow::FB_Mix_Lvl_KT) * notePitch),
-                     env_clip_peak);
-  m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_Lvl, _voiceId, tmp_lvl * tmp_pan);
-  // output mixer
-  const float poly_pan = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Key_Pan) * (basePitch - 6.0f)
-      + (m_smoothers.get(C15::Smoothers::Poly_Fast::Unison_Pan) * m_spread.m_pan[m_uVoice][uIndex]);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Right, _voiceId, tmp_lvl * tmp_pan);
+    updateEnvLevels(_voiceId);
+    // temporary variables
+    const uint32_t uIndex = m_unison_index[_voiceId];
+    const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
+    float tmp_lvl, tmp_pan;
+    // feedback mixer
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::FB_Mix_Lvl);
+    tmp_pan = std::min(m_convert->eval_level(m_smoothers.get(C15::Smoothers::Poly_Slow::FB_Mix_Lvl_KT) * notePitch),
+        env_clip_peak);
+    m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_Lvl, _voiceId, tmp_lvl * tmp_pan);
+    // output mixer
+    const float poly_pan = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Key_Pan) * (basePitch - 6.0f)
+        + (m_smoothers.get(C15::Smoothers::Poly_Fast::Unison_Pan) * m_spread.m_pan[m_uVoice][uIndex]);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Right, _voiceId, tmp_lvl * tmp_pan);
 }
 
 void PolySection::postProcess_mono_fast()
 {
-  // temporary variables
-  float tmp_lvl, tmp_abs, tmp_inv;
-  // state variable filter
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::SV_Flt_LBH);
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_LBH_1, m_svf_LBH1Curve.applyCurve(tmp_lvl));
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_LBH_2, m_svf_LBH2Curve.applyCurve(tmp_lvl));
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::SV_Flt_Par);
-  tmp_abs = std::abs(tmp_lvl);
-  tmp_inv = 1.0f - tmp_abs;
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_1, 0.7f * tmp_abs);
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_2, (0.7f * tmp_lvl) + tmp_inv);
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_3, tmp_inv);
-  m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_4, tmp_abs);
+    // temporary variables
+    float tmp_lvl, tmp_abs, tmp_inv;
+    // state variable filter
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::SV_Flt_LBH);
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_LBH_1, m_svf_LBH1Curve.applyCurve(tmp_lvl));
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_LBH_2, m_svf_LBH2Curve.applyCurve(tmp_lvl));
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::SV_Flt_Par);
+    tmp_abs = std::abs(tmp_lvl);
+    tmp_inv = 1.0f - tmp_abs;
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_1, 0.7f * tmp_abs);
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_2, (0.7f * tmp_lvl) + tmp_inv);
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_3, tmp_inv);
+    m_signals.set(C15::Signals::Quasipoly_Signals::SV_Flt_Par_4, tmp_abs);
 }
 
 void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
 {
-  // envelopes
-  updateEnvTimes(_voiceId);
-  // temporary variables
-  const float notePitch = m_note_pitch[_voiceId];
-  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue;
-  // osc a
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                        1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
-  // osc b
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                        1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
-  // comb filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
-                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
-                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
-  unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
-  envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
-  unitMod = std::abs(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay));
-  unitPitch = (-0.5f * notePitch * keyTracking);
-  unitValue
-      = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId];  // decay now fully formed as min/max
-  m_comb_decay_times[0][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
-  m_comb_decay_times[1][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Comb_Flt_AP_Freq, _voiceId,
-      evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Tune);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
-      evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
-  // state variable filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
-  unitPitch = m_svf_resCurve.applyCurve(std::clamp(
-      m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res) + envMod + (notePitch * keyTracking), 0.0f, 1.0f));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_Damp, _voiceId, 2.0f - (2.0f * unitPitch));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_FMax, _voiceId,
-                0.7352f + (0.2930f * unitPitch * (1.3075f + unitPitch)));
-  // feedback mixer
-  m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_HPF, _voiceId,
-                evalNyquist(m_convert->eval_lin_pitch(12.0f + notePitch) * 440.0f));
+    // envelopes
+    updateEnvTimes(_voiceId);
+    // temporary variables
+    const float notePitch = m_note_pitch[_voiceId];
+    float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue;
+    // osc a
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
+        evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+    envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
+        m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
+            * NlToolbox::Crossfades::unipolarCrossFade(
+                  1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+    // osc b
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
+        evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+    envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
+        m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
+            * NlToolbox::Crossfades::unipolarCrossFade(
+                  1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+    // comb filter
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
+        evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
+        unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
+    unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
+    envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
+    unitMod = std::abs(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay));
+    unitPitch = (-0.5f * notePitch * keyTracking);
+    unitValue
+        = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId]; // decay now fully formed as min/max
+    m_comb_decay_times[0][_voiceId]
+        = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
+    m_comb_decay_times[1][_voiceId]
+        = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Comb_Flt_AP_Freq, _voiceId,
+        evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Tune);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
+        evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
+    // state variable filter
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
+    unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
+    unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
+    unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
+    unitValue
+        = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
+    unitValue
+        = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
+    unitPitch = m_svf_resCurve.applyCurve(std::clamp(
+        m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res) + envMod + (notePitch * keyTracking), 0.0f, 1.0f));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_Damp, _voiceId, 2.0f - (2.0f * unitPitch));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_FMax, _voiceId,
+        0.7352f + (0.2930f * unitPitch * (1.3075f + unitPitch)));
+    // feedback mixer
+    m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_HPF, _voiceId,
+        evalNyquist(m_convert->eval_lin_pitch(12.0f + notePitch) * 440.0f));
 }
 
 void PolySection::postProcess_mono_slow()
 {
-  // osc a
-  m_signals.set(C15::Signals::Quasipoly_Signals::Osc_A_Chirp,
-                evalNyquist(m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Chirp) * 440.0f));
-  // osc b
-  m_signals.set(C15::Signals::Quasipoly_Signals::Osc_B_Chirp,
-                evalNyquist(m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Chirp) * 440.0f));
+    // osc a
+    m_signals.set(C15::Signals::Quasipoly_Signals::Osc_A_Chirp,
+        evalNyquist(m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Chirp) * 440.0f));
+    // osc b
+    m_signals.set(C15::Signals::Quasipoly_Signals::Osc_B_Chirp,
+        evalNyquist(m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Chirp) * 440.0f));
 }
 
 void PolySection::postProcess_poly_key(const uint32_t _voiceId)
 {
-  // pitch, unison, temporary variables
-  const uint32_t uIndex = m_unison_index[_voiceId];
-  const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
-  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue, tmp_lvl, tmp_pan;
-  // osc a
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                        1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
-  // osc b
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                        1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
-  // comb filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
-                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
-                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
-  unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
-  envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
-  unitMod = std::abs(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay));
-  unitPitch = (-0.5f * notePitch * keyTracking);
-  unitValue
-      = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId];  // decay now fully formed as min/max
-  m_comb_decay_times[0][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
-  m_comb_decay_times[1][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Comb_Flt_AP_Freq, _voiceId,
-      evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Tune);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
-      evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
-  // state variable filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
-  unitPitch = m_svf_resCurve.applyCurve(std::clamp(
-      m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res) + envMod + (notePitch * keyTracking), 0.0f, 1.0f));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_Damp, _voiceId, 2.0f - (2.0f * unitPitch));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_FMax, _voiceId,
-                0.7352f + (0.2930f * unitPitch * (1.3075f + unitPitch)));
-  // feedback mixer
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::FB_Mix_Lvl);
-  tmp_pan = std::min(m_convert->eval_level(m_smoothers.get(C15::Smoothers::Poly_Slow::FB_Mix_Lvl_KT) * notePitch),
-                     env_clip_peak);
-  m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_Lvl, _voiceId, tmp_lvl * tmp_pan);
-  m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_HPF, _voiceId,
-                evalNyquist(m_convert->eval_lin_pitch(12.0f + notePitch) * 440.0f));
-  // output mixer
-  const float poly_pan = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Key_Pan) * (basePitch - 6.0f)
-      + (m_smoothers.get(C15::Smoothers::Poly_Fast::Unison_Pan) * m_spread.m_pan[m_uVoice][uIndex]);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Right, _voiceId, tmp_lvl * tmp_pan);
-  tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Lvl);
-  tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Pan) + poly_pan, 0.0f, 1.0f);
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
-  m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Right, _voiceId, tmp_lvl * tmp_pan);
+    // pitch, unison, temporary variables
+    const uint32_t uIndex = m_unison_index[_voiceId];
+    const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
+    float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue, tmp_lvl, tmp_pan;
+    // osc a
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
+        evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+    envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
+        m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
+            * NlToolbox::Crossfades::unipolarCrossFade(
+                  1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+    // osc b
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
+        evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+    envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
+    m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
+        m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
+            * NlToolbox::Crossfades::unipolarCrossFade(
+                  1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+    // comb filter
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
+        evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
+    m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
+        unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
+    unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
+    envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
+    unitMod = std::abs(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay));
+    unitPitch = (-0.5f * notePitch * keyTracking);
+    unitValue
+        = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId]; // decay now fully formed as min/max
+    m_comb_decay_times[0][_voiceId]
+        = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
+    m_comb_decay_times[1][_voiceId]
+        = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Comb_Flt_AP_Freq, _voiceId,
+        evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_KT);
+    unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Tune);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_LP_Env_C);
+    m_signals.set(
+        C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
+        evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
+    // state variable filter
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
+    unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
+    unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
+    unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
+    unitValue
+        = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
+    unitValue
+        = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
+    keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
+    envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
+        * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
+    unitPitch = m_svf_resCurve.applyCurve(std::clamp(
+        m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res) + envMod + (notePitch * keyTracking), 0.0f, 1.0f));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_Damp, _voiceId, 2.0f - (2.0f * unitPitch));
+    m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_Res_FMax, _voiceId,
+        0.7352f + (0.2930f * unitPitch * (1.3075f + unitPitch)));
+    // feedback mixer
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::FB_Mix_Lvl);
+    tmp_pan = std::min(m_convert->eval_level(m_smoothers.get(C15::Smoothers::Poly_Slow::FB_Mix_Lvl_KT) * notePitch),
+        env_clip_peak);
+    m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_Lvl, _voiceId, tmp_lvl * tmp_pan);
+    m_signals.set(C15::Signals::Truepoly_Signals::FB_Mix_HPF, _voiceId,
+        evalNyquist(m_convert->eval_lin_pitch(12.0f + notePitch) * 440.0f));
+    // output mixer
+    const float poly_pan = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Key_Pan) * (basePitch - 6.0f)
+        + (m_smoothers.get(C15::Smoothers::Poly_Fast::Unison_Pan) * m_spread.m_pan[m_uVoice][uIndex]);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_A_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_A_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_B_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_B_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_Comb_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_Comb_Right, _voiceId, tmp_lvl * tmp_pan);
+    tmp_lvl = m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Lvl);
+    tmp_pan = std::clamp(m_smoothers.get(C15::Smoothers::Poly_Fast::Out_Mix_SVF_Pan) + poly_pan, 0.0f, 1.0f);
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Left, _voiceId, tmp_lvl * (1.0f - tmp_pan));
+    m_signals.set(C15::Signals::Truepoly_Signals::Out_Mix_SVF_Right, _voiceId, tmp_lvl * tmp_pan);
 }
 
 void PolySection::startEnvelopes(const uint32_t _voiceId, const float _pitch, const float _vel)
 {
-  float time, timeKT, dest, levelVel, attackVel, decay1Vel, decay2Vel, levelKT, peak, unclipped;
-  // env a
-  timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Time_KT) * _pitch;
-  levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Lvl_Vel);
-  attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Att_Vel) * _vel;
-  decay1Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Dec_1_Vel) * _vel;
-  decay2Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Dec_2_Vel) * _vel;
-  levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Lvl_KT) * _pitch;
-  if(levelVel < 0.0f)
-  {
-    peak = std::min(m_convert->eval_level((_vel * levelVel) + levelKT), env_clip_peak);
-  }
-  else
-  {
-    peak = std::min(m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT), env_clip_peak);
-  }
-  m_env_a.m_levelFactor[_voiceId] = peak;
-  m_env_a.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
-  m_env_a.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
-  m_env_a.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
-  m_env_a.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Elevate));
-  m_env_a.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Att_Curve));
-  m_env_a.setPeakLevel(_voiceId, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Att) * m_env_a.m_timeFactor[_voiceId][0];
-  m_env_a.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  m_env_a.setSegmentDest(_voiceId, 1, false, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_1) * m_env_a.m_timeFactor[_voiceId][1];
-  m_env_a.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_BP);
-  m_env_a.setSegmentDest(_voiceId, 2, true, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_2) * m_env_a.m_timeFactor[_voiceId][2];
-  m_env_a.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Sus);
-  m_env_a.setSegmentDest(_voiceId, 3, true, peak);
-  // env b
-  timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Time_KT) * _pitch;
-  levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Lvl_Vel);
-  attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Att_Vel) * _vel;
-  decay1Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Dec_1_Vel) * _vel;
-  decay2Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Dec_2_Vel) * _vel;
-  levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Lvl_KT) * _pitch;
-  if(levelVel < 0.0f)
-  {
-    peak = std::min(m_convert->eval_level((_vel * levelVel) + levelKT), env_clip_peak);
-  }
-  else
-  {
-    peak = std::min(m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT), env_clip_peak);
-  }
-  m_env_b.m_levelFactor[_voiceId] = peak;
-  m_env_b.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
-  m_env_b.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
-  m_env_b.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
-  m_env_b.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Elevate));
-  m_env_b.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Att_Curve));
-  m_env_b.setPeakLevel(_voiceId, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Att) * m_env_b.m_timeFactor[_voiceId][0];
-  m_env_b.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  m_env_b.setSegmentDest(_voiceId, 1, false, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_1) * m_env_b.m_timeFactor[_voiceId][1];
-  m_env_b.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_BP);
-  m_env_b.setSegmentDest(_voiceId, 2, true, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_2) * m_env_b.m_timeFactor[_voiceId][2];
-  m_env_b.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Sus);
-  m_env_b.setSegmentDest(_voiceId, 3, true, peak);
-  // env c
-  timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Time_KT) * _pitch;
-  levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Lvl_Vel);
-  attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Att_Vel) * _vel;
-  levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Lvl_KT) * _pitch;
-  if(levelVel < 0.0f)
-  {
-    unclipped = m_convert->eval_level((_vel * levelVel) + levelKT);
-  }
-  else
-  {
-    unclipped = m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT);
-  }
-  peak = std::min(unclipped, env_clip_peak);
-  m_env_c.m_clipFactor[_voiceId] = unclipped / peak;
-  m_env_c.m_levelFactor[_voiceId] = peak;
-  m_env_c.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
-  m_env_c.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
-  m_env_c.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
-  m_env_c.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Att_Curve));
-  m_env_c.setRetriggerHardness(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Retr_H));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Att) * m_env_c.m_timeFactor[_voiceId][0];
-  m_env_c.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  m_env_c.setSegmentDest(_voiceId, 1, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_1) * m_env_c.m_timeFactor[_voiceId][1];
-  m_env_c.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_BP);
-  m_env_c.setSegmentDest(_voiceId, 2, peak);
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_2) * m_env_c.m_timeFactor[_voiceId][2];
-  m_env_c.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_Sus);
-  m_env_c.setSegmentDest(_voiceId, 3, peak);
-  // start envelopes
-  m_env_a.start(_voiceId);
-  m_env_b.start(_voiceId);
-  m_env_c.start(_voiceId);
-  m_env_g.start(_voiceId);
+    float time, timeKT, dest, levelVel, attackVel, decay1Vel, decay2Vel, levelKT, peak, unclipped;
+    // env a
+    timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Time_KT) * _pitch;
+    levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Lvl_Vel);
+    attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Att_Vel) * _vel;
+    decay1Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Dec_1_Vel) * _vel;
+    decay2Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Dec_2_Vel) * _vel;
+    levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Lvl_KT) * _pitch;
+    if (levelVel < 0.0f) {
+        peak = std::min(m_convert->eval_level((_vel * levelVel) + levelKT), env_clip_peak);
+    } else {
+        peak = std::min(m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT), env_clip_peak);
+    }
+    m_env_a.m_levelFactor[_voiceId] = peak;
+    m_env_a.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
+    m_env_a.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
+    m_env_a.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
+    m_env_a.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Elevate));
+    m_env_a.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Att_Curve));
+    m_env_a.setPeakLevel(_voiceId, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Att) * m_env_a.m_timeFactor[_voiceId][0];
+    m_env_a.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    m_env_a.setSegmentDest(_voiceId, 1, false, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_1) * m_env_a.m_timeFactor[_voiceId][1];
+    m_env_a.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_BP);
+    m_env_a.setSegmentDest(_voiceId, 2, true, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_2) * m_env_a.m_timeFactor[_voiceId][2];
+    m_env_a.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Sus);
+    m_env_a.setSegmentDest(_voiceId, 3, true, peak);
+    // env b
+    timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Time_KT) * _pitch;
+    levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Lvl_Vel);
+    attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Att_Vel) * _vel;
+    decay1Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Dec_1_Vel) * _vel;
+    decay2Vel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Dec_2_Vel) * _vel;
+    levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Lvl_KT) * _pitch;
+    if (levelVel < 0.0f) {
+        peak = std::min(m_convert->eval_level((_vel * levelVel) + levelKT), env_clip_peak);
+    } else {
+        peak = std::min(m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT), env_clip_peak);
+    }
+    m_env_b.m_levelFactor[_voiceId] = peak;
+    m_env_b.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
+    m_env_b.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
+    m_env_b.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
+    m_env_b.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Elevate));
+    m_env_b.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Att_Curve));
+    m_env_b.setPeakLevel(_voiceId, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Att) * m_env_b.m_timeFactor[_voiceId][0];
+    m_env_b.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    m_env_b.setSegmentDest(_voiceId, 1, false, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_1) * m_env_b.m_timeFactor[_voiceId][1];
+    m_env_b.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_BP);
+    m_env_b.setSegmentDest(_voiceId, 2, true, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_2) * m_env_b.m_timeFactor[_voiceId][2];
+    m_env_b.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Sus);
+    m_env_b.setSegmentDest(_voiceId, 3, true, peak);
+    // env c
+    timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Time_KT) * _pitch;
+    levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Lvl_Vel);
+    attackVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Att_Vel) * _vel;
+    levelKT = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Lvl_KT) * _pitch;
+    if (levelVel < 0.0f) {
+        unclipped = m_convert->eval_level((_vel * levelVel) + levelKT);
+    } else {
+        unclipped = m_convert->eval_level(((1.0f - _vel) * -levelVel) + levelKT);
+    }
+    peak = std::min(unclipped, env_clip_peak);
+    m_env_c.m_clipFactor[_voiceId] = unclipped / peak;
+    m_env_c.m_levelFactor[_voiceId] = peak;
+    m_env_c.m_timeFactor[_voiceId][0] = m_convert->eval_level(timeKT + attackVel) * m_millisecond;
+    m_env_c.m_timeFactor[_voiceId][1] = m_convert->eval_level(timeKT + decay1Vel) * m_millisecond;
+    m_env_c.m_timeFactor[_voiceId][2] = m_convert->eval_level(timeKT + decay2Vel) * m_millisecond;
+    m_env_c.setAttackCurve(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Att_Curve));
+    m_env_c.setRetriggerHardness(m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Retr_H));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Att) * m_env_c.m_timeFactor[_voiceId][0];
+    m_env_c.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    m_env_c.setSegmentDest(_voiceId, 1, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_1) * m_env_c.m_timeFactor[_voiceId][1];
+    m_env_c.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_BP);
+    m_env_c.setSegmentDest(_voiceId, 2, peak);
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_2) * m_env_c.m_timeFactor[_voiceId][2];
+    m_env_c.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_Sus);
+    m_env_c.setSegmentDest(_voiceId, 3, peak);
+    // start envelopes
+    m_env_a.start(_voiceId);
+    m_env_b.start(_voiceId);
+    m_env_c.start(_voiceId);
+    m_env_g.start(_voiceId);
 }
 
 void PolySection::stopEnvelopes(const uint32_t _voiceId, const float _pitch, const float _vel)
 {
-  float time, timeKT, releaseVel;
-  // env a
-  timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Time_KT) * _pitch;
-  releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Rel_Vel) * _vel;
-  m_env_a.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_a.m_timeFactor[_voiceId][3];
-    m_env_a.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_a.setSegmentDx(_voiceId, 4, 0.0f);
-  }
-  // env b
-  timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Time_KT) * _pitch;
-  releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Rel_Vel) * _vel;
-  m_env_b.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_b.m_timeFactor[_voiceId][3];
-    m_env_b.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_b.setSegmentDx(_voiceId, 4, 0.0f);
-  }
-  // env c
-  timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Time_KT) * _pitch;
-  releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Rel_Vel) * _vel;
-  m_env_c.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_c.m_timeFactor[_voiceId][3];
-    m_env_c.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_c.setSegmentDx(_voiceId, 4, 0.0f);
-  }
-  // stop envelopes
-  m_env_a.stop(_voiceId);
-  m_env_b.stop(_voiceId);
-  m_env_c.stop(_voiceId);
-  m_env_g.stop(_voiceId);
+    float time, timeKT, releaseVel;
+    // env a
+    timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Time_KT) * _pitch;
+    releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_A_Rel_Vel) * _vel;
+    m_env_a.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_a.m_timeFactor[_voiceId][3];
+        m_env_a.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_a.setSegmentDx(_voiceId, 4, 0.0f);
+    }
+    // env b
+    timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Time_KT) * _pitch;
+    releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Rel_Vel) * _vel;
+    m_env_b.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_b.m_timeFactor[_voiceId][3];
+        m_env_b.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_b.setSegmentDx(_voiceId, 4, 0.0f);
+    }
+    // env c
+    timeKT = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Time_KT) * _pitch;
+    releaseVel = -m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Rel_Vel) * _vel;
+    m_env_c.m_timeFactor[_voiceId][3] = m_convert->eval_level(timeKT + releaseVel) * m_millisecond;
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_c.m_timeFactor[_voiceId][3];
+        m_env_c.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_c.setSegmentDx(_voiceId, 4, 0.0f);
+    }
+    // stop envelopes
+    m_env_a.stop(_voiceId);
+    m_env_b.stop(_voiceId);
+    m_env_c.stop(_voiceId);
+    m_env_g.stop(_voiceId);
 }
 
 void PolySection::updateEnvLevels(const uint32_t _voiceId)
 {
-  float peak, dest;
-  // env a
-  m_env_a.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Elevate));
-  peak = m_env_a.m_levelFactor[_voiceId];
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_BP);
-  m_env_a.setSegmentDest(_voiceId, 2, true, dest);
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Sus);
-  m_env_a.setSegmentDest(_voiceId, 3, true, dest);
-  // env b
-  m_env_b.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Elevate));
-  peak = m_env_b.m_levelFactor[_voiceId];
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_BP);
-  m_env_b.setSegmentDest(_voiceId, 2, true, dest);
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Sus);
-  m_env_b.setSegmentDest(_voiceId, 3, true, dest);
-  // env c
-  peak = m_env_c.m_levelFactor[_voiceId];
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_BP);
-  m_env_c.setSegmentDest(_voiceId, 2, dest);
-  dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_Sus);
-  m_env_c.setSegmentDest(_voiceId, 3, dest);
+    float peak, dest;
+    // env a
+    m_env_a.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Elevate));
+    peak = m_env_a.m_levelFactor[_voiceId];
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_BP);
+    m_env_a.setSegmentDest(_voiceId, 2, true, dest);
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Sus);
+    m_env_a.setSegmentDest(_voiceId, 3, true, dest);
+    // env b
+    m_env_b.setSplitValue(m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Elevate));
+    peak = m_env_b.m_levelFactor[_voiceId];
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_BP);
+    m_env_b.setSegmentDest(_voiceId, 2, true, dest);
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Sus);
+    m_env_b.setSegmentDest(_voiceId, 3, true, dest);
+    // env c
+    peak = m_env_c.m_levelFactor[_voiceId];
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_BP);
+    m_env_c.setSegmentDest(_voiceId, 2, dest);
+    dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_Sus);
+    m_env_c.setSegmentDest(_voiceId, 3, dest);
 }
 
 void PolySection::updateEnvTimes(const uint32_t _voiceId)
 {
-  float time;
-  // env a
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Att) * m_env_a.m_timeFactor[_voiceId][0];
-  m_env_a.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_1) * m_env_a.m_timeFactor[_voiceId][1];
-  m_env_a.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_2) * m_env_a.m_timeFactor[_voiceId][2];
-  m_env_a.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_a.m_timeFactor[_voiceId][3];
-    m_env_a.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_a.setSegmentDx(_voiceId, 4, 0.0f);
-  }
-  // env b
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Att) * m_env_b.m_timeFactor[_voiceId][0];
-  m_env_b.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_1) * m_env_b.m_timeFactor[_voiceId][1];
-  m_env_b.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_2) * m_env_b.m_timeFactor[_voiceId][2];
-  m_env_b.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_b.m_timeFactor[_voiceId][3];
-    m_env_b.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_b.setSegmentDx(_voiceId, 4, 0.0f);
-  }
-  // env c
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Att) * m_env_c.m_timeFactor[_voiceId][0];
-  m_env_c.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_1) * m_env_c.m_timeFactor[_voiceId][1];
-  m_env_c.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_2) * m_env_c.m_timeFactor[_voiceId][2];
-  m_env_c.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
-  time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Rel);
-  if(time <= env_highest_finite_time)
-  {
-    time *= m_env_c.m_timeFactor[_voiceId][3];
-    m_env_c.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
-  }
-  else
-  {
-    m_env_c.setSegmentDx(_voiceId, 4, 0.0f);
-  }
+    float time;
+    // env a
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Att) * m_env_a.m_timeFactor[_voiceId][0];
+    m_env_a.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_1) * m_env_a.m_timeFactor[_voiceId][1];
+    m_env_a.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_2) * m_env_a.m_timeFactor[_voiceId][2];
+    m_env_a.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_a.m_timeFactor[_voiceId][3];
+        m_env_a.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_a.setSegmentDx(_voiceId, 4, 0.0f);
+    }
+    // env b
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Att) * m_env_b.m_timeFactor[_voiceId][0];
+    m_env_b.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_1) * m_env_b.m_timeFactor[_voiceId][1];
+    m_env_b.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_2) * m_env_b.m_timeFactor[_voiceId][2];
+    m_env_b.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_b.m_timeFactor[_voiceId][3];
+        m_env_b.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_b.setSegmentDx(_voiceId, 4, 0.0f);
+    }
+    // env c
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Att) * m_env_c.m_timeFactor[_voiceId][0];
+    m_env_c.setSegmentDx(_voiceId, 1, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_1) * m_env_c.m_timeFactor[_voiceId][1];
+    m_env_c.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_2) * m_env_c.m_timeFactor[_voiceId][2];
+    m_env_c.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
+    time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Rel);
+    if (time <= env_highest_finite_time) {
+        time *= m_env_c.m_timeFactor[_voiceId][3];
+        m_env_c.setSegmentDx(_voiceId, 4, 1.0f / (time + 1.0f));
+    } else {
+        m_env_c.setSegmentDx(_voiceId, 4, 0.0f);
+    }
 }
 
 void PolySection::updateNotePitch(const uint32_t _voiceId)
 {
-  const float glide = m_mono_glide.m_value;
-  m_base_pitch[_voiceId]
-      = ((1.0f - glide) * m_last_key_tune[_voiceId]) + (glide * m_key_tune[_voiceId]) + evalScale(_voiceId);
-  m_note_pitch[_voiceId] = m_base_pitch[_voiceId]
-      + (m_smoothers.get(C15::Smoothers::Poly_Slow::Unison_Detune)
-         * m_spread.m_detune[m_uVoice][m_unison_index[_voiceId]])
-      + m_smoothers.get(C15::Smoothers::Poly_Slow::Voice_Grp_Tune)
-      + m_globalsignals->get(C15::Signals::Global_Signals::Master_Tune) + m_shift[_voiceId];
+    const float glide = m_mono_glide.m_value;
+    m_base_pitch[_voiceId]
+        = ((1.0f - glide) * m_last_key_tune[_voiceId]) + (glide * m_key_tune[_voiceId]) + evalScale(_voiceId);
+    m_note_pitch[_voiceId] = m_base_pitch[_voiceId]
+        + (m_smoothers.get(C15::Smoothers::Poly_Slow::Unison_Detune)
+              * m_spread.m_detune[m_uVoice][m_unison_index[_voiceId]])
+        + m_smoothers.get(C15::Smoothers::Poly_Slow::Voice_Grp_Tune)
+        + m_globalsignals->get(C15::Signals::Global_Signals::Master_Tune) + m_shift[_voiceId];
 }
 
 void PolySection::setSlowFilterCoefs(const uint32_t _voiceId)
 {
-  m_soundgenerator.set(m_signals, _voiceId);
-  m_combfilter.set(m_signals, m_samplerate, _voiceId);
-  m_feedbackmixer.set(m_signals, _voiceId);
+    m_soundgenerator.set(m_signals, _voiceId);
+    m_combfilter.set(m_signals, m_samplerate, _voiceId);
+    m_feedbackmixer.set(m_signals, _voiceId);
 }

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -744,15 +744,6 @@ void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::Unmodula
         }
     }
     switch (static_cast<C15::Parameters::Local_Unmodulateables>(_id)) {
-    case C15::Parameters::Local_Unmodulateables::Mono_Grp_Enable:
-        m_alloc.setMonoEnable(layerId, param->m_scaled);
-        break;
-    case C15::Parameters::Local_Unmodulateables::Mono_Grp_Prio:
-        m_alloc.setMonoPriority(layerId, param->m_scaled);
-        break;
-    case C15::Parameters::Local_Unmodulateables::Mono_Grp_Legato:
-        m_alloc.setMonoLegato(layerId, param->m_scaled);
-        break;
     case C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_From:
         if (m_layer_mode == LayerMode::Layer) {
             evalVoiceFadeChg(layerId);

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -753,12 +753,15 @@ void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::Unmodula
     case C15::Parameters::Local_Unmodulateables::Mono_Grp_Legato:
         m_alloc.setMonoLegato(layerId, param->m_scaled);
         break;
-    // TODO: implement Key Fade evaluation of individual levels (by layerId)
     case C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_From:
-        evalVoiceFadeChg(layerId);
+        if (m_layer_mode == LayerMode::Layer) {
+            evalVoiceFadeChg(layerId);
+        }
         break;
     case C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_Range:
-        evalVoiceFadeChg(layerId);
+        if (m_layer_mode == LayerMode::Layer) {
+            evalVoiceFadeChg(layerId);
+        }
         break;
     default:
         break;
@@ -1855,7 +1858,6 @@ void dsp_host_dual::recallSplit()
 
 void dsp_host_dual::recallLayer()
 {
-    // TODO: implement Key Fade evaluation of individual levels (both parts)
     if (LOG_RECALL) {
         nltools::Log::info("recallLayer(@", m_clock.m_index, ")");
     }
@@ -1923,6 +1925,7 @@ void dsp_host_dual::recallLayer()
         for (uint32_t i = 0; i < msg->unmodulateables[layerId].size(); i++) {
             localParRcl(layerId, msg->unmodulateables[layerId][i]);
         }
+        evalVoiceFadeChg(layerId);
         // local updates: modulateables
         if (LOG_RECALL) {
             nltools::Log::info("recall: local modulateables:");

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -13,2510 +13,2153 @@
 
 dsp_host_dual::dsp_host_dual()
 {
-  m_mainOut_L = m_mainOut_R = 0.0f;
-  m_layer_mode = m_preloaded_layer_mode = C15::Properties::LayerMode::Single;
+    m_mainOut_L = m_mainOut_R = 0.0f;
+    m_layer_mode = m_preloaded_layer_mode = C15::Properties::LayerMode::Single;
 }
 
 void dsp_host_dual::init(const uint32_t _samplerate, const uint32_t _polyphony)
 {
-  const float samplerate = static_cast<float>(_samplerate);
-  // init of crucial components: voiceAlloc, conversion, clock, time, ae_fade_table ("fadepoint"), ae_fader ("pickup")
-  m_alloc.init(&m_layer_mode, &m_preloaded_layer_mode);
-  m_alloc.setSplitPoint(30);  // temporary..?
-  m_convert.init();
-  m_clock.init(_samplerate);
-  m_time.init(_samplerate);
-  m_fade.init(samplerate);
-  m_output_mute.init(&m_fade.m_value);
-  // proper time init
-  m_edit_time.init(C15::Properties::SmootherScale::Linear, 200.0f, 0.0f, 0.1f);
-  m_edit_time.m_scaled = scale(m_edit_time.m_scaling, m_edit_time.m_position);
-  updateTime(&m_edit_time.m_dx, m_edit_time.m_scaled);
-  m_transition_time.init(C15::Properties::SmootherScale::Expon_Env_Time, 1.0f, -20.0f, 0.0f);
-  m_transition_time.m_scaled = scale(m_transition_time.m_scaling, m_transition_time.m_position);
-  updateTime(&m_transition_time.m_dx, m_transition_time.m_scaled);
-  // note: time and reference setting params are currently hard-coded but could also be part of parameter list
-  m_reference.init(C15::Properties::SmootherScale::Linear, 80.0f, 400.0f, 0.5f);
-  m_reference.m_scaled = scale(m_reference.m_scaling, m_reference.m_position);
-  // dsp sections init
-  m_global.init(m_time.m_sample_inc);
-  m_global.update_tone_amplitude(-6.0f);
-  m_global.update_tone_frequency(m_reference.m_scaled);
-  m_global.update_tone_mode(0);
+    const float samplerate = static_cast<float>(_samplerate);
+    // init of crucial components: voiceAlloc, conversion, clock, time, ae_fade_table ("fadepoint"), ae_fader ("pickup")
+    m_alloc.init(&m_layer_mode, &m_preloaded_layer_mode);
+    m_alloc.setSplitPoint(30); // temporary..?
+    m_convert.init();
+    m_clock.init(_samplerate);
+    m_time.init(_samplerate);
+    m_fade.init(samplerate);
+    m_output_mute.init(&m_fade.m_value);
+    // proper time init
+    m_edit_time.init(C15::Properties::SmootherScale::Linear, 200.0f, 0.0f, 0.1f);
+    m_edit_time.m_scaled = scale(m_edit_time.m_scaling, m_edit_time.m_position);
+    updateTime(&m_edit_time.m_dx, m_edit_time.m_scaled);
+    m_transition_time.init(C15::Properties::SmootherScale::Expon_Env_Time, 1.0f, -20.0f, 0.0f);
+    m_transition_time.m_scaled = scale(m_transition_time.m_scaling, m_transition_time.m_position);
+    updateTime(&m_transition_time.m_dx, m_transition_time.m_scaled);
+    // note: time and reference setting params are currently hard-coded but could also be part of parameter list
+    m_reference.init(C15::Properties::SmootherScale::Linear, 80.0f, 400.0f, 0.5f);
+    m_reference.m_scaled = scale(m_reference.m_scaling, m_reference.m_position);
+    // dsp sections init
+    m_global.init(m_time.m_sample_inc);
+    m_global.update_tone_amplitude(-6.0f);
+    m_global.update_tone_frequency(m_reference.m_scaled);
+    m_global.update_tone_mode(0);
 
-  // voice fade stuff I (currently explicit)
-  m_poly[0].m_fadeStart = 0;
-  m_poly[0].m_fadeEnd = C15::Config::key_count - 1;
-  m_poly[0].m_fadeIncrement = 1;
-  // init poly dsp: exponentiator, feedback pointers
-  m_poly[0].init(&m_global.m_signals, &m_convert, &m_time, &m_z_layers[0], &m_reference.m_scaled, m_time.m_millisecond,
-                 env_init_gateRelease, samplerate);
-  // voice fade stuff II (currently explicit)
-  m_poly[1].m_fadeStart = C15::Config::key_count - 1;
-  m_poly[1].m_fadeEnd = 0;
-  m_poly[1].m_fadeIncrement = -1;
-  // init poly dsp: exponentiator, feedback pointers
-  m_poly[1].init(&m_global.m_signals, &m_convert, &m_time, &m_z_layers[1], &m_reference.m_scaled, m_time.m_millisecond,
-                 env_init_gateRelease, samplerate);
-  // init mono dsp
-  m_mono[0].init(&m_convert, &m_z_layers[0], m_time.m_millisecond, samplerate);
-  m_mono[1].init(&m_convert, &m_z_layers[1], m_time.m_millisecond, samplerate);
-  // init parameters by parameter list
-  m_params.init_modMatrix();
-  for(uint32_t i = 0; i < C15::Config::tcd_elements; i++)
-  {
-    auto element = C15::ParameterList[i];
-    switch(element.m_param.m_type)
-    {
-      // (global) unmodulateable parameters need their properties and can directly feed to global signals
-      case C15::Descriptors::ParameterType::Global_Modulateable:
-        m_params.init_global_modulateable(element);
-        switch(element.m_ae.m_signal.m_signal)
-        {
-          case C15::Descriptors::ParameterSignal::Global_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_global.add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_global.add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_global.add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_global.add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-            }
-            break;
-        }
-        break;
+    // voice fade stuff I (currently explicit)
+    m_poly[0].m_fadeStart = 0;
+    m_poly[0].m_fadeEnd = C15::Config::key_count - 1;
+    m_poly[0].m_fadeIncrement = 1;
+    // init poly dsp: exponentiator, feedback pointers
+    m_poly[0].init(&m_global.m_signals, &m_convert, &m_time, &m_z_layers[0], &m_reference.m_scaled, m_time.m_millisecond,
+        env_init_gateRelease, samplerate);
+    // voice fade stuff II (currently explicit)
+    m_poly[1].m_fadeStart = C15::Config::key_count - 1;
+    m_poly[1].m_fadeEnd = 0;
+    m_poly[1].m_fadeIncrement = -1;
+    // init poly dsp: exponentiator, feedback pointers
+    m_poly[1].init(&m_global.m_signals, &m_convert, &m_time, &m_z_layers[1], &m_reference.m_scaled, m_time.m_millisecond,
+        env_init_gateRelease, samplerate);
+    // init mono dsp
+    m_mono[0].init(&m_convert, &m_z_layers[0], m_time.m_millisecond, samplerate);
+    m_mono[1].init(&m_convert, &m_z_layers[1], m_time.m_millisecond, samplerate);
+    // init parameters by parameter list
+    m_params.init_modMatrix();
+    for (uint32_t i = 0; i < C15::Config::tcd_elements; i++) {
+        auto element = C15::ParameterList[i];
+        switch (element.m_param.m_type) {
         // (global) unmodulateable parameters need their properties and can directly feed to global signals
-      case C15::Descriptors::ParameterType::Global_Unmodulateable:
-        m_params.init_global_unmodulateable(element);
-        switch(element.m_ae.m_signal.m_signal)
-        {
-          case C15::Descriptors::ParameterSignal::Global_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_global.add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_global.add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_global.add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_global.add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+        case C15::Descriptors::ParameterType::Global_Modulateable:
+            m_params.init_global_modulateable(element);
+            switch (element.m_ae.m_signal.m_signal) {
+            case C15::Descriptors::ParameterSignal::Global_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_global.add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_global.add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_global.add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_global.add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
                 break;
             }
+            break;
+            // (global) unmodulateable parameters need their properties and can directly feed to global signals
+        case C15::Descriptors::ParameterType::Global_Unmodulateable:
+            m_params.init_global_unmodulateable(element);
+            switch (element.m_ae.m_signal.m_signal) {
+            case C15::Descriptors::ParameterSignal::Global_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_global.add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_global.add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_global.add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_global.add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
+                break;
+            }
+            break;
+        // macro controls need to know their position in mod matrix (which hw amounts are relevant)
+        case C15::Descriptors::ParameterType::Macro_Control:
+            m_params.init_macro(element);
+            break;
+        // (local) modulateable parameters need their properties and can directly feed to either quasipoly or mono signals
+        case C15::Descriptors::ParameterType::Local_Modulateable:
+            m_params.init_local_modulateable(element);
+            switch (element.m_ae.m_signal.m_signal) {
+            case C15::Descriptors::ParameterSignal::Quasipoly_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_poly[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_poly[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_poly[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_poly[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
+                break;
+            case C15::Descriptors::ParameterSignal::Mono_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_mono[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_mono[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_mono[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_mono[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
+                break;
+            }
+            break;
+        // (local) unmodulateable parameters need their properties and can directly feed to either quasipoly or mono signals
+        case C15::Descriptors::ParameterType::Local_Unmodulateable:
+            m_params.init_local_unmodulateable(element);
+            switch (element.m_ae.m_signal.m_signal) {
+            case C15::Descriptors::ParameterSignal::Quasipoly_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_poly[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_poly[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_poly[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_poly[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_poly[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
+                break;
+            case C15::Descriptors::ParameterSignal::Mono_Signal:
+                switch (element.m_ae.m_smoother.m_clock) {
+                case C15::Descriptors::SmootherClock::Sync:
+                    m_mono[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Audio:
+                    m_mono[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Fast:
+                    m_mono[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                case C15::Descriptors::SmootherClock::Slow:
+                    m_mono[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    m_mono[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
+                    break;
+                }
+                break;
+            }
+            break;
+        case C15::Descriptors::ParameterType::Macro_Time:
+            auto mc = m_params.init_macro_time(element);
+            mc->m_time.m_scaled = scale(mc->m_time.m_scaling, mc->m_time.m_position);
+            updateTime(&mc->m_time.m_dx, mc->m_time.m_scaled);
             break;
         }
-        break;
-      // macro controls need to know their position in mod matrix (which hw amounts are relevant)
-      case C15::Descriptors::ParameterType::Macro_Control:
-        m_params.init_macro(element);
-        break;
-      // (local) modulateable parameters need their properties and can directly feed to either quasipoly or mono signals
-      case C15::Descriptors::ParameterType::Local_Modulateable:
-        m_params.init_local_modulateable(element);
-        switch(element.m_ae.m_signal.m_signal)
-        {
-          case C15::Descriptors::ParameterSignal::Quasipoly_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_poly[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_poly[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_poly[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_poly[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-            }
-            break;
-          case C15::Descriptors::ParameterSignal::Mono_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_mono[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_mono[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_mono[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_mono[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-            }
-            break;
-        }
-        break;
-      // (local) unmodulateable parameters need their properties and can directly feed to either quasipoly or mono signals
-      case C15::Descriptors::ParameterType::Local_Unmodulateable:
-        m_params.init_local_unmodulateable(element);
-        switch(element.m_ae.m_signal.m_signal)
-        {
-          case C15::Descriptors::ParameterSignal::Quasipoly_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_poly[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_poly[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_poly[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_poly[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_poly[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-            }
-            break;
-          case C15::Descriptors::ParameterSignal::Mono_Signal:
-            switch(element.m_ae.m_smoother.m_clock)
-            {
-              case C15::Descriptors::SmootherClock::Sync:
-                m_mono[0].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_sync_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Audio:
-                m_mono[0].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_audio_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Fast:
-                m_mono[0].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_fast_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-              case C15::Descriptors::SmootherClock::Slow:
-                m_mono[0].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                m_mono[1].add_copy_slow_id(element.m_ae.m_smoother.m_index, element.m_ae.m_signal.m_index);
-                break;
-            }
-            break;
-        }
-        break;
-      case C15::Descriptors::ParameterType::Macro_Time:
-        auto mc = m_params.init_macro_time(element);
-        mc->m_time.m_scaled = scale(mc->m_time.m_scaling, mc->m_time.m_position);
-        updateTime(&mc->m_time.m_dx, mc->m_time.m_scaled);
-        break;
     }
-  }
-  // temporary: load initials in order to have valid osc reset params
-  //onSettingInitialSinglePreset();
-  if(LOG_INIT)
-  {
-    nltools::Log::info("dsp_host_dual::init - engine dsp status: global");
-    nltools::Log::info("missing: nltools::msg - reference, initial:", m_reference.m_scaled);
-  }
-  // testing voice fading
-  //m_poly[0].evalVoiceFade(30.f, 11.f);
-  //m_poly[1].evalVoiceFade(42.f, 11.f);
-  /*
-  nltools::Log::info("fades I:");
-  m_poly[0].evalVoiceFade(0.f, 0.f);
-  m_poly[0].evalVoiceFade(60.f, 0.f);
-  m_poly[0].evalVoiceFade(0.f, 59.f);
-  m_poly[0].evalVoiceFade(0.f, 60.f);
-  m_poly[0].evalVoiceFade(30.f, 60.f);
-  nltools::Log::info("fades II:");
-  m_poly[1].evalVoiceFade(60.f, 0.f);
-  m_poly[1].evalVoiceFade(0.f, 0.f);
-  m_poly[1].evalVoiceFade(60.f, 59.f);
-  m_poly[1].evalVoiceFade(60.f, 60.f);
-  m_poly[1].evalVoiceFade(30.f, 60.f);
-  */
+    // temporary: load initials in order to have valid osc reset params
+    //onSettingInitialSinglePreset();
+
+    // testing voice fading
+    //m_poly[0].evalVoiceFade(30.f, 11.f);
+    //m_poly[1].evalVoiceFade(42.f, 11.f);
+    /*
+    nltools::Log::info("fades I:");
+    m_poly[0].evalVoiceFade(0.f, 0.f);
+    m_poly[0].evalVoiceFade(60.f, 0.f);
+    m_poly[0].evalVoiceFade(0.f, 59.f);
+    m_poly[0].evalVoiceFade(0.f, 60.f);
+    m_poly[0].evalVoiceFade(30.f, 60.f);
+    nltools::Log::info("fades II:");
+    m_poly[1].evalVoiceFade(60.f, 0.f);
+    m_poly[1].evalVoiceFade(0.f, 0.f);
+    m_poly[1].evalVoiceFade(60.f, 59.f);
+    m_poly[1].evalVoiceFade(60.f, 60.f);
+    m_poly[1].evalVoiceFade(30.f, 60.f);
+    */
+
+    if (LOG_INIT) {
+        //nltools::Log::info("dsp_host_dual::init - engine dsp status: global");
+        //nltools::Log::info("missing: nltools::msg - reference, initial:", m_reference.m_scaled);
+    }
 }
 
 C15::ParameterDescriptor dsp_host_dual::getParameter(const int _id)
 {
-  if((_id > -1) && (_id < C15::Config::tcd_elements))
-  {
-    if(LOG_DISPATCH)
-    {
-      if(C15::ParameterList[_id].m_param.m_type != C15::Descriptors::ParameterType::None)
-      {
-        nltools::Log::info("dispatch(", _id, "):", C15::ParameterList[_id].m_pg.m_group_label_short, "-",
-                           C15::ParameterList[_id].m_pg.m_param_label_short);
-      }
-      else
-      {
-        nltools::Log::warning("dispatch(", _id, "): None!");
-      }
+    if ((_id > -1) && (_id < C15::Config::tcd_elements)) {
+        if (LOG_DISPATCH) {
+            if (C15::ParameterList[_id].m_param.m_type != C15::Descriptors::ParameterType::None) {
+                nltools::Log::info("dispatch(", _id, "):", C15::ParameterList[_id].m_pg.m_group_label_short, "-",
+                    C15::ParameterList[_id].m_pg.m_param_label_short);
+            } else {
+                nltools::Log::warning("dispatch(", _id, "): None!");
+            }
+        }
+        return C15::ParameterList[_id];
     }
-    return C15::ParameterList[_id];
-  }
-  if(LOG_FAIL)
-  {
-    nltools::Log::warning("dispatch(", _id, "):", "failed!");
-  }
-  return m_invalid_param;
+    if (LOG_FAIL) {
+        nltools::Log::warning("dispatch(", _id, "):", "failed!");
+    }
+    return m_invalid_param;
 }
 
 void dsp_host_dual::logStatus()
 {
-  if(LOG_ENGINE_STATUS)
-  {
-    nltools::Log::info("engine status:");
-    nltools::Log::info("-clock(index:", m_clock.m_index, ", fast:", m_clock.m_fast, ", slow:", m_clock.m_slow, ")");
-    nltools::Log::info("-output(left:", m_mainOut_L, ", right:", m_mainOut_R, ", mute:", m_output_mute.get_value(),
-                       ")");
-    nltools::Log::info("-dsp(dx:", m_time.m_sample_inc, ", ms:", m_time.m_millisecond, ")");
-  }
-  else if(LOG_ENGINE_EDITS)
-  {
-    nltools::Log::info("Engine Param Status - - - - - - - - - - - - - - - \n\n");
-    for(uint32_t i = 0; i < LOG_PARAMS_LENGTH; i++)
-    {
-      auto element = C15::ParameterList[LOG_PARAMS[i]];
-      switch(element.m_param.m_type)
-      {
-        case C15::Descriptors::ParameterType::None:
-          break;
-        case C15::Descriptors::ParameterType::Hardware_Source:
-          nltools::Log::info("HW[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_hw_src(element.m_param.m_index)->m_position,
-                             ", beh:", static_cast<int>(m_params.get_hw_src(element.m_param.m_index)->m_behavior), ")");
-          break;
-        case C15::Descriptors::ParameterType::Hardware_Amount:
-          nltools::Log::info("HA[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_hw_amt(element.m_param.m_index)->m_position, ")");
-          break;
-        case C15::Descriptors::ParameterType::Macro_Control:
-          nltools::Log::info("MC[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_macro(element.m_param.m_index)->m_position, ")");
-          break;
-        case C15::Descriptors::ParameterType::Macro_Time:
-          nltools::Log::info("MT[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_macro_time(element.m_param.m_index)->m_position,
-                             ", scl:", m_params.get_macro_time(element.m_param.m_index)->m_scaled, ")");
-          break;
-        case C15::Descriptors::ParameterType::Global_Modulateable:
-          nltools::Log::info("GT[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short, ":(pos:",
-                             m_params.get_global_target(element.m_param.m_index)
-                                 ->polarize(m_params.get_global_target(element.m_param.m_index)->m_position),
-                             ", scl:", m_params.get_global_target(element.m_param.m_index)->m_scaled,
-                             ", amt:", m_params.get_global_target(element.m_param.m_index)->m_amount,
-                             ", src:", static_cast<int>(m_params.get_global_target(element.m_param.m_index)->m_source),
-                             ")");
-          break;
-        case C15::Descriptors::ParameterType::Global_Unmodulateable:
-          nltools::Log::info("GD[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_global_direct(element.m_param.m_index)->m_position,
-                             ", scl:", m_params.get_global_direct(element.m_param.m_index)->m_scaled, ")");
-          break;
-        case C15::Descriptors::ParameterType::Local_Modulateable:
-          nltools::Log::info("LT[I, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short, ":(pos:",
-                             m_params.get_local_target(0, element.m_param.m_index)
-                                 ->polarize(m_params.get_local_target(0, element.m_param.m_index)->m_position),
-                             ", scl:", m_params.get_local_target(0, element.m_param.m_index)->m_scaled,
-                             ", amt:", m_params.get_local_target(0, element.m_param.m_index)->m_amount, ", src:",
-                             static_cast<int>(m_params.get_local_target(0, element.m_param.m_index)->m_source), ")");
-          if(m_layer_mode != C15::Properties::LayerMode::Single)
-          {
-            nltools::Log::info("LT[II, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                               element.m_pg.m_param_label_short, ":(pos:",
-                               m_params.get_local_target(1, element.m_param.m_index)
-                                   ->polarize(m_params.get_local_target(1, element.m_param.m_index)->m_position),
-                               ", scl:", m_params.get_local_target(1, element.m_param.m_index)->m_scaled,
-                               ", amt:", m_params.get_local_target(1, element.m_param.m_index)->m_amount, ", src:",
-                               static_cast<int>(m_params.get_local_target(1, element.m_param.m_index)->m_source), ")");
-          }
-          break;
-        case C15::Descriptors::ParameterType::Local_Unmodulateable:
-          nltools::Log::info("LD[I, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                             element.m_pg.m_param_label_short,
-                             ":(pos:", m_params.get_local_direct(0, element.m_param.m_index)->m_position,
-                             ", scl:", m_params.get_local_direct(0, element.m_param.m_index)->m_scaled, ")");
-          if(m_layer_mode != C15::Properties::LayerMode::Single)
-          {
-            nltools::Log::info("LD[II, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
-                               element.m_pg.m_param_label_short,
-                               ":(pos:", m_params.get_local_direct(1, element.m_param.m_index)->m_position,
-                               ", scl:", m_params.get_local_direct(1, element.m_param.m_index)->m_scaled, ")");
-          }
-          break;
-      }
+    if (LOG_ENGINE_STATUS) {
+        nltools::Log::info("engine status:");
+        nltools::Log::info("-clock(index:", m_clock.m_index, ", fast:", m_clock.m_fast, ", slow:", m_clock.m_slow, ")");
+        nltools::Log::info("-output(left:", m_mainOut_L, ", right:", m_mainOut_R, ", mute:", m_output_mute.get_value(),
+            ")");
+        nltools::Log::info("-dsp(dx:", m_time.m_sample_inc, ", ms:", m_time.m_millisecond, ")");
+    } else if (LOG_ENGINE_EDITS) {
+        nltools::Log::info("Engine Param Status - - - - - - - - - - - - - - - \n\n");
+        for (uint32_t i = 0; i < LOG_PARAMS_LENGTH; i++) {
+            auto element = C15::ParameterList[LOG_PARAMS[i]];
+            switch (element.m_param.m_type) {
+            case C15::Descriptors::ParameterType::None:
+                break;
+            case C15::Descriptors::ParameterType::Hardware_Source:
+                nltools::Log::info("HW[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_hw_src(element.m_param.m_index)->m_position,
+                    ", beh:", static_cast<int>(m_params.get_hw_src(element.m_param.m_index)->m_behavior), ")");
+                break;
+            case C15::Descriptors::ParameterType::Hardware_Amount:
+                nltools::Log::info("HA[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_hw_amt(element.m_param.m_index)->m_position, ")");
+                break;
+            case C15::Descriptors::ParameterType::Macro_Control:
+                nltools::Log::info("MC[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_macro(element.m_param.m_index)->m_position, ")");
+                break;
+            case C15::Descriptors::ParameterType::Macro_Time:
+                nltools::Log::info("MT[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_macro_time(element.m_param.m_index)->m_position,
+                    ", scl:", m_params.get_macro_time(element.m_param.m_index)->m_scaled, ")");
+                break;
+            case C15::Descriptors::ParameterType::Global_Modulateable:
+                nltools::Log::info("GT[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short, ":(pos:",
+                    m_params.get_global_target(element.m_param.m_index)
+                        ->polarize(m_params.get_global_target(element.m_param.m_index)->m_position),
+                    ", scl:", m_params.get_global_target(element.m_param.m_index)->m_scaled,
+                    ", amt:", m_params.get_global_target(element.m_param.m_index)->m_amount,
+                    ", src:", static_cast<int>(m_params.get_global_target(element.m_param.m_index)->m_source),
+                    ")");
+                break;
+            case C15::Descriptors::ParameterType::Global_Unmodulateable:
+                nltools::Log::info("GD[", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_global_direct(element.m_param.m_index)->m_position,
+                    ", scl:", m_params.get_global_direct(element.m_param.m_index)->m_scaled, ")");
+                break;
+            case C15::Descriptors::ParameterType::Local_Modulateable:
+                nltools::Log::info("LT[I, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short, ":(pos:",
+                    m_params.get_local_target(0, element.m_param.m_index)
+                        ->polarize(m_params.get_local_target(0, element.m_param.m_index)->m_position),
+                    ", scl:", m_params.get_local_target(0, element.m_param.m_index)->m_scaled,
+                    ", amt:", m_params.get_local_target(0, element.m_param.m_index)->m_amount, ", src:",
+                    static_cast<int>(m_params.get_local_target(0, element.m_param.m_index)->m_source), ")");
+                if (m_layer_mode != C15::Properties::LayerMode::Single) {
+                    nltools::Log::info("LT[II, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                        element.m_pg.m_param_label_short, ":(pos:",
+                        m_params.get_local_target(1, element.m_param.m_index)
+                            ->polarize(m_params.get_local_target(1, element.m_param.m_index)->m_position),
+                        ", scl:", m_params.get_local_target(1, element.m_param.m_index)->m_scaled,
+                        ", amt:", m_params.get_local_target(1, element.m_param.m_index)->m_amount, ", src:",
+                        static_cast<int>(m_params.get_local_target(1, element.m_param.m_index)->m_source), ")");
+                }
+                break;
+            case C15::Descriptors::ParameterType::Local_Unmodulateable:
+                nltools::Log::info("LD[I, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                    element.m_pg.m_param_label_short,
+                    ":(pos:", m_params.get_local_direct(0, element.m_param.m_index)->m_position,
+                    ", scl:", m_params.get_local_direct(0, element.m_param.m_index)->m_scaled, ")");
+                if (m_layer_mode != C15::Properties::LayerMode::Single) {
+                    nltools::Log::info("LD[II, ", LOG_PARAMS[i], "]", element.m_pg.m_group_label_short, ">",
+                        element.m_pg.m_param_label_short,
+                        ":(pos:", m_params.get_local_direct(1, element.m_param.m_index)->m_position,
+                        ", scl:", m_params.get_local_direct(1, element.m_param.m_index)->m_scaled, ")");
+                }
+                break;
+            }
+        }
+        nltools::Log::info("\n\n - - - - - - - - - - - - - - - Engine Param Status");
     }
-    nltools::Log::info("\n\n - - - - - - - - - - - - - - - Engine Param Status");
-  }
 }
 
 void dsp_host_dual::onMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1)
 {
 
-  if(LOG_MIDI)
-  {
-    nltools::Log::info("midiMsg(status:", _status, ", data0:", _data0, ", data1:", _data1, ")");
-  }
-  const uint32_t ch = _status & 15, st = (_status & 127) >> 4;
-  uint32_t arg = 0;
-  // LPC MIDI Protocol 1.7 transmits every LPC Message as MIDI PitchBend Message! (avoiding TCD Protocol collisions)
-  if(st == 6)
-  {
-    switch(ch)
-    {
-      case 0:
-        // Pedal 1
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Pedal1, raw:", arg, ")");
-        }
-        updateHW(0, static_cast<float>(arg));
-        break;
-      case 1:
-        // Pedal 2
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Pedal2, raw:", arg, ")");
-        }
-        updateHW(1, static_cast<float>(arg));
-        break;
-      case 2:
-        // Pedal 3
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Pedal3, raw:", arg, ")");
-        }
-        updateHW(2, static_cast<float>(arg));
-        break;
-      case 3:
-        // Pedal 4
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Pedal4, raw:", arg, ")");
-        }
-        updateHW(3, static_cast<float>(arg));
-        break;
-      case 4:
-        // Bender
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Bender, raw:", arg, ")");
-        }
-        updateHW(4, static_cast<float>(arg));
-        break;
-      case 5:
-        // Aftertouch
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Aftertouch, raw:", arg, ")");
-        }
-        updateHW(5, static_cast<float>(arg));
-        break;
-      case 6:
-        // Ribbon 1
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Ribbon1, raw:", arg, ")");
-        }
-        updateHW(6, static_cast<float>(arg));
-        break;
-      case 7:
-        // Ribbon 2
-        arg = _data1 + (_data0 << 7);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:Ribbon2, raw:", arg, ")");
-        }
-        updateHW(7, static_cast<float>(arg));
-        break;
-      case 13:
-        // Key Pos (down or up)
-        arg = _data1;
-        m_key_pos = arg - C15::Config::key_from;
-        // key position is only valid within range [36 ... 96]
-        m_key_valid = (arg >= C15::Config::key_from) && (arg <= C15::Config::key_to);
-        if(LOG_MIDI_DETAIL)
-        {
-          nltools::Log::info("midiMsg(source:KeyPos, raw:", arg, ", valid:", m_key_valid, ")");
-        }
-        break;
-      case 14:
-        // Key Down
-        arg = _data1 + (_data0 << 7);
-        if(m_key_valid)
-        {
-          keyDown(static_cast<float>(arg) * m_norm_vel);
-        }
-        else if(LOG_FAIL)
-        {
-          nltools::Log::warning("key_down(pos:", m_key_pos, ") failed!");
-        }
-        // ...
-        break;
-      case 15:
-        // Key Up
-        arg = _data1 + (_data0 << 7);
-        if(m_key_valid)
-        {
-          keyUp(static_cast<float>(arg) * m_norm_vel);
-        }
-        else if(LOG_FAIL)
-        {
-          nltools::Log::warning("key_up(pos:", m_key_pos, ") failed!");
-        }
-        break;
-      default:
-        break;
+    if (LOG_MIDI) {
+        nltools::Log::info("midiMsg(status:", _status, ", data0:", _data0, ", data1:", _data1, ")");
     }
-  }
+    const uint32_t ch = _status & 15, st = (_status & 127) >> 4;
+    uint32_t arg = 0;
+    // LPC MIDI Protocol 1.7 transmits every LPC Message as MIDI PitchBend Message! (avoiding TCD Protocol collisions)
+    if (st == 6) {
+        switch (ch) {
+        case 0:
+            // Pedal 1
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Pedal1, raw:", arg, ")");
+            }
+            updateHW(0, static_cast<float>(arg));
+            break;
+        case 1:
+            // Pedal 2
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Pedal2, raw:", arg, ")");
+            }
+            updateHW(1, static_cast<float>(arg));
+            break;
+        case 2:
+            // Pedal 3
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Pedal3, raw:", arg, ")");
+            }
+            updateHW(2, static_cast<float>(arg));
+            break;
+        case 3:
+            // Pedal 4
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Pedal4, raw:", arg, ")");
+            }
+            updateHW(3, static_cast<float>(arg));
+            break;
+        case 4:
+            // Bender
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Bender, raw:", arg, ")");
+            }
+            updateHW(4, static_cast<float>(arg));
+            break;
+        case 5:
+            // Aftertouch
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Aftertouch, raw:", arg, ")");
+            }
+            updateHW(5, static_cast<float>(arg));
+            break;
+        case 6:
+            // Ribbon 1
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Ribbon1, raw:", arg, ")");
+            }
+            updateHW(6, static_cast<float>(arg));
+            break;
+        case 7:
+            // Ribbon 2
+            arg = _data1 + (_data0 << 7);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:Ribbon2, raw:", arg, ")");
+            }
+            updateHW(7, static_cast<float>(arg));
+            break;
+        case 13:
+            // Key Pos (down or up)
+            arg = _data1;
+            m_key_pos = arg - C15::Config::key_from;
+            // key position is only valid within range [36 ... 96]
+            m_key_valid = (arg >= C15::Config::key_from) && (arg <= C15::Config::key_to);
+            if (LOG_MIDI_DETAIL) {
+                nltools::Log::info("midiMsg(source:KeyPos, raw:", arg, ", valid:", m_key_valid, ")");
+            }
+            break;
+        case 14:
+            // Key Down
+            arg = _data1 + (_data0 << 7);
+            if (m_key_valid) {
+                keyDown(static_cast<float>(arg) * m_norm_vel);
+            } else if (LOG_FAIL) {
+                nltools::Log::warning("key_down(pos:", m_key_pos, ") failed!");
+            }
+            // ...
+            break;
+        case 15:
+            // Key Up
+            arg = _data1 + (_data0 << 7);
+            if (m_key_valid) {
+                keyUp(static_cast<float>(arg) * m_norm_vel);
+            } else if (LOG_FAIL) {
+                nltools::Log::warning("key_up(pos:", m_key_pos, ") failed!");
+            }
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 void dsp_host_dual::onRawMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1)
 {
-  const uint32_t type = (_status & 127) >> 4;
-  uint32_t arg = 0;
-  switch(type)
-  {
+    const uint32_t type = (_status & 127) >> 4;
+    uint32_t arg = 0;
+    switch (type) {
     case 0:
-      // note off
-      arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_vel);
-      onMidiMessage(0xED, 0, _data0);            // keyPos
-      onMidiMessage(0xEF, arg >> 7, arg & 127);  // keyUp
-      break;
+        // note off
+        arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_vel);
+        onMidiMessage(0xED, 0, _data0); // keyPos
+        onMidiMessage(0xEF, arg >> 7, arg & 127); // keyUp
+        break;
     case 1:
-      // note on
-      arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_vel);
-      onMidiMessage(0xED, 0, _data0);  // keyPos
-      if(arg != 0)
-      {
-        onMidiMessage(0xEE, arg >> 7, arg & 127);  // keyDown
-      }
-      else
-      {
-        onMidiMessage(0xEF, 0, 0);  // keyUp
-      }
-      break;
+        // note on
+        arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_vel);
+        onMidiMessage(0xED, 0, _data0); // keyPos
+        if (arg != 0) {
+            onMidiMessage(0xEE, arg >> 7, arg & 127); // keyDown
+        } else {
+            onMidiMessage(0xEF, 0, 0); // keyUp
+        }
+        break;
     case 3:
-      // ctrl chg (hw sources: pedals, ribbons) - hard coded ReMOTE template "MSE 2"
-      arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_hw);
-      switch(_data0)
-      {
+        // ctrl chg (hw sources: pedals, ribbons) - hard coded ReMOTE template "MSE 2"
+        arg = static_cast<uint32_t>(static_cast<float>(_data1) * m_format_hw);
+        switch (_data0) {
         case 61:
-          // Pedal 1
-          onMidiMessage(0xE0, arg >> 7, arg & 127);
-          break;
+            // Pedal 1
+            onMidiMessage(0xE0, arg >> 7, arg & 127);
+            break;
         case 62:
-          // Pedal 2
-          onMidiMessage(0xE1, arg >> 7, arg & 127);
-          break;
+            // Pedal 2
+            onMidiMessage(0xE1, arg >> 7, arg & 127);
+            break;
         case 63:
-          // Pedal 3
-          onMidiMessage(0xE2, arg >> 7, arg & 127);
-          break;
+            // Pedal 3
+            onMidiMessage(0xE2, arg >> 7, arg & 127);
+            break;
         case 64:
-          // Pedal 4
-          onMidiMessage(0xE3, arg >> 7, arg & 127);
-          break;
+            // Pedal 4
+            onMidiMessage(0xE3, arg >> 7, arg & 127);
+            break;
         case 67:
-          // Ribbon 1
-          onMidiMessage(0xE6, arg >> 7, arg & 127);
-          break;
+            // Ribbon 1
+            onMidiMessage(0xE6, arg >> 7, arg & 127);
+            break;
         case 68:
-          // Ribbon 2
-          onMidiMessage(0xE7, arg >> 7, arg & 127);
-          break;
+            // Ribbon 2
+            onMidiMessage(0xE7, arg >> 7, arg & 127);
+            break;
         default:
-          break;
-      }
-      break;
+            break;
+        }
+        break;
     case 5:
-      // mono at (hw source)
-      arg = static_cast<uint32_t>(static_cast<float>(_data0) * m_format_hw);
-      onMidiMessage(0xE5, arg >> 7, arg & 127);  // hw_at
-      break;
+        // mono at (hw source)
+        arg = static_cast<uint32_t>(static_cast<float>(_data0) * m_format_hw);
+        onMidiMessage(0xE5, arg >> 7, arg & 127); // hw_at
+        break;
     case 6:
-      // bend (hw source)
-      arg = static_cast<uint32_t>(static_cast<float>(_data0 + (_data1 << 7)) * m_format_pb);
-      onMidiMessage(0xE4, arg >> 7, arg & 127);  // hw_bend
-      break;
+        // bend (hw source)
+        arg = static_cast<uint32_t>(static_cast<float>(_data0 + (_data1 << 7)) * m_format_pb);
+        onMidiMessage(0xE4, arg >> 7, arg & 127); // hw_bend
+        break;
     default:
-      break;
-  }
+        break;
+    }
 }
 
-void dsp_host_dual::onPresetMessage(const nltools::msg::SinglePresetMessage &_msg)
+void dsp_host_dual::onPresetMessage(const nltools::msg::SinglePresetMessage& _msg)
 {
-  m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Single;
-  m_preloaded_layer_mode = C15::Properties::LayerMode::Single;
-  m_preloaded_single_data = _msg;
-  if(LOG_RECALL)
-  {
-    // log preset with primitive timestamp (for debugging fade events)
-    nltools::Log::info("Received Single Preset Message! (@", m_clock.m_index, ")");
-  }
-  if(m_glitch_suppression)
-  {
-    // glitch suppression: start outputMute fade
-    m_fade.enable(FadeEvent::RecallMute, 0);  // enable fader with event
-    m_output_mute.pick(0);                    // pickup fade-out
-  }
-  else
-  {
-    // direct apply: recall single preset buffer
-    m_layer_mode = m_preloaded_layer_mode;
-    recallSingle();
-  }
+    m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Single;
+    m_preloaded_layer_mode = C15::Properties::LayerMode::Single;
+    m_preloaded_single_data = _msg;
+    if (LOG_RECALL) {
+        // log preset with primitive timestamp (for debugging fade events)
+        nltools::Log::info("Received Single Preset Message! (@", m_clock.m_index, ")");
+    }
+    if (m_glitch_suppression) {
+        // glitch suppression: start outputMute fade
+        m_fade.enable(FadeEvent::RecallMute, 0); // enable fader with event
+        m_output_mute.pick(0); // pickup fade-out
+    } else {
+        // direct apply: recall single preset buffer
+        m_layer_mode = m_preloaded_layer_mode;
+        recallSingle();
+    }
 }
 
-void dsp_host_dual::onPresetMessage(const nltools::msg::SplitPresetMessage &_msg)
+void dsp_host_dual::onPresetMessage(const nltools::msg::SplitPresetMessage& _msg)
 {
-  m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Split;
-  m_preloaded_layer_mode = C15::Properties::LayerMode::Split;
-  m_preloaded_split_data = _msg;
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("Received Split Preset Message!, (@", m_clock.m_index, ")");
-  }
-  if(m_glitch_suppression)
-  {
-    m_fade.enable(FadeEvent::RecallMute, 0);
-    m_output_mute.pick(0);
-  }
-  else
-  {
-    m_layer_mode = m_preloaded_layer_mode;
-    recallSplit();
-  }
+    m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Split;
+    m_preloaded_layer_mode = C15::Properties::LayerMode::Split;
+    m_preloaded_split_data = _msg;
+    if (LOG_RECALL) {
+        nltools::Log::info("Received Split Preset Message!, (@", m_clock.m_index, ")");
+    }
+    if (m_glitch_suppression) {
+        m_fade.enable(FadeEvent::RecallMute, 0);
+        m_output_mute.pick(0);
+    } else {
+        m_layer_mode = m_preloaded_layer_mode;
+        recallSplit();
+    }
 }
 
-void dsp_host_dual::onPresetMessage(const nltools::msg::LayerPresetMessage &_msg)
+void dsp_host_dual::onPresetMessage(const nltools::msg::LayerPresetMessage& _msg)
 {
-  m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Layer;
-  m_preloaded_layer_mode = C15::Properties::LayerMode::Layer;
-  m_preloaded_layer_data = _msg;
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("Received Layer Preset Message!, (@", m_clock.m_index, ")");
-  }
-  if(m_glitch_suppression)
-  {
-    m_fade.enable(FadeEvent::RecallMute, 0);
-    m_output_mute.pick(0);
-  }
-  else
-  {
-    m_layer_mode = m_preloaded_layer_mode;
-    recallLayer();
-  }
+    m_layer_changed = m_layer_mode != C15::Properties::LayerMode::Layer;
+    m_preloaded_layer_mode = C15::Properties::LayerMode::Layer;
+    m_preloaded_layer_data = _msg;
+    if (LOG_RECALL) {
+        nltools::Log::info("Received Layer Preset Message!, (@", m_clock.m_index, ")");
+    }
+    if (m_glitch_suppression) {
+        m_fade.enable(FadeEvent::RecallMute, 0);
+        m_output_mute.pick(0);
+    } else {
+        m_layer_mode = m_preloaded_layer_mode;
+        recallLayer();
+    }
 }
 
-void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::HWSourceChangedMessage &_msg)
+void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::HWSourceChangedMessage& _msg)
 {
-  auto param = m_params.get_hw_src(_id);
-  float inc = -param->m_position;
-  if(param->update_behavior(getBehavior(_msg.returnMode)))
-  {
-    param->update_position(static_cast<float>(_msg.controlPosition));
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("hw_edit(pos:", param->m_position, ", behavior:", static_cast<int>(param->m_behavior), ")");
+    auto param = m_params.get_hw_src(_id);
+    float inc = -param->m_position;
+    if (param->update_behavior(getBehavior(_msg.returnMode))) {
+        param->update_position(static_cast<float>(_msg.controlPosition));
+        if (LOG_EDITS) {
+            nltools::Log::info("hw_edit(pos:", param->m_position, ", behavior:", static_cast<int>(param->m_behavior), ")");
+        }
+    } else if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("hw_edit(pos:", param->m_position, ")");
+        }
+        inc += param->m_position;
+        hwModChain(param, _id, inc);
     }
-  }
-  else if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("hw_edit(pos:", param->m_position, ")");
-    }
-    inc += param->m_position;
-    hwModChain(param, _id, inc);
-  }
 }
 
-void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::HWAmountChangedMessage &_msg)
+void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::HWAmountChangedMessage& _msg)
 {
-  auto param = m_params.get_hw_amt(_id);
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("ha_edit(srcId:", param->m_sourceId, ", amtId:", _id, ", pos:", param->m_position, ")");
+    auto param = m_params.get_hw_amt(_id);
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("ha_edit(srcId:", param->m_sourceId, ", amtId:", _id, ", pos:", param->m_position, ")");
+        }
     }
-  }
 }
 
-void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::MacroControlChangedMessage &_msg)
+void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::MacroControlChangedMessage& _msg)
 {
-  auto param = m_params.get_macro(_id);
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("mc_edit(pos:", param->m_position, ")");
+    auto param = m_params.get_macro(_id);
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("mc_edit(pos:", param->m_position, ")");
+        }
+        globalModChain(param);
+        if (m_layer_mode == LayerMode::Single) {
+            localModChain(param);
+        } else {
+            for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+                localModChain(layerId, param);
+            }
+        }
     }
-    globalModChain(param);
-    if(m_layer_mode == LayerMode::Single)
-    {
-      localModChain(param);
-    }
-    else
-    {
-      for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-      {
-        localModChain(layerId, param);
-      }
-    }
-  }
 }
 
-void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage &_msg)
+void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage& _msg)
 {
-  const uint32_t macroId = getMacroId(_msg.sourceMacro);
-  auto param = m_params.get_global_target(_id);
-  bool aspect_update = param->update_source(getMacro(_msg.sourceMacro));
-  if(aspect_update)
-  {
-    m_params.m_global.m_assignment.reassign(_id, macroId);
-  }
-  aspect_update |= param->update_amount(static_cast<float>(_msg.mcAmount));
-  if(param->update_position(param->depolarize(static_cast<float>(_msg.controlPosition))))
-  {
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("global_target_edit(pos:", param->m_position, ", val:", param->m_scaled, ")");
-      if(aspect_update)
-      {
-        nltools::Log::info("global_target_edit(mc:", macroId, ", amt:", param->m_amount, ")");
-      }
+    const uint32_t macroId = getMacroId(_msg.sourceMacro);
+    auto param = m_params.get_global_target(_id);
+    bool aspect_update = param->update_source(getMacro(_msg.sourceMacro));
+    if (aspect_update) {
+        m_params.m_global.m_assignment.reassign(_id, macroId);
     }
-    globalTransition(param, m_edit_time.m_dx);
-  }
-  else if(aspect_update)
-  {
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("global_target_edit(mc:", macroId, ", amt:", param->m_amount, ")");
+    aspect_update |= param->update_amount(static_cast<float>(_msg.mcAmount));
+    if (param->update_position(param->depolarize(static_cast<float>(_msg.controlPosition)))) {
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+        if (LOG_EDITS) {
+            nltools::Log::info("global_target_edit(pos:", param->m_position, ", val:", param->m_scaled, ")");
+            if (aspect_update) {
+                nltools::Log::info("global_target_edit(mc:", macroId, ", amt:", param->m_amount, ")");
+            }
+        }
+        globalTransition(param, m_edit_time.m_dx);
+    } else if (aspect_update) {
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        if (LOG_EDITS) {
+            nltools::Log::info("global_target_edit(mc:", macroId, ", amt:", param->m_amount, ")");
+        }
     }
-  }
-  if(_id == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point))
-  {
-    m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
-  }
+    if (_id == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point)) {
+        m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
+    }
 }
 
-void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::globalParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  auto param = m_params.get_global_direct(_id);
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("global_direct_edit(pos:", param->m_position, ", val:", param->m_scaled, ")");
+    auto param = m_params.get_global_direct(_id);
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        if (LOG_EDITS) {
+            nltools::Log::info("global_direct_edit(pos:", param->m_position, ", val:", param->m_scaled, ")");
+        }
+        if (_id == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key)) {
+            m_global.start_base_key(m_edit_time.m_dx.m_dx_slow, param->m_scaled);
+        } else {
+            globalTransition(param, m_edit_time.m_dx);
+        }
     }
-    if(_id == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key))
-    {
-      m_global.start_base_key(m_edit_time.m_dx.m_dx_slow, param->m_scaled);
-    }
-    else
-    {
-      globalTransition(param, m_edit_time.m_dx);
-    }
-  }
 }
 
-void dsp_host_dual::globalTimeChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::globalTimeChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  auto param = m_params.get_macro_time(_id);
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("mc_edit(time:", param->m_position, ")");
+    auto param = m_params.get_macro_time(_id);
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("mc_edit(time:", param->m_position, ")");
+        }
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        updateTime(&param->m_dx, param->m_scaled);
     }
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    updateTime(&param->m_dx, param->m_scaled);
-  }
 }
 
-void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup), macroId = getMacroId(_msg.sourceMacro);
-  auto param = m_params.get_local_target(layerId, _id);
-  bool aspect_update = param->update_source(getMacro(_msg.sourceMacro));
-  if(aspect_update)
-  {
-    m_params.m_layer[layerId].m_assignment.reassign(_id, macroId);
-  }
-  aspect_update |= param->update_amount(static_cast<float>(_msg.mcAmount));
-  if(param->update_position(param->depolarize(static_cast<float>(_msg.controlPosition))))
-  {
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("local_target_edit(layer:", layerId, ", pos:", param->m_position, ", val:", param->m_scaled,
-                         ")");
-      if(aspect_update)
-      {
-        nltools::Log::info("local_target_edit(layer:", layerId, ", mc:", macroId, ", amt:", param->m_amount, ")");
-      }
+    const uint32_t layerId = getLayerId(_msg.voiceGroup), macroId = getMacroId(_msg.sourceMacro);
+    auto param = m_params.get_local_target(layerId, _id);
+    bool aspect_update = param->update_source(getMacro(_msg.sourceMacro));
+    if (aspect_update) {
+        m_params.m_layer[layerId].m_assignment.reassign(_id, macroId);
     }
-    if(m_layer_mode == LayerMode::Single)
-    {
-      for(uint32_t lId = 0; lId < m_params.m_layer_count; lId++)
-      {
-        localTransition(lId, param, m_edit_time.m_dx);
-      }
+    aspect_update |= param->update_amount(static_cast<float>(_msg.mcAmount));
+    if (param->update_position(param->depolarize(static_cast<float>(_msg.controlPosition)))) {
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+        if (LOG_EDITS) {
+            nltools::Log::info("local_target_edit(layer:", layerId, ", pos:", param->m_position, ", val:", param->m_scaled,
+                ")");
+            if (aspect_update) {
+                nltools::Log::info("local_target_edit(layer:", layerId, ", mc:", macroId, ", amt:", param->m_amount, ")");
+            }
+        }
+        if (m_layer_mode == LayerMode::Single) {
+            for (uint32_t lId = 0; lId < m_params.m_layer_count; lId++) {
+                localTransition(lId, param, m_edit_time.m_dx);
+            }
+        } else {
+            localTransition(layerId, param, m_edit_time.m_dx);
+        }
+    } else if (aspect_update) {
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        if (LOG_EDITS) {
+            nltools::Log::info("local_target_edit(layer:", layerId, ", mc:", macroId, ", amt:", param->m_amount, ")");
+        }
     }
-    else
-    {
-      localTransition(layerId, param, m_edit_time.m_dx);
-    }
-  }
-  else if(aspect_update)
-  {
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("local_target_edit(layer:", layerId, ", mc:", macroId, ", amt:", param->m_amount, ")");
-    }
-  }
-  switch(static_cast<C15::Parameters::Local_Modulateables>(_id))
-  {
+    switch (static_cast<C15::Parameters::Local_Modulateables>(_id)) {
     case C15::Parameters::Local_Modulateables::Mono_Grp_Glide:
-      // ...
-      break;
+        // ...
+        break;
     default:
-      break;
-  }
+        break;
+    }
 }
 
-void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup);
-  auto param = m_params.get_local_direct(layerId, _id);
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("local_direct_edit(layer:", layerId, ", pos:", param->m_position, ", val:", param->m_scaled,
-                         ")");
+    const uint32_t layerId = getLayerId(_msg.voiceGroup);
+    auto param = m_params.get_local_direct(layerId, _id);
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        if (LOG_EDITS) {
+            nltools::Log::info("local_direct_edit(layer:", layerId, ", pos:", param->m_position, ", val:", param->m_scaled,
+                ")");
+        }
+        if (m_layer_mode == LayerMode::Single) {
+            for (uint32_t lId = 0; lId < m_params.m_layer_count; lId++) {
+                localTransition(lId, param, m_edit_time.m_dx);
+            }
+        } else {
+            localTransition(layerId, param, m_edit_time.m_dx);
+        }
     }
-    if(m_layer_mode == LayerMode::Single)
-    {
-      for(uint32_t lId = 0; lId < m_params.m_layer_count; lId++)
-      {
-        localTransition(lId, param, m_edit_time.m_dx);
-      }
-    }
-    else
-    {
-      localTransition(layerId, param, m_edit_time.m_dx);
-    }
-  }
-  switch(static_cast<C15::Parameters::Local_Unmodulateables>(_id))
-  {
+    switch (static_cast<C15::Parameters::Local_Unmodulateables>(_id)) {
     case C15::Parameters::Local_Unmodulateables::Mono_Grp_Enable:
-      m_alloc.setMonoEnable(layerId, param->m_scaled);
-      break;
+        m_alloc.setMonoEnable(layerId, param->m_scaled);
+        break;
     case C15::Parameters::Local_Unmodulateables::Mono_Grp_Prio:
-      m_alloc.setMonoPriority(layerId, param->m_scaled);
-      break;
+        m_alloc.setMonoPriority(layerId, param->m_scaled);
+        break;
     case C15::Parameters::Local_Unmodulateables::Mono_Grp_Legato:
-      m_alloc.setMonoLegato(layerId, param->m_scaled);
-      break;
+        m_alloc.setMonoLegato(layerId, param->m_scaled);
+        break;
     // TODO: implement Key Fade evaluation of individual levels (by layerId)
     case C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_From:
-      evalVoiceFadeChg(layerId);
-      break;
+        evalVoiceFadeChg(layerId);
+        break;
     case C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_Range:
-      evalVoiceFadeChg(layerId);
-      break;
+        evalVoiceFadeChg(layerId);
+        break;
     default:
-      break;
-  }
+        break;
+    }
 }
 
-void dsp_host_dual::localUnisonVoicesChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localUnisonVoicesChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup);
-  auto param = m_params.get_local_unison_voices(getLayer(_msg.voiceGroup));
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("unison_voices_edit(layer:", layerId, ", pos:", param->m_position, ")");
+    const uint32_t layerId = getLayerId(_msg.voiceGroup);
+    auto param = m_params.get_local_unison_voices(getLayer(_msg.voiceGroup));
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("unison_voices_edit(layer:", layerId, ", pos:", param->m_position, ")");
+        }
+        // application now via fade point
+        m_fade.enable(FadeEvent::UnisonMute, 0);
+        m_output_mute.pick(0);
+        m_output_mute.m_preloaded_layerId = layerId;
+        m_output_mute.m_preloaded_position = param->m_position;
     }
-    // application now via fade point
-    m_fade.enable(FadeEvent::UnisonMute, 0);
-    m_output_mute.pick(0);
-    m_output_mute.m_preloaded_layerId = layerId;
-    m_output_mute.m_preloaded_position = param->m_position;
-  }
 }
 
-void dsp_host_dual::localMonoEnableChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localMonoEnableChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup);
-  auto param = m_params.get_local_mono_enable(getLayer(_msg.voiceGroup));
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("mono_enable_edit(layer:", layerId, ", pos:", param->m_position, ")");
+    const uint32_t layerId = getLayerId(_msg.voiceGroup);
+    auto param = m_params.get_local_mono_enable(getLayer(_msg.voiceGroup));
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("mono_enable_edit(layer:", layerId, ", pos:", param->m_position, ")");
+        }
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        // application now via fade point
+        m_fade.enable(FadeEvent::MonoMute, 0);
+        m_output_mute.pick(0);
+        m_output_mute.m_preloaded_layerId = layerId;
+        m_output_mute.m_preloaded_position = param->m_scaled;
     }
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    // application now via fade point
-    m_fade.enable(FadeEvent::MonoMute, 0);
-    m_output_mute.pick(0);
-    m_output_mute.m_preloaded_layerId = layerId;
-    m_output_mute.m_preloaded_position = param->m_scaled;
-  }
 }
-void dsp_host_dual::localMonoPriorityChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localMonoPriorityChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup);
-  auto param = m_params.get_local_mono_priority(getLayer(_msg.voiceGroup));
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("mono_priority_edit(layer:", layerId, ", pos:", param->m_position, ")");
+    const uint32_t layerId = getLayerId(_msg.voiceGroup);
+    auto param = m_params.get_local_mono_priority(getLayer(_msg.voiceGroup));
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("mono_priority_edit(layer:", layerId, ", pos:", param->m_position, ")");
+        }
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        m_alloc.setMonoPriority(layerId, param->m_scaled);
     }
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    m_alloc.setMonoPriority(layerId, param->m_scaled);
-  }
 }
-void dsp_host_dual::localMonoLegatoChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg)
+void dsp_host_dual::localMonoLegatoChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
 {
-  const uint32_t layerId = getLayerId(_msg.voiceGroup);
-  auto param = m_params.get_local_mono_legato(getLayer(_msg.voiceGroup));
-  if(param->update_position(static_cast<float>(_msg.controlPosition)))
-  {
-    if(LOG_EDITS)
-    {
-      nltools::Log::info("mono_leagto_edit(layer:", layerId, ", pos:", param->m_position, ")");
+    const uint32_t layerId = getLayerId(_msg.voiceGroup);
+    auto param = m_params.get_local_mono_legato(getLayer(_msg.voiceGroup));
+    if (param->update_position(static_cast<float>(_msg.controlPosition))) {
+        if (LOG_EDITS) {
+            nltools::Log::info("mono_leagto_edit(layer:", layerId, ", pos:", param->m_position, ")");
+        }
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        m_alloc.setMonoLegato(layerId, param->m_scaled);
     }
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    m_alloc.setMonoLegato(layerId, param->m_scaled);
-  }
 }
 
 void dsp_host_dual::onSettingEditTime(const float _position)
 {
-  // inconvenient clamping of odd position range ...
-  if(m_edit_time.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position))
-  {
-    if(LOG_SETTINGS)
-    {
-      nltools::Log::info("edit_time(pos:", m_edit_time.m_position, ", raw:", _position, ")");
+    // inconvenient clamping of odd position range ...
+    if (m_edit_time.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position)) {
+        if (LOG_SETTINGS) {
+            nltools::Log::info("edit_time(pos:", m_edit_time.m_position, ", raw:", _position, ")");
+        }
+        updateTime(&m_edit_time.m_dx, scale(m_edit_time.m_scaling, m_edit_time.m_position));
     }
-    updateTime(&m_edit_time.m_dx, scale(m_edit_time.m_scaling, m_edit_time.m_position));
-  }
 }
 
 void dsp_host_dual::onSettingTransitionTime(const float _position)
 {
-  // inconvenient clamping of odd position range ...
-  if(m_transition_time.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position))
-  {
-    if(LOG_SETTINGS)
-    {
-      nltools::Log::info("transition_time(pos:", m_transition_time.m_position, ", raw:", _position, ")");
+    // inconvenient clamping of odd position range ...
+    if (m_transition_time.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position)) {
+        if (LOG_SETTINGS) {
+            nltools::Log::info("transition_time(pos:", m_transition_time.m_position, ", raw:", _position, ")");
+        }
+        updateTime(&m_transition_time.m_dx, scale(m_transition_time.m_scaling, m_transition_time.m_position));
     }
-    updateTime(&m_transition_time.m_dx, scale(m_transition_time.m_scaling, m_transition_time.m_position));
-  }
 }
 
 void dsp_host_dual::onSettingNoteShift(const float _shift)
 {
-  m_poly[0].m_note_shift = m_poly[1].m_note_shift = _shift;
-  if(LOG_SETTINGS)
-  {
-    nltools::Log::info("note_shift:", _shift);
-  }
+    m_poly[0].m_note_shift = m_poly[1].m_note_shift = _shift;
+    if (LOG_SETTINGS) {
+        nltools::Log::info("note_shift:", _shift);
+    }
 }
 
 void dsp_host_dual::onSettingGlitchSuppr(const bool _enabled)
 {
-  m_glitch_suppression = _enabled;
-  if(LOG_SETTINGS)
-  {
-    nltools::Log::info("glitch_suppression:", _enabled);
-  }
+    m_glitch_suppression = _enabled;
+    if (LOG_SETTINGS) {
+        nltools::Log::info("glitch_suppression:", _enabled);
+    }
 }
 
 void dsp_host_dual::onSettingTuneReference(const float _position)
 {
-  // inconvenient clamping of odd position range ...
-  if(m_reference.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position))
-  {
-    m_reference.m_scaled = scale(m_reference.m_scaling, m_reference.m_position);
-    m_global.update_tone_frequency(m_reference.m_scaled);
-    if(LOG_SETTINGS)
-    {
-      nltools::Log::info("tune_reference:", _position);
+    // inconvenient clamping of odd position range ...
+    if (m_reference.update_position(_position < 0.0f ? 0.0f : _position > 1.0f ? 1.0f : _position)) {
+        m_reference.m_scaled = scale(m_reference.m_scaling, m_reference.m_position);
+        m_global.update_tone_frequency(m_reference.m_scaled);
+        if (LOG_SETTINGS) {
+            nltools::Log::info("tune_reference:", _position);
+        }
     }
-  }
 }
 
 void dsp_host_dual::onSettingInitialSinglePreset()
 {
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recallInitialSinglePreset(@", m_clock.m_index, ")");
-  }
-  m_layer_mode = LayerMode::Single;
-  auto unison = m_params.get_local_unison_voices(C15::Properties::LayerId::I);
-  unison->update_position(unison->m_initial);
-  if(LOG_RESET)
-  {
-    nltools::Log::info("recall single voice reset");
-  }
-  m_alloc.setUnison(0, unison->m_position);
-  m_params.m_global.m_assignment.reset();
-  const uint32_t uVoice = m_alloc.m_unison - 1;
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    m_poly[layerId].resetEnvelopes();
-    m_poly[layerId].m_uVoice = uVoice;
-    m_poly[layerId].m_key_active = 0;
-    m_params.m_layer[layerId].m_assignment.reset();
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw_sources:");
-  }
-  for(uint32_t i = 0; i < m_params.m_global.m_source_count; i++)
-  {
-    auto param = m_params.get_hw_src(i);
-    //param->update_behavior(C15::Properties::HW_Return_Behavior::Zero);
-    param->update_position(param->m_initial);
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw_amounts:");
-  }
-  for(uint32_t i = 0; i < m_params.m_global.m_amount_count; i++)
-  {
-    auto param = m_params.get_hw_amt(i);
-    param->update_position(param->m_initial);
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: macros:");
-  }
-  for(uint32_t i = 0; i < m_params.m_global.m_macro_count; i++)
-  {
-    auto param = m_params.get_macro(i);
-    param->update_position(param->m_initial);
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global unmodulateables:");
-  }
-  for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
-  {
-    auto param = m_params.get_global_direct(i);
-    param->update_position(param->m_initial);
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    globalTransition(param, m_transition_time.m_dx);
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global modulateables:");
-  }
-  for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
-  {
-    auto param = m_params.get_global_target(i);
-    param->update_source(C15::Parameters::Macro_Controls::None);
-    param->update_amount(0.0f);
-    param->update_position(param->m_initial);
-    param->update_modulation_aspects(0.0f);
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-    globalTransition(param, m_transition_time.m_dx);
-  }
-  // maybe, setting both voice groups resolves missing split sound?
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local unmodulateables:");
+    if (LOG_RECALL) {
+        nltools::Log::info("recallInitialSinglePreset(@", m_clock.m_index, ")");
     }
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
-    {
-      auto param = m_params.get_local_direct(layerId, i);
-      param->update_position(param->m_initial);
-      param->m_scaled = scale(param->m_scaling, param->m_position);
-      localTransition(layerId, param, m_transition_time.m_dx);
+    m_layer_mode = LayerMode::Single;
+    auto unison = m_params.get_local_unison_voices(C15::Properties::LayerId::I);
+    unison->update_position(unison->m_initial);
+    if (LOG_RESET) {
+        nltools::Log::info("recall single voice reset");
     }
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local modulateables:");
+    m_alloc.setUnison(0, unison->m_position);
+    m_params.m_global.m_assignment.reset();
+    const uint32_t uVoice = m_alloc.m_unison - 1;
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        m_poly[layerId].resetEnvelopes();
+        m_poly[layerId].m_uVoice = uVoice;
+        m_poly[layerId].m_key_active = 0;
+        m_params.m_layer[layerId].m_assignment.reset();
     }
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
-    {
-      auto param = m_params.get_local_target(layerId, i);
-      param->update_source(C15::Parameters::Macro_Controls::None);
-      param->update_amount(0.0f);
-      param->update_position(param->depolarize(param->m_initial));
-      param->update_modulation_aspects(m_params.get_macro(static_cast<uint32_t>(param->m_source))->m_position);
-      param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-      localTransition(layerId, param, m_transition_time.m_dx);
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw_sources:");
     }
-  }
+    for (uint32_t i = 0; i < m_params.m_global.m_source_count; i++) {
+        auto param = m_params.get_hw_src(i);
+        //param->update_behavior(C15::Properties::HW_Return_Behavior::Zero);
+        param->update_position(param->m_initial);
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw_amounts:");
+    }
+    for (uint32_t i = 0; i < m_params.m_global.m_amount_count; i++) {
+        auto param = m_params.get_hw_amt(i);
+        param->update_position(param->m_initial);
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: macros:");
+    }
+    for (uint32_t i = 0; i < m_params.m_global.m_macro_count; i++) {
+        auto param = m_params.get_macro(i);
+        param->update_position(param->m_initial);
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global unmodulateables:");
+    }
+    for (uint32_t i = 0; i < m_params.m_global.m_direct_count; i++) {
+        auto param = m_params.get_global_direct(i);
+        param->update_position(param->m_initial);
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        globalTransition(param, m_transition_time.m_dx);
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global modulateables:");
+    }
+    for (uint32_t i = 0; i < m_params.m_global.m_target_count; i++) {
+        auto param = m_params.get_global_target(i);
+        param->update_source(C15::Parameters::Macro_Controls::None);
+        param->update_amount(0.0f);
+        param->update_position(param->m_initial);
+        param->update_modulation_aspects(0.0f);
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+        globalTransition(param, m_transition_time.m_dx);
+    }
+    // maybe, setting both voice groups resolves missing split sound?
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local unmodulateables:");
+        }
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++) {
+            auto param = m_params.get_local_direct(layerId, i);
+            param->update_position(param->m_initial);
+            param->m_scaled = scale(param->m_scaling, param->m_position);
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local modulateables:");
+        }
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++) {
+            auto param = m_params.get_local_target(layerId, i);
+            param->update_source(C15::Parameters::Macro_Controls::None);
+            param->update_amount(0.0f);
+            param->update_position(param->depolarize(param->m_initial));
+            param->update_modulation_aspects(m_params.get_macro(static_cast<uint32_t>(param->m_source))->m_position);
+            param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+    }
 }
 
 uint32_t dsp_host_dual::onSettingToneToggle()
 {
-  m_tone_state = (m_tone_state + 1) % 3;
-  m_fade.enable(FadeEvent::ToneMute, 0);
-  m_output_mute.pick(0);
-  return m_tone_state;
+    m_tone_state = (m_tone_state + 1) % 3;
+    m_fade.enable(FadeEvent::ToneMute, 0);
+    m_output_mute.pick(0);
+    return m_tone_state;
 }
 
 void dsp_host_dual::render()
 {
-  // clock & fadepoint rendering
-  m_clock.render();
-  evalFadePoint();
-  // slow rendering
-  if(m_clock.m_slow)
-  {
-    // render components
-    m_global.render_slow();
-    m_poly[0].render_slow();
-    m_poly[1].render_slow();
-    m_mono[0].render_slow();
-    m_mono[1].render_slow();
-  }
-  // fast rendering
-  if(m_clock.m_fast)
-  {
-    // render components
-    m_global.render_fast();
-    m_poly[0].render_fast();
-    m_poly[1].render_fast();
-    m_mono[0].render_fast();
-    m_mono[1].render_fast();
-  }
-  // audio rendering (always) -- temporary soundgenerator patching
-  const float mute = m_output_mute.get_value();
-  // - audio dsp poly - first stage - both layers (up to Output Mixer)
-  m_poly[0].render_audio(mute);
-  m_poly[1].render_audio(mute);
-  // - audio dsp mono - each layer with separate sends - left, right)
+    // clock & fadepoint rendering
+    m_clock.render();
+    evalFadePoint();
+    // slow rendering
+    if (m_clock.m_slow) {
+        // render components
+        m_global.render_slow();
+        m_poly[0].render_slow();
+        m_poly[1].render_slow();
+        m_mono[0].render_slow();
+        m_mono[1].render_slow();
+    }
+    // fast rendering
+    if (m_clock.m_fast) {
+        // render components
+        m_global.render_fast();
+        m_poly[0].render_fast();
+        m_poly[1].render_fast();
+        m_mono[0].render_fast();
+        m_mono[1].render_fast();
+    }
+    // audio rendering (always) -- temporary soundgenerator patching
+    const float mute = m_output_mute.get_value();
+    // - audio dsp poly - first stage - both layers (up to Output Mixer)
+    m_poly[0].render_audio(mute);
+    m_poly[1].render_audio(mute);
+    // - audio dsp mono - each layer with separate sends - left, right)
 
-  m_mono[0].render_audio(m_poly[0].m_send_self_l + m_poly[1].m_send_other_l,
-                         m_poly[0].m_send_self_r + m_poly[1].m_send_other_r, m_poly[0].getVoiceGroupVolume());
-  m_mono[1].render_audio(m_poly[0].m_send_other_l + m_poly[1].m_send_self_l,
-                         m_poly[0].m_send_other_r + m_poly[1].m_send_self_r, m_poly[1].getVoiceGroupVolume());
-  // audio dsp poly - second stage - both layers (FB Mixer)
-  m_poly[0].render_feedback(m_z_layers[1]);  // pass other layer's signals as arg
-  m_poly[1].render_feedback(m_z_layers[0]);  // pass other layer's signals as arg
-  // - audio dsp global - main out: combine layers, apply test_tone and soft clip
-  m_global.render_audio(m_mono[0].m_out_l + m_mono[1].m_out_l, m_mono[0].m_out_r + m_mono[1].m_out_r);
-  // - final: main out, output mute
-  m_mainOut_L = m_global.m_out_l * mute;
-  m_mainOut_R = m_global.m_out_r * mute;
+    m_mono[0].render_audio(m_poly[0].m_send_self_l + m_poly[1].m_send_other_l,
+        m_poly[0].m_send_self_r + m_poly[1].m_send_other_r, m_poly[0].getVoiceGroupVolume());
+    m_mono[1].render_audio(m_poly[0].m_send_other_l + m_poly[1].m_send_self_l,
+        m_poly[0].m_send_other_r + m_poly[1].m_send_self_r, m_poly[1].getVoiceGroupVolume());
+    // audio dsp poly - second stage - both layers (FB Mixer)
+    m_poly[0].render_feedback(m_z_layers[1]); // pass other layer's signals as arg
+    m_poly[1].render_feedback(m_z_layers[0]); // pass other layer's signals as arg
+    // - audio dsp global - main out: combine layers, apply test_tone and soft clip
+    m_global.render_audio(m_mono[0].m_out_l + m_mono[1].m_out_l, m_mono[0].m_out_r + m_mono[1].m_out_r);
+    // - final: main out, output mute
+    m_mainOut_L = m_global.m_out_l * mute;
+    m_mainOut_R = m_global.m_out_r * mute;
 }
 
 void dsp_host_dual::reset()
 {
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    m_z_layers[layerId].reset();
-    m_poly[layerId].resetDSP();
-    m_mono[layerId].resetDSP();
-  }
-  m_global.resetDSP();
-  m_mainOut_L = m_mainOut_R = 0.0f;
-  if(LOG_RESET)
-  {
-    nltools::Log::info("DSP has been reset.");
-  }
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        m_z_layers[layerId].reset();
+        m_poly[layerId].resetDSP();
+        m_mono[layerId].resetDSP();
+    }
+    m_global.resetDSP();
+    m_mainOut_L = m_mainOut_R = 0.0f;
+    if (LOG_RESET) {
+        nltools::Log::info("DSP has been reset.");
+    }
 }
 
 C15::Properties::HW_Return_Behavior dsp_host_dual::getBehavior(const ReturnMode _mode)
 {
-  switch(_mode)
-  {
+    switch (_mode) {
     case ReturnMode::None:
-      return C15::Properties::HW_Return_Behavior::Stay;
+        return C15::Properties::HW_Return_Behavior::Stay;
     case ReturnMode::Zero:
-      return C15::Properties::HW_Return_Behavior::Zero;
+        return C15::Properties::HW_Return_Behavior::Zero;
     case ReturnMode::Center:
-      return C15::Properties::HW_Return_Behavior::Center;
+        return C15::Properties::HW_Return_Behavior::Center;
     default:
-      return C15::Properties::HW_Return_Behavior::Stay;
-  }
+        return C15::Properties::HW_Return_Behavior::Stay;
+    }
 }
 
 C15::Properties::HW_Return_Behavior dsp_host_dual::getBehavior(const RibbonReturnMode _mode)
 {
-  switch(_mode)
-  {
+    switch (_mode) {
     case RibbonReturnMode::STAY:
-      return C15::Properties::HW_Return_Behavior::Stay;
+        return C15::Properties::HW_Return_Behavior::Stay;
     case RibbonReturnMode::RETURN:
-      return C15::Properties::HW_Return_Behavior::Center;
+        return C15::Properties::HW_Return_Behavior::Center;
     default:
-      return C15::Properties::HW_Return_Behavior::Stay;
-  }
+        return C15::Properties::HW_Return_Behavior::Stay;
+    }
 }
 
 C15::Parameters::Macro_Controls dsp_host_dual::getMacro(const MacroControls _mc)
 {
-  switch(_mc)
-  {
+    switch (_mc) {
     case MacroControls::NONE:
-      return C15::Parameters::Macro_Controls::None;
+        return C15::Parameters::Macro_Controls::None;
     case MacroControls::MC1:
-      return C15::Parameters::Macro_Controls::MC_A;
+        return C15::Parameters::Macro_Controls::MC_A;
     case MacroControls::MC2:
-      return C15::Parameters::Macro_Controls::MC_B;
+        return C15::Parameters::Macro_Controls::MC_B;
     case MacroControls::MC3:
-      return C15::Parameters::Macro_Controls::MC_C;
+        return C15::Parameters::Macro_Controls::MC_C;
     case MacroControls::MC4:
-      return C15::Parameters::Macro_Controls::MC_D;
+        return C15::Parameters::Macro_Controls::MC_D;
     case MacroControls::MC5:
-      return C15::Parameters::Macro_Controls::MC_E;
+        return C15::Parameters::Macro_Controls::MC_E;
     case MacroControls::MC6:
-      return C15::Parameters::Macro_Controls::MC_F;
+        return C15::Parameters::Macro_Controls::MC_F;
     default:
-      return C15::Parameters::Macro_Controls::None;
-  }
-  // maybe, a simple static_cast would be sufficient ...
+        return C15::Parameters::Macro_Controls::None;
+    }
+    // maybe, a simple static_cast would be sufficient ...
 }
 
 uint32_t dsp_host_dual::getMacroId(const MacroControls _mc)
 {
-  return static_cast<uint32_t>(_mc);  // assuming idential MC enumeration
+    return static_cast<uint32_t>(_mc); // assuming idential MC enumeration
 }
 
 C15::Properties::LayerId dsp_host_dual::getLayer(const VoiceGroup _vg)
 {
-  switch(_vg)
-  {
+    switch (_vg) {
     case VoiceGroup::I:
-      return C15::Properties::LayerId::I;
+        return C15::Properties::LayerId::I;
     case VoiceGroup::II:
-      return C15::Properties::LayerId::II;
+        return C15::Properties::LayerId::II;
     default:
-      return C15::Properties::LayerId::I;
-  }
+        return C15::Properties::LayerId::I;
+    }
 }
 
 uint32_t dsp_host_dual::getLayerId(const VoiceGroup _vg)
 {
-  switch(_vg)
-  {
+    switch (_vg) {
     case VoiceGroup::I:
-      return 0;
+        return 0;
     case VoiceGroup::II:
-      return 1;
+        return 1;
     default:
-      return 0;
-  }
+        return 0;
+    }
 }
 
 void dsp_host_dual::keyDown(const float _vel)
 {
-  if(m_alloc.keyDown(m_key_pos, _vel))
-  {
-    if(LOG_KEYS)
-    {
-      nltools::Log::info("key_down(pos:", m_key_pos, ", vel:", _vel, ", unison:", m_alloc.m_unison, ")");
-    }
-    for(auto event = m_alloc.m_traversal.first(); m_alloc.m_traversal.running(); event = m_alloc.m_traversal.next())
-    {
-      if(m_poly[event->m_localIndex].keyDown(event))
-      {
-        // mono legato
-        m_mono[event->m_localIndex].keyDown(event);
-      }
-      if(LOG_KEYS_POLY)
-      {
-        nltools::Log::info("key_down_poly(group:", event->m_localIndex, "voice:", event->m_voiceId,
-                           ", unisonIndex:", event->m_unisonIndex, ", stolen:", event->m_stolen,
-                           ", tune:", event->m_tune, ", velocity:", event->m_velocity, ")");
-        nltools::Log::info("key_details(active:", event->m_active, ", trigger_env:", event->m_trigger_env,
-                           ", trigger_glide:", event->m_trigger_glide, ")");
-      }
-    }
-  }
-  else if(LOG_FAIL)
+    if (m_alloc.keyDown(m_key_pos, _vel)) {
+        if (LOG_KEYS) {
+            nltools::Log::info("key_down(pos:", m_key_pos, ", vel:", _vel, ", unison:", m_alloc.m_unison, ")");
+        }
+        for (auto event = m_alloc.m_traversal.first(); m_alloc.m_traversal.running(); event = m_alloc.m_traversal.next()) {
+            if (m_poly[event->m_localIndex].keyDown(event)) {
+                // mono legato
+                m_mono[event->m_localIndex].keyDown(event);
+            }
+            if (LOG_KEYS_POLY) {
+                nltools::Log::info("key_down_poly(group:", event->m_localIndex, "voice:", event->m_voiceId,
+                    ", unisonIndex:", event->m_unisonIndex, ", stolen:", event->m_stolen,
+                    ", tune:", event->m_tune, ", velocity:", event->m_velocity, ")");
+                nltools::Log::info("key_details(active:", event->m_active, ", trigger_env:", event->m_trigger_env,
+                    ", trigger_glide:", event->m_trigger_glide, ")");
+            }
+        }
+    } else if (LOG_FAIL)
 
-  {
-    nltools::Log::warning("keyDown(pos:", m_key_pos, ") failed!");
-  }
+    {
+        nltools::Log::warning("keyDown(pos:", m_key_pos, ") failed!");
+    }
 }
 
 void dsp_host_dual::keyUp(const float _vel)
 {
-  if(m_alloc.keyUp(m_key_pos, _vel))
-  {
-    if(LOG_KEYS)
-    {
-      nltools::Log::info("key_up(pos:", m_key_pos, ", vel:", _vel, ", unison:", m_alloc.m_unison, ")");
+    if (m_alloc.keyUp(m_key_pos, _vel)) {
+        if (LOG_KEYS) {
+            nltools::Log::info("key_up(pos:", m_key_pos, ", vel:", _vel, ", unison:", m_alloc.m_unison, ")");
+        }
+        for (auto event = m_alloc.m_traversal.first(); m_alloc.m_traversal.running(); event = m_alloc.m_traversal.next()) {
+            m_poly[event->m_localIndex].keyUp(event);
+            if (LOG_KEYS_POLY) {
+                nltools::Log::info("key_up_poly(group:", event->m_localIndex, "voice:", event->m_voiceId,
+                    ", tune:", event->m_tune, ", velocity:", event->m_velocity, ")");
+                nltools::Log::info("key_details(active:", event->m_active, ", trigger_env:", event->m_trigger_env,
+                    ", trigger_glide:", event->m_trigger_glide, ")");
+            }
+        }
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("keyUp(pos:", m_key_pos, ") failed!");
     }
-    for(auto event = m_alloc.m_traversal.first(); m_alloc.m_traversal.running(); event = m_alloc.m_traversal.next())
-    {
-      m_poly[event->m_localIndex].keyUp(event);
-      if(LOG_KEYS_POLY)
-      {
-        nltools::Log::info("key_up_poly(group:", event->m_localIndex, "voice:", event->m_voiceId,
-                           ", tune:", event->m_tune, ", velocity:", event->m_velocity, ")");
-        nltools::Log::info("key_details(active:", event->m_active, ", trigger_env:", event->m_trigger_env,
-                           ", trigger_glide:", event->m_trigger_glide, ")");
-      }
-    }
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("keyUp(pos:", m_key_pos, ") failed!");
-  }
 }
 
 float dsp_host_dual::scale(const Scale_Aspect _scl, float _value)
 {
-  float result = 0.0f;
-  switch(_scl.m_id)
-  {
+    float result = 0.0f;
+    switch (_scl.m_id) {
     case C15::Properties::SmootherScale::None:
-      break;
+        break;
     case C15::Properties::SmootherScale::Linear:
-      result = _scl.m_offset + (_scl.m_factor * _value);
-      break;
+        result = _scl.m_offset + (_scl.m_factor * _value);
+        break;
     case C15::Properties::SmootherScale::Parabolic:
-      result = _scl.m_offset + (_scl.m_factor * _value * std::abs(_value));
-      break;
+        result = _scl.m_offset + (_scl.m_factor * _value * std::abs(_value));
+        break;
     case C15::Properties::SmootherScale::Cubic:
-      result = _scl.m_offset + (_scl.m_factor * _value * _value * _value);
-      break;
+        result = _scl.m_offset + (_scl.m_factor * _value * _value * _value);
+        break;
     case C15::Properties::SmootherScale::S_Curve:
-      _value = (2.0f * (1.0f - _value)) - 1.0f;
-      result = _scl.m_offset + (_scl.m_factor * ((_value * _value * _value * -0.25f) + (_value * 0.75f) + 0.5f));
-      break;
+        _value = (2.0f * (1.0f - _value)) - 1.0f;
+        result = _scl.m_offset + (_scl.m_factor * ((_value * _value * _value * -0.25f) + (_value * 0.75f) + 0.5f));
+        break;
     case C15::Properties::SmootherScale::Expon_Gain:
-      result = m_convert.eval_level(_scl.m_offset + (_scl.m_factor * _value));
-      break;
+        result = m_convert.eval_level(_scl.m_offset + (_scl.m_factor * _value));
+        break;
     case C15::Properties::SmootherScale::Expon_Osc_Pitch:
-      result = m_convert.eval_osc_pitch(_scl.m_offset + (_scl.m_factor * _value));
-      break;
+        result = m_convert.eval_osc_pitch(_scl.m_offset + (_scl.m_factor * _value));
+        break;
     case C15::Properties::SmootherScale::Expon_Lin_Pitch:
-      result = m_convert.eval_lin_pitch(_scl.m_offset + (_scl.m_factor * _value));
-      break;
+        result = m_convert.eval_lin_pitch(_scl.m_offset + (_scl.m_factor * _value));
+        break;
     case C15::Properties::SmootherScale::Expon_Shaper_Drive:
-      result = (m_convert.eval_level(_value * _scl.m_factor) * _scl.m_offset) - _scl.m_offset;
-      break;
+        result = (m_convert.eval_level(_value * _scl.m_factor) * _scl.m_offset) - _scl.m_offset;
+        break;
     case C15::Properties::SmootherScale::Expon_Mix_Drive:
-      result = _scl.m_offset * m_convert.eval_level(_scl.m_factor * _value);
-      break;
+        result = _scl.m_offset * m_convert.eval_level(_scl.m_factor * _value);
+        break;
     case C15::Properties::SmootherScale::Expon_Env_Time:
-      result = m_convert.eval_time((_value * _scl.m_factor * 104.0781f) + _scl.m_offset);
-      break;
-  }
-  return result;
+        result = m_convert.eval_time((_value * _scl.m_factor * 104.0781f) + _scl.m_offset);
+        break;
+    }
+    return result;
 }
 
 void dsp_host_dual::updateHW(const uint32_t _id, const float _raw)
 {
-  auto source = m_params.get_hw_src(_id);
-  float value = _raw * m_norm_hw;
-  if(source->m_behavior == C15::Properties::HW_Return_Behavior::Center)
-  {
-    value = (2.0f * value) - 1.0f;  // make return_to_center sources bipolar
-  }
-  const float inc = value - source->m_position;
-  source->m_position = value;
-  hwModChain(source, _id, inc);
-}
-
-void dsp_host_dual::updateTime(Time_Aspect *_param, const float _ms)
-{
-  m_time.update_ms(_ms);
-  _param->m_dx_audio = m_time.m_dx_audio;
-  _param->m_dx_fast = m_time.m_dx_fast;
-  _param->m_dx_slow = m_time.m_dx_slow;
-  if(LOG_TIMES)
-  {
-    nltools::Log::info("time_update(ms:", _ms, ", dx:", m_time.m_dx_audio, m_time.m_dx_fast, m_time.m_dx_slow, ")");
-  }
-}
-
-void dsp_host_dual::hwModChain(HW_Src_Param *_src, const uint32_t _id, const float _inc)
-{
-  if(LOG_HW)
-  {
-    nltools::Log::info("hw_move(id:", _id, ", pos:", _src->m_position, ")");
-  }
-  if(_src->m_behavior == C15::Properties::HW_Return_Behavior::Stay)
-  {
-    for(uint32_t macroId = 1; macroId < m_params.m_global.m_macro_count; macroId++)
-    {
-      const uint32_t amountIndex = _src->m_offset + macroId - 1;
-      auto amount = m_params.get_hw_amt(amountIndex);
-      if(amount->m_position != 0.0f)
-      {
-        auto macro = m_params.get_macro(macroId);
-        macro->m_position = _src->m_position;
-        if(m_layer_mode == LayerMode::Single)
-        {
-          if(LOG_HW)
-          {
-            nltools::Log::info("hw_nonreturn_to_mc(mode: single, srcId:", _id, ", mcId:", macroId,
-                               ", amtId:", amountIndex, ", amount:", amount->m_position, ", value:", macro->m_position,
-                               ")");
-          }
-          localModChain(macro);
-        }
-        else
-        {
-          if(LOG_HW)
-          {
-            nltools::Log::info("hw_nonreturn_to_mc(mode: dual, srcId:", _id, ", mcId:", macroId,
-                               ", amtId:", amountIndex, ", amount:", amount->m_position, ", value:", macro->m_position,
-                               ")");
-          }
-          for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-          {
-            localModChain(layerId, macro);
-          }
-        }
-        globalModChain(macro);
-      }
+    auto source = m_params.get_hw_src(_id);
+    float value = _raw * m_norm_hw;
+    if (source->m_behavior == C15::Properties::HW_Return_Behavior::Center) {
+        value = (2.0f * value) - 1.0f; // make return_to_center sources bipolar
     }
-  }
-  else
-  {
-    for(uint32_t macroId = 1; macroId < m_params.m_global.m_macro_count; macroId++)
-    {
-      const uint32_t amountIndex = _src->m_offset + macroId - 1;
-      auto amount = m_params.get_hw_amt(amountIndex);
-      if(amount->m_position != 0.0f)
-      {
-        auto amount = m_params.get_hw_amt(amountIndex);
-        if(amount->m_position != 0.0f)
-        {
-          auto macro = m_params.get_macro(macroId);
-          macro->m_unclipped = macro->m_position + (_inc * amount->m_position);
-          const float clipped
-              = macro->m_unclipped < 0.0f ? 0.0f : macro->m_unclipped > 1.0f ? 1.0f : macro->m_unclipped;
-          if(macro->m_position != clipped)
-          {
-            macro->m_position = clipped;
-            if(m_layer_mode == LayerMode::Single)
-            {
-              if(LOG_HW)
-              {
-                nltools::Log::info("hw_return_to_mc(mode: single, srcId:", _id, ", mcId:", macroId,
-                                   ", amtId:", amountIndex, ", amount:", amount->m_position,
-                                   ", value:", macro->m_position, ")");
-              }
-              localModChain(macro);
+    const float inc = value - source->m_position;
+    source->m_position = value;
+    hwModChain(source, _id, inc);
+}
+
+void dsp_host_dual::updateTime(Time_Aspect* _param, const float _ms)
+{
+    m_time.update_ms(_ms);
+    _param->m_dx_audio = m_time.m_dx_audio;
+    _param->m_dx_fast = m_time.m_dx_fast;
+    _param->m_dx_slow = m_time.m_dx_slow;
+    if (LOG_TIMES) {
+        nltools::Log::info("time_update(ms:", _ms, ", dx:", m_time.m_dx_audio, m_time.m_dx_fast, m_time.m_dx_slow, ")");
+    }
+}
+
+void dsp_host_dual::hwModChain(HW_Src_Param* _src, const uint32_t _id, const float _inc)
+{
+    if (LOG_HW) {
+        nltools::Log::info("hw_move(id:", _id, ", pos:", _src->m_position, ")");
+    }
+    if (_src->m_behavior == C15::Properties::HW_Return_Behavior::Stay) {
+        for (uint32_t macroId = 1; macroId < m_params.m_global.m_macro_count; macroId++) {
+            const uint32_t amountIndex = _src->m_offset + macroId - 1;
+            auto amount = m_params.get_hw_amt(amountIndex);
+            if (amount->m_position != 0.0f) {
+                auto macro = m_params.get_macro(macroId);
+                macro->m_position = _src->m_position;
+                if (m_layer_mode == LayerMode::Single) {
+                    if (LOG_HW) {
+                        nltools::Log::info("hw_nonreturn_to_mc(mode: single, srcId:", _id, ", mcId:", macroId,
+                            ", amtId:", amountIndex, ", amount:", amount->m_position, ", value:", macro->m_position,
+                            ")");
+                    }
+                    localModChain(macro);
+                } else {
+                    if (LOG_HW) {
+                        nltools::Log::info("hw_nonreturn_to_mc(mode: dual, srcId:", _id, ", mcId:", macroId,
+                            ", amtId:", amountIndex, ", amount:", amount->m_position, ", value:", macro->m_position,
+                            ")");
+                    }
+                    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+                        localModChain(layerId, macro);
+                    }
+                }
+                globalModChain(macro);
             }
-            else
-            {
-              if(LOG_HW)
-              {
-                nltools::Log::info("hw_return_to_mc(mode: dual, srcId:", _id, ", mcId:", macroId,
-                                   ", amtId:", amountIndex, ", amount:", amount->m_position,
-                                   ", value:", macro->m_position, ")");
-              }
-              for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-              {
-                localModChain(layerId, macro);
-              }
+        }
+    } else {
+        for (uint32_t macroId = 1; macroId < m_params.m_global.m_macro_count; macroId++) {
+            const uint32_t amountIndex = _src->m_offset + macroId - 1;
+            auto amount = m_params.get_hw_amt(amountIndex);
+            if (amount->m_position != 0.0f) {
+                auto amount = m_params.get_hw_amt(amountIndex);
+                if (amount->m_position != 0.0f) {
+                    auto macro = m_params.get_macro(macroId);
+                    macro->m_unclipped = macro->m_position + (_inc * amount->m_position);
+                    const float clipped
+                        = macro->m_unclipped < 0.0f ? 0.0f : macro->m_unclipped > 1.0f ? 1.0f : macro->m_unclipped;
+                    if (macro->m_position != clipped) {
+                        macro->m_position = clipped;
+                        if (m_layer_mode == LayerMode::Single) {
+                            if (LOG_HW) {
+                                nltools::Log::info("hw_return_to_mc(mode: single, srcId:", _id, ", mcId:", macroId,
+                                    ", amtId:", amountIndex, ", amount:", amount->m_position,
+                                    ", value:", macro->m_position, ")");
+                            }
+                            localModChain(macro);
+                        } else {
+                            if (LOG_HW) {
+                                nltools::Log::info("hw_return_to_mc(mode: dual, srcId:", _id, ", mcId:", macroId,
+                                    ", amtId:", amountIndex, ", amount:", amount->m_position,
+                                    ", value:", macro->m_position, ")");
+                            }
+                            for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+                                localModChain(layerId, macro);
+                            }
+                        }
+                        globalModChain(macro);
+                    }
+                }
             }
-            globalModChain(macro);
-          }
         }
-      }
     }
-  }
 }
 
-void dsp_host_dual::globalModChain(Macro_Param *_mc)
+void dsp_host_dual::globalModChain(Macro_Param* _mc)
 {
-  for(auto param = m_params.globalChainFirst(_mc->m_id); m_params.globalChainRunning();
-      param = m_params.globalChainNext())
-  {
-    if(param->modulate(_mc->m_position))
-    {
-      const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
-      if(param->m_position != clipped)
-      {
-        param->m_position = clipped;
-        param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
-        globalTransition(param, _mc->m_time.m_dx);
-        if(param->m_splitpoint)
-        {
-          m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
+    for (auto param = m_params.globalChainFirst(_mc->m_id); m_params.globalChainRunning();
+         param = m_params.globalChainNext()) {
+        if (param->modulate(_mc->m_position)) {
+            const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
+            if (param->m_position != clipped) {
+                param->m_position = clipped;
+                param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
+                globalTransition(param, _mc->m_time.m_dx);
+                if (param->m_splitpoint) {
+                    m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
+                }
+            }
         }
-      }
     }
-  }
 }
 
-void dsp_host_dual::localModChain(Macro_Param *_mc)
+void dsp_host_dual::localModChain(Macro_Param* _mc)
 {
-  for(auto param = m_params.localChainFirst(0, _mc->m_id); m_params.localChainRunning(0);
-      param = m_params.localChainNext(0))
-  {
-    if(param->modulate(_mc->m_position))
-    {
-      const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
-      if(param->m_position != clipped)
-      {
-        param->m_position = clipped;
-        param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
-        localTransition(0, param, _mc->m_time.m_dx);
-        localTransition(1, param, _mc->m_time.m_dx);
-      }
+    for (auto param = m_params.localChainFirst(0, _mc->m_id); m_params.localChainRunning(0);
+         param = m_params.localChainNext(0)) {
+        if (param->modulate(_mc->m_position)) {
+            const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
+            if (param->m_position != clipped) {
+                param->m_position = clipped;
+                param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
+                localTransition(0, param, _mc->m_time.m_dx);
+                localTransition(1, param, _mc->m_time.m_dx);
+            }
+        }
     }
-  }
 }
 
-void dsp_host_dual::localModChain(const uint32_t _layer, Macro_Param *_mc)
+void dsp_host_dual::localModChain(const uint32_t _layer, Macro_Param* _mc)
 {
-  for(auto param = m_params.localChainFirst(_layer, _mc->m_id); m_params.localChainRunning(_layer);
-      param = m_params.localChainNext(_layer))
-  {
-    if(param->modulate(_mc->m_position))
-    {
-      const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
-      if(param->m_position != clipped)
-      {
-        param->m_position = clipped;
-        param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
-        localTransition(_layer, param, _mc->m_time.m_dx);
-      }
+    for (auto param = m_params.localChainFirst(_layer, _mc->m_id); m_params.localChainRunning(_layer);
+         param = m_params.localChainNext(_layer)) {
+        if (param->modulate(_mc->m_position)) {
+            const float clipped = param->m_unclipped < 0.0f ? 0.0f : param->m_unclipped > 1.0f ? 1.0f : param->m_unclipped;
+            if (param->m_position != clipped) {
+                param->m_position = clipped;
+                param->m_scaled = scale(param->m_scaling, param->polarize(clipped));
+                localTransition(_layer, param, _mc->m_time.m_dx);
+            }
+        }
     }
-  }
 }
 
-void dsp_host_dual::globalTransition(const Target_Param *_param, const Time_Aspect _time)
+void dsp_host_dual::globalTransition(const Target_Param* _param, const Time_Aspect _time)
 {
-  float dx = 0.0f, dest = _param->m_scaled;
-  bool valid = true;
-  switch(_param->m_render.m_section)
-  {
+    float dx = 0.0f, dest = _param->m_scaled;
+    bool valid = true;
+    switch (_param->m_render.m_section) {
     case C15::Descriptors::SmootherSection::Global:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_global.start_sync(_param->m_render.m_index, dest);
-          break;
+            m_global.start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_global.start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_global.start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_global.start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_global.start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_global.start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_global.start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     default:
-      valid = false;
-      break;
-  }
-  if(LOG_TRANSITIONS)
-  {
-    if(valid)
-    {
-      nltools::Log::info("global_transition(index:", _param->m_render.m_index, ", dx:", dx, ", dest:", dest, ")");
+        valid = false;
+        break;
     }
-    else if(LOG_FAIL)
-    {
-      nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+    if (LOG_TRANSITIONS) {
+        if (valid) {
+            nltools::Log::info("global_transition(index:", _param->m_render.m_index, ", dx:", dx, ", dest:", dest, ")");
+        } else if (LOG_FAIL) {
+            nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+        }
     }
-  }
 }
 
-void dsp_host_dual::globalTransition(const Direct_Param *_param, const Time_Aspect _time)
+void dsp_host_dual::globalTransition(const Direct_Param* _param, const Time_Aspect _time)
 {
-  float dx = 0.0f, dest = _param->m_scaled;
-  bool valid = true;
-  switch(_param->m_render.m_section)
-  {
+    float dx = 0.0f, dest = _param->m_scaled;
+    bool valid = true;
+    switch (_param->m_render.m_section) {
     case C15::Descriptors::SmootherSection::Global:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_global.start_sync(_param->m_render.m_index, dest);
-          break;
+            m_global.start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_global.start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_global.start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_global.start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_global.start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_global.start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_global.start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     default:
-      valid = false;
-      break;
-  }
-  if(LOG_TRANSITIONS)
-  {
-    if(valid)
-    {
-      nltools::Log::info("global_transition(index:", _param->m_render.m_index, ", dx:", dx, ", dest:", dest, ")");
+        valid = false;
+        break;
     }
-    else if(LOG_FAIL)
-    {
-      nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+    if (LOG_TRANSITIONS) {
+        if (valid) {
+            nltools::Log::info("global_transition(index:", _param->m_render.m_index, ", dx:", dx, ", dest:", dest, ")");
+        } else if (LOG_FAIL) {
+            nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+        }
     }
-  }
 }
 
-void dsp_host_dual::localTransition(const uint32_t _layer, const Direct_Param *_param, const Time_Aspect _time)
+void dsp_host_dual::localTransition(const uint32_t _layer, const Direct_Param* _param, const Time_Aspect _time)
 {
-  float dx = 0.0f, dest = _param->m_scaled;
-  bool valid = true;
-  switch(_param->m_render.m_section)
-  {
+    float dx = 0.0f, dest = _param->m_scaled;
+    bool valid = true;
+    switch (_param->m_render.m_section) {
     case C15::Descriptors::SmootherSection::Poly:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_poly[_layer].start_sync(_param->m_render.m_index, dest);
-          break;
+            m_poly[_layer].start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_poly[_layer].start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_poly[_layer].start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_poly[_layer].start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_poly[_layer].start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_poly[_layer].start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_poly[_layer].start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     case C15::Descriptors::SmootherSection::Mono:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_mono[_layer].start_sync(_param->m_render.m_index, dest);
-          break;
+            m_mono[_layer].start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_mono[_layer].start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_mono[_layer].start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_mono[_layer].start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_mono[_layer].start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_mono[_layer].start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_mono[_layer].start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     default:
-      valid = false;
-      break;
-  }
-  if(LOG_TRANSITIONS)
-  {
-    if(valid)
-    {
-      nltools::Log::info("local_transition(layer:", _layer, "index:", _param->m_render.m_index, ", dx:", dx,
-                         ", dest:", dest, ")");
+        valid = false;
+        break;
     }
-    else if(LOG_FAIL)
-    {
-      nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+    if (LOG_TRANSITIONS) {
+        if (valid) {
+            nltools::Log::info("local_transition(layer:", _layer, "index:", _param->m_render.m_index, ", dx:", dx,
+                ", dest:", dest, ")");
+        } else if (LOG_FAIL) {
+            nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+        }
     }
-  }
 }
-void dsp_host_dual::localTransition(const uint32_t _layer, const Target_Param *_param, const Time_Aspect _time)
+void dsp_host_dual::localTransition(const uint32_t _layer, const Target_Param* _param, const Time_Aspect _time)
 {
-  float dx = 0.0f, dest = _param->m_scaled;
-  bool valid = true;
-  switch(_param->m_render.m_section)
-  {
+    float dx = 0.0f, dest = _param->m_scaled;
+    bool valid = true;
+    switch (_param->m_render.m_section) {
     case C15::Descriptors::SmootherSection::Poly:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_poly[_layer].start_sync(_param->m_render.m_index, dest);
-          break;
+            m_poly[_layer].start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_poly[_layer].start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_poly[_layer].start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_poly[_layer].start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_poly[_layer].start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_poly[_layer].start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_poly[_layer].start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     case C15::Descriptors::SmootherSection::Mono:
-      switch(_param->m_render.m_clock)
-      {
+        switch (_param->m_render.m_clock) {
         case C15::Descriptors::SmootherClock::Sync:
-          m_mono[_layer].start_sync(_param->m_render.m_index, dest);
-          break;
+            m_mono[_layer].start_sync(_param->m_render.m_index, dest);
+            break;
         case C15::Descriptors::SmootherClock::Audio:
-          dx = _time.m_dx_audio;
-          m_mono[_layer].start_audio(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_audio;
+            m_mono[_layer].start_audio(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Fast:
-          dx = _time.m_dx_fast;
-          m_mono[_layer].start_fast(_param->m_render.m_index, dx, dest);
-          break;
+            dx = _time.m_dx_fast;
+            m_mono[_layer].start_fast(_param->m_render.m_index, dx, dest);
+            break;
         case C15::Descriptors::SmootherClock::Slow:
-          dx = _time.m_dx_slow;
-          m_mono[_layer].start_slow(_param->m_render.m_index, dx, dest);
-          break;
-      }
-      break;
+            dx = _time.m_dx_slow;
+            m_mono[_layer].start_slow(_param->m_render.m_index, dx, dest);
+            break;
+        }
+        break;
     default:
-      valid = false;
-      break;
-  }
-  if(LOG_TRANSITIONS)
-  {
-    if(valid)
-    {
-      nltools::Log::info("local_transition(layer:", _layer, "index:", _param->m_render.m_index, ", dx:", dx,
-                         ", dest:", dest, ")");
+        valid = false;
+        break;
     }
-    else if(LOG_FAIL)
-    {
-      nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+    if (LOG_TRANSITIONS) {
+        if (valid) {
+            nltools::Log::info("local_transition(layer:", _layer, "index:", _param->m_render.m_index, ", dx:", dx,
+                ", dest:", dest, ")");
+        } else if (LOG_FAIL) {
+            nltools::Log::warning("failed to start global_transition(index:", _param->m_render.m_index, ")");
+        }
     }
-  }
 }
 
 void dsp_host_dual::evalFadePoint()
 {
-  m_fade.render();
-  // act when fade process was completed
-  if(m_fade.get_state())
-  {
-    switch(m_fade.m_event)
-    {
-      case FadeEvent::RecallMute:
-        m_layer_mode = m_preloaded_layer_mode;
-        // flush - currently global ... (?)
-        m_poly[0].flushDSP();
-        m_poly[1].flushDSP();
-        m_mono[0].flushDSP();
-        m_mono[1].flushDSP();
-        //load preset
-        switch(m_layer_mode)
-        {
-          case C15::Properties::LayerMode::Single:
-            recallSingle();
+    m_fade.render();
+    // act when fade process was completed
+    if (m_fade.get_state()) {
+        switch (m_fade.m_event) {
+        case FadeEvent::RecallMute:
+            m_layer_mode = m_preloaded_layer_mode;
+            // flush - currently global ... (?)
+            m_poly[0].flushDSP();
+            m_poly[1].flushDSP();
+            m_mono[0].flushDSP();
+            m_mono[1].flushDSP();
+            //load preset
+            switch (m_layer_mode) {
+            case C15::Properties::LayerMode::Single:
+                recallSingle();
+                break;
+            case C15::Properties::LayerMode::Split:
+                recallSplit();
+                break;
+            case C15::Properties::LayerMode::Layer:
+                recallLayer();
+                break;
+            }
+            m_fade.stop();
+            m_output_mute.pick(2);
+            m_fade.enable(FadeEvent::Unmute, 1);
             break;
-          case C15::Properties::LayerMode::Split:
-            recallSplit();
+        case FadeEvent::ToneMute:
+            m_global.update_tone_mode(m_tone_state);
+            m_fade.stop();
+            m_output_mute.pick(2);
+            m_fade.enable(FadeEvent::Unmute, 1);
             break;
-          case C15::Properties::LayerMode::Layer:
-            recallLayer();
+        case FadeEvent::UnisonMute:
+            // apply preloaded unison change
+            m_alloc.setUnison(m_output_mute.m_preloaded_layerId, m_output_mute.m_preloaded_position);
+            if (m_layer_mode == LayerMode::Split) {
+                m_poly[m_output_mute.m_preloaded_layerId].resetEnvelopes();
+                m_poly[m_output_mute.m_preloaded_layerId].m_uVoice = m_alloc.m_unison - 1;
+                m_poly[m_output_mute.m_preloaded_layerId].m_key_active = 0;
+            } else {
+                for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+                    m_poly[layerId].resetEnvelopes();
+                    m_poly[layerId].m_uVoice = m_alloc.m_unison - 1;
+                    m_poly[layerId].m_key_active = 0;
+                }
+            }
+            m_fade.stop();
+            m_output_mute.pick(2);
+            m_fade.enable(FadeEvent::Unmute, 1);
+            break;
+        case FadeEvent::MonoMute:
+            // apply preloaded mono change
+            m_alloc.setMonoEnable(m_output_mute.m_preloaded_layerId, m_output_mute.m_preloaded_position);
+            if (m_layer_mode == LayerMode::Split) {
+                m_poly[m_output_mute.m_preloaded_layerId].resetEnvelopes();
+                m_poly[m_output_mute.m_preloaded_layerId].m_key_active = 0;
+            } else {
+                for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+                    m_poly[layerId].resetEnvelopes();
+                    m_poly[layerId].m_key_active = 0;
+                }
+            }
+            m_fade.stop();
+            m_output_mute.pick(2);
+            m_fade.enable(FadeEvent::Unmute, 1);
+            break;
+        case FadeEvent::Unmute:
+            m_fade.stop();
+            m_output_mute.stop();
             break;
         }
-        m_fade.stop();
-        m_output_mute.pick(2);
-        m_fade.enable(FadeEvent::Unmute, 1);
-        break;
-      case FadeEvent::ToneMute:
-        m_global.update_tone_mode(m_tone_state);
-        m_fade.stop();
-        m_output_mute.pick(2);
-        m_fade.enable(FadeEvent::Unmute, 1);
-        break;
-      case FadeEvent::UnisonMute:
-        // apply preloaded unison change
-        m_alloc.setUnison(m_output_mute.m_preloaded_layerId, m_output_mute.m_preloaded_position);
-        if(m_layer_mode == LayerMode::Split)
-        {
-          m_poly[m_output_mute.m_preloaded_layerId].resetEnvelopes();
-          m_poly[m_output_mute.m_preloaded_layerId].m_uVoice = m_alloc.m_unison - 1;
-          m_poly[m_output_mute.m_preloaded_layerId].m_key_active = 0;
-        }
-        else
-        {
-          for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-          {
-            m_poly[layerId].resetEnvelopes();
-            m_poly[layerId].m_uVoice = m_alloc.m_unison - 1;
-            m_poly[layerId].m_key_active = 0;
-          }
-        }
-        m_fade.stop();
-        m_output_mute.pick(2);
-        m_fade.enable(FadeEvent::Unmute, 1);
-        break;
-      case FadeEvent::MonoMute:
-        // apply preloaded mono change
-        m_alloc.setMonoEnable(m_output_mute.m_preloaded_layerId, m_output_mute.m_preloaded_position);
-        if(m_layer_mode == LayerMode::Split)
-        {
-          m_poly[m_output_mute.m_preloaded_layerId].resetEnvelopes();
-          m_poly[m_output_mute.m_preloaded_layerId].m_key_active = 0;
-        }
-        else
-        {
-          for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-          {
-            m_poly[layerId].resetEnvelopes();
-            m_poly[layerId].m_key_active = 0;
-          }
-        }
-        m_fade.stop();
-        m_output_mute.pick(2);
-        m_fade.enable(FadeEvent::Unmute, 1);
-        break;
-      case FadeEvent::Unmute:
-        m_fade.stop();
-        m_output_mute.stop();
-        break;
     }
-  }
 }
 
 void dsp_host_dual::evalPolyChg(const C15::Properties::LayerId _layerId,
-                                const nltools::msg::ParameterGroups::UnmodulateableParameter &_unisonVoices,
-                                const nltools::msg::ParameterGroups::UnmodulateableParameter &_monoEnable)
+    const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,
+    const nltools::msg::ParameterGroups::UnmodulateableParameter& _monoEnable)
 {
-  const uint32_t layerId = static_cast<uint32_t>(_layerId);
-  auto unison_voices = m_params.get_local_unison_voices(_layerId);
-  m_layer_changed |= unison_voices->update_position(static_cast<float>(_unisonVoices.controlPosition));
-  auto mono_enable = m_params.get_local_mono_enable(_layerId);
-  m_layer_changed |= mono_enable->update_position(static_cast<float>(_monoEnable.controlPosition));
+    const uint32_t layerId = static_cast<uint32_t>(_layerId);
+    auto unison_voices = m_params.get_local_unison_voices(_layerId);
+    m_layer_changed |= unison_voices->update_position(static_cast<float>(_unisonVoices.controlPosition));
+    auto mono_enable = m_params.get_local_mono_enable(_layerId);
+    m_layer_changed |= mono_enable->update_position(static_cast<float>(_monoEnable.controlPosition));
 }
 
 void dsp_host_dual::evalVoiceFadeChg(const uint32_t _layer)
 {
-  m_poly[_layer].evalVoiceFade(
-      m_params
-          .get_local_direct(_layer, static_cast<uint32_t>(C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_From))
-          ->m_scaled,
-      m_params
-          .get_local_direct(_layer, static_cast<uint32_t>(C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_Range))
-          ->m_scaled);
+    m_poly[_layer].evalVoiceFade(
+        m_params
+            .get_local_direct(_layer, static_cast<uint32_t>(C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_From))
+            ->m_scaled,
+        m_params
+            .get_local_direct(_layer, static_cast<uint32_t>(C15::Parameters::Local_Unmodulateables::Voice_Grp_Fade_Range))
+            ->m_scaled);
 }
 
 void dsp_host_dual::recallSingle()
 {
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recallSingle(@", m_clock.m_index, ")");
-  }
-  auto msg = &m_preloaded_single_data;
-  // update unison and mono groups
-  evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
-  // reset detection
-  if(m_layer_changed)
-  {
-    if(LOG_RESET)
-    {
-      nltools::Log::info("recall single voice reset");
+    if (LOG_RECALL) {
+        nltools::Log::info("recallSingle(@", m_clock.m_index, ")");
     }
-    m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position);
-    m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position);
-    const uint32_t uVoice = m_alloc.m_unison - 1;
-    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-    {
-      m_poly[layerId].resetEnvelopes();
-      m_poly[layerId].m_uVoice = uVoice;
-      m_poly[layerId].m_key_active = 0;
+    auto msg = &m_preloaded_single_data;
+    // update unison and mono groups
+    evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
+    // reset detection
+    if (m_layer_changed) {
+        if (LOG_RESET) {
+            nltools::Log::info("recall single voice reset");
+        }
+        m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position);
+        m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position);
+        const uint32_t uVoice = m_alloc.m_unison - 1;
+        for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+            m_poly[layerId].resetEnvelopes();
+            m_poly[layerId].m_uVoice = uVoice;
+            m_poly[layerId].m_key_active = 0;
+        }
     }
-  }
-  // reset
-  m_params.m_global.m_assignment.reset();
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    // macro assignments
-    m_params.m_layer[layerId].m_assignment.reset();
-    // voice fade
-    m_poly[layerId].resetVoiceFade();
-  }
-  // global updates: hw sources
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw sources:");
-  }
-  for(uint32_t i = 0; i < msg->hwsources.size(); i++)
-  {
-    globalParRcl(msg->hwsources[i]);
-  }
-  // global updates: hw amounts
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw amounts:");
-  }
-  for(uint32_t i = 0; i < msg->hwamounts.size(); i++)
-  {
-    globalParRcl(msg->hwamounts[i]);
-  }
-  // global updates: macros
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: macros:");
-  }
-  for(uint32_t i = 0; i < msg->macros.size(); i++)
-  {
-    globalParRcl(msg->macros[i]);
-  }
-  for(uint32_t i = 0; i < msg->macrotimes.size(); i++)
-  {
-    globalTimeRcl(msg->macrotimes[i]);
-  }
-  // global updates: parameters
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global params (unmodulateables):");
-  }
-  for(uint32_t i = 0; i < msg->globalparams.size(); i++)
-  {
-    globalParRcl(msg->globalparams[i]);
-  }
-  // local updates: unison, mono
-  localPolyRcl(0, msg->unison, msg->mono);
-  // local updates: unmodulateables
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: local unmodulateables/mc_times:");
-  }
-  for(uint32_t i = 0; i < msg->unmodulateables.size(); i++)
-  {
-    localParRcl(0, msg->unmodulateables[i]);
-  }
-  // local updates: modulateables
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: local modulateables:");
-  }
-  for(uint32_t i = 0; i < msg->modulateables.size(); i++)
-  {
-    localParRcl(0, msg->modulateables[i]);
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: start transitions:");
-  }
-  // start transitions: global unmodulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
-  {
-    auto param = m_params.get_global_direct(i);
-    if(i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key))
-    {
-      m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+    // reset
+    m_params.m_global.m_assignment.reset();
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        // macro assignments
+        m_params.m_layer[layerId].m_assignment.reset();
+        // voice fade
+        m_poly[layerId].resetVoiceFade();
     }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
+    // global updates: hw sources
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw sources:");
     }
-  }
-  // start transitions: global modulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
-  {
-    auto param = m_params.get_global_target(i);
-    globalTransition(param, m_transition_time.m_dx);
-  }
-  // start transitions: local unmodulateables
-  for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
-  {
-    auto param = m_params.get_local_direct(0, i);
-    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-    {
-      localTransition(layerId, param, m_transition_time.m_dx);
+    for (uint32_t i = 0; i < msg->hwsources.size(); i++) {
+        globalParRcl(msg->hwsources[i]);
     }
-  }
-  // start transitions: local modulateables
-  for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
-  {
-    auto param = m_params.get_local_target(0, i);
-    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-    {
-      localTransition(layerId, param, m_transition_time.m_dx);
+    // global updates: hw amounts
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw amounts:");
     }
-  }
-  // logging levels after recall for debugging switching dual modes
-  if(LOG_RECALL_LEVELS)
-  {
-    debugLevels();
-  }
+    for (uint32_t i = 0; i < msg->hwamounts.size(); i++) {
+        globalParRcl(msg->hwamounts[i]);
+    }
+    // global updates: macros
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: macros:");
+    }
+    for (uint32_t i = 0; i < msg->macros.size(); i++) {
+        globalParRcl(msg->macros[i]);
+    }
+    for (uint32_t i = 0; i < msg->macrotimes.size(); i++) {
+        globalTimeRcl(msg->macrotimes[i]);
+    }
+    // global updates: parameters
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global params (unmodulateables):");
+    }
+    for (uint32_t i = 0; i < msg->globalparams.size(); i++) {
+        globalParRcl(msg->globalparams[i]);
+    }
+    // local updates: unison, mono
+    localPolyRcl(0, msg->unison, msg->mono);
+    // local updates: unmodulateables
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: local unmodulateables/mc_times:");
+    }
+    for (uint32_t i = 0; i < msg->unmodulateables.size(); i++) {
+        localParRcl(0, msg->unmodulateables[i]);
+    }
+    // local updates: modulateables
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: local modulateables:");
+    }
+    for (uint32_t i = 0; i < msg->modulateables.size(); i++) {
+        localParRcl(0, msg->modulateables[i]);
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: start transitions:");
+    }
+    // start transitions: global unmodulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_direct_count; i++) {
+        auto param = m_params.get_global_direct(i);
+        if (i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key)) {
+            m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+        } else {
+            globalTransition(param, m_transition_time.m_dx);
+        }
+    }
+    // start transitions: global modulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_target_count; i++) {
+        auto param = m_params.get_global_target(i);
+        globalTransition(param, m_transition_time.m_dx);
+    }
+    // start transitions: local unmodulateables
+    for (uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++) {
+        auto param = m_params.get_local_direct(0, i);
+        for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+    }
+    // start transitions: local modulateables
+    for (uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++) {
+        auto param = m_params.get_local_target(0, i);
+        for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+    }
+    // logging levels after recall for debugging switching dual modes
+    if (LOG_RECALL_LEVELS) {
+        debugLevels();
+    }
 }
 
 void dsp_host_dual::recallSplit()
 {
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recallSplit(@", m_clock.m_index, ")");
-  }
-  const bool layer_changed = m_layer_changed;
-  auto msg = &m_preloaded_split_data;
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    const C15::Properties::LayerId layer = static_cast<C15::Properties::LayerId>(layerId);
-    m_layer_changed = layer_changed;
-    // update unison and mono groups
-    evalPolyChg(layer, msg->unison[layerId].unisonVoices, msg->mono[layerId].monoEnable);
-    // reset detection
-    if(m_layer_changed)
-    {
-      if(LOG_RESET)
-      {
-        nltools::Log::info("recall split voice reset(layerId:", layerId, ")");
-      }
-      m_alloc.setUnison(layerId, m_params.get_local_unison_voices(layer)->m_position);
-      m_alloc.setMonoEnable(layerId, m_params.get_local_mono_enable(layer)->m_position);
-      const uint32_t uVoice = m_alloc.m_unison - 1;
-      m_poly[layerId].resetEnvelopes();
-      m_poly[layerId].m_uVoice = uVoice;
-      m_poly[layerId].m_key_active = 0;
+    if (LOG_RECALL) {
+        nltools::Log::info("recallSplit(@", m_clock.m_index, ")");
     }
-    // reset macro assignments
-    m_params.m_layer[layerId].m_assignment.reset();
-    // reset voice fade
-    m_poly[layerId].resetVoiceFade();
-  }
-  m_params.m_global.m_assignment.reset();
-  // global updates: hw sources
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw sources:");
-  }
-  for(uint32_t i = 0; i < msg->hwsources.size(); i++)
-  {
-    globalParRcl(msg->hwsources[i]);
-  }
-  // global updates: hw amounts
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw amounts:");
-  }
-  for(uint32_t i = 0; i < msg->hwamounts.size(); i++)
-  {
-    globalParRcl(msg->hwamounts[i]);
-  }
-  // global updates: macros
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: macros:");
-  }
-  for(uint32_t i = 0; i < msg->macros.size(); i++)
-  {
-    globalParRcl(msg->macros[i]);
-  }
-  for(uint32_t i = 0; i < msg->macrotimes.size(); i++)
-  {
-    globalTimeRcl(msg->macrotimes[i]);
-  }
-  // global updates: parameters
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global params (modulateables):");
-  }
-  globalParRcl(msg->splitpoint);
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global params (unmodulateables):");
-  }
-  for(uint32_t i = 0; i < msg->globalparams.size(); i++)
-  {
-    globalParRcl(msg->globalparams[i]);
-  }
-  // local updates (each layer)
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    // local updates: unison, mono
-    localPolyRcl(layerId, msg->unison[layerId], msg->mono[layerId]);
-    // local updates: unmodulateables
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local unmodulateables/mc_times:");
+    const bool layer_changed = m_layer_changed;
+    auto msg = &m_preloaded_split_data;
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        const C15::Properties::LayerId layer = static_cast<C15::Properties::LayerId>(layerId);
+        m_layer_changed = layer_changed;
+        // update unison and mono groups
+        evalPolyChg(layer, msg->unison[layerId].unisonVoices, msg->mono[layerId].monoEnable);
+        // reset detection
+        if (m_layer_changed) {
+            if (LOG_RESET) {
+                nltools::Log::info("recall split voice reset(layerId:", layerId, ")");
+            }
+            m_alloc.setUnison(layerId, m_params.get_local_unison_voices(layer)->m_position);
+            m_alloc.setMonoEnable(layerId, m_params.get_local_mono_enable(layer)->m_position);
+            const uint32_t uVoice = m_alloc.m_unison - 1;
+            m_poly[layerId].resetEnvelopes();
+            m_poly[layerId].m_uVoice = uVoice;
+            m_poly[layerId].m_key_active = 0;
+        }
+        // reset macro assignments
+        m_params.m_layer[layerId].m_assignment.reset();
+        // reset voice fade
+        m_poly[layerId].resetVoiceFade();
     }
-    for(uint32_t i = 0; i < msg->unmodulateables[layerId].size(); i++)
-    {
-      localParRcl(layerId, msg->unmodulateables[layerId][i]);
+    m_params.m_global.m_assignment.reset();
+    // global updates: hw sources
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw sources:");
     }
-    // local updates: modulateables
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local modulateables:");
+    for (uint32_t i = 0; i < msg->hwsources.size(); i++) {
+        globalParRcl(msg->hwsources[i]);
     }
-    for(uint32_t i = 0; i < msg->modulateables[layerId].size(); i++)
-    {
-      localParRcl(layerId, msg->modulateables[layerId][i]);
+    // global updates: hw amounts
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw amounts:");
     }
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: start transitions:");
-  }
-  // start transitions: global unmodulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
-  {
-    auto param = m_params.get_global_direct(i);
-    if(i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key))
-    {
-      m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+    for (uint32_t i = 0; i < msg->hwamounts.size(); i++) {
+        globalParRcl(msg->hwamounts[i]);
     }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
+    // global updates: macros
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: macros:");
     }
-  }
-  // start transitions: global modulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
-  {
-    auto param = m_params.get_global_target(i);
-    globalTransition(param, m_transition_time.m_dx);
-  }
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    // start transitions: local unmodulateables
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
-    {
-      auto param = m_params.get_local_direct(layerId, i);
-      localTransition(layerId, param, m_transition_time.m_dx);
+    for (uint32_t i = 0; i < msg->macros.size(); i++) {
+        globalParRcl(msg->macros[i]);
     }
-    // start transitions: local modulateables
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
-    {
-      auto param = m_params.get_local_target(layerId, i);
-      localTransition(layerId, param, m_transition_time.m_dx);
+    for (uint32_t i = 0; i < msg->macrotimes.size(); i++) {
+        globalTimeRcl(msg->macrotimes[i]);
     }
-  }
-  // logging levels after recall for debugging switching dual modes
-  if(LOG_RECALL_LEVELS)
-  {
-    debugLevels();
-  }
+    // global updates: parameters
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global params (modulateables):");
+    }
+    globalParRcl(msg->splitpoint);
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global params (unmodulateables):");
+    }
+    for (uint32_t i = 0; i < msg->globalparams.size(); i++) {
+        globalParRcl(msg->globalparams[i]);
+    }
+    // local updates (each layer)
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        // local updates: unison, mono
+        localPolyRcl(layerId, msg->unison[layerId], msg->mono[layerId]);
+        // local updates: unmodulateables
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local unmodulateables/mc_times:");
+        }
+        for (uint32_t i = 0; i < msg->unmodulateables[layerId].size(); i++) {
+            localParRcl(layerId, msg->unmodulateables[layerId][i]);
+        }
+        // local updates: modulateables
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local modulateables:");
+        }
+        for (uint32_t i = 0; i < msg->modulateables[layerId].size(); i++) {
+            localParRcl(layerId, msg->modulateables[layerId][i]);
+        }
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: start transitions:");
+    }
+    // start transitions: global unmodulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_direct_count; i++) {
+        auto param = m_params.get_global_direct(i);
+        if (i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key)) {
+            m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+        } else {
+            globalTransition(param, m_transition_time.m_dx);
+        }
+    }
+    // start transitions: global modulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_target_count; i++) {
+        auto param = m_params.get_global_target(i);
+        globalTransition(param, m_transition_time.m_dx);
+    }
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        // start transitions: local unmodulateables
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++) {
+            auto param = m_params.get_local_direct(layerId, i);
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+        // start transitions: local modulateables
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++) {
+            auto param = m_params.get_local_target(layerId, i);
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+    }
+    // logging levels after recall for debugging switching dual modes
+    if (LOG_RECALL_LEVELS) {
+        debugLevels();
+    }
 }
 
 void dsp_host_dual::recallLayer()
 {
-  // TODO: implement Key Fade evaluation of individual levels (both parts)
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recallLayer(@", m_clock.m_index, ")");
-  }
-  auto msg = &m_preloaded_layer_data;
-  // update unison and mono groups
-  evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
-  // reset detection
-  if(m_layer_changed)
-  {
-    if(LOG_RESET)
-    {
-      nltools::Log::info("recall layer voice reset");
+    // TODO: implement Key Fade evaluation of individual levels (both parts)
+    if (LOG_RECALL) {
+        nltools::Log::info("recallLayer(@", m_clock.m_index, ")");
     }
-    m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position);
-    m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position);
-    const uint32_t uVoice = m_alloc.m_unison - 1;
-    for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-    {
-      m_poly[layerId].resetEnvelopes();
-      m_poly[layerId].m_uVoice = uVoice;
-      m_poly[layerId].m_key_active = 0;
+    auto msg = &m_preloaded_layer_data;
+    // update unison and mono groups
+    evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
+    // reset detection
+    if (m_layer_changed) {
+        if (LOG_RESET) {
+            nltools::Log::info("recall layer voice reset");
+        }
+        m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position);
+        m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position);
+        const uint32_t uVoice = m_alloc.m_unison - 1;
+        for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+            m_poly[layerId].resetEnvelopes();
+            m_poly[layerId].m_uVoice = uVoice;
+            m_poly[layerId].m_key_active = 0;
+        }
     }
-  }
-  // reset macro assignments
-  m_params.m_global.m_assignment.reset();
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    m_params.m_layer[layerId].m_assignment.reset();
-  }
-  // global updates: hw sources
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw sources:");
-  }
-  for(uint32_t i = 0; i < msg->hwsources.size(); i++)
-  {
-    globalParRcl(msg->hwsources[i]);
-  }
-  // global updates: hw amounts
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: hw amounts:");
-  }
-  for(uint32_t i = 0; i < msg->hwamounts.size(); i++)
-  {
-    globalParRcl(msg->hwamounts[i]);
-  }
-  // global updates: macros
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: macros:");
-  }
-  for(uint32_t i = 0; i < msg->macros.size(); i++)
-  {
-    globalParRcl(msg->macros[i]);
-  }
-  for(uint32_t i = 0; i < msg->macrotimes.size(); i++)
-  {
-    globalTimeRcl(msg->macrotimes[i]);
-  }
-  // global updates: parameters
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: global params (unmodulateables):");
-  }
-  for(uint32_t i = 0; i < msg->globalparams.size(); i++)
-  {
-    globalParRcl(msg->globalparams[i]);
-  }
-  // local updates: unison, mono
-  localPolyRcl(0, msg->unison, msg->mono);
-  // local updates (each layer)
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    // local updates: unmodulateables
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local unmodulateables/mc_times:");
+    // reset macro assignments
+    m_params.m_global.m_assignment.reset();
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        m_params.m_layer[layerId].m_assignment.reset();
     }
-    for(uint32_t i = 0; i < msg->unmodulateables[layerId].size(); i++)
-    {
-      localParRcl(layerId, msg->unmodulateables[layerId][i]);
+    // global updates: hw sources
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw sources:");
     }
-    // local updates: modulateables
-    if(LOG_RECALL)
-    {
-      nltools::Log::info("recall: local modulateables:");
+    for (uint32_t i = 0; i < msg->hwsources.size(); i++) {
+        globalParRcl(msg->hwsources[i]);
     }
-    for(uint32_t i = 0; i < msg->modulateables[layerId].size(); i++)
-    {
-      localParRcl(layerId, msg->modulateables[layerId][i]);
+    // global updates: hw amounts
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: hw amounts:");
     }
-  }
-  if(LOG_RECALL)
-  {
-    nltools::Log::info("recall: start transitions:");
-  }
-  // start transitions: global unmodulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_direct_count; i++)
-  {
-    auto param = m_params.get_global_direct(i);
-    if(i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key))
-    {
-      m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+    for (uint32_t i = 0; i < msg->hwamounts.size(); i++) {
+        globalParRcl(msg->hwamounts[i]);
     }
-    else
-    {
-      globalTransition(param, m_transition_time.m_dx);
+    // global updates: macros
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: macros:");
     }
-  }
-  // start transitions: global modulateables
-  for(uint32_t i = 0; i < m_params.m_global.m_target_count; i++)
-  {
-    auto param = m_params.get_global_target(i);
-    globalTransition(param, m_transition_time.m_dx);
-  }
-  for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
-  {
-    // start transitions: local unmodulateables
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++)
-    {
-      auto param = m_params.get_local_direct(layerId, i);
-      localTransition(layerId, param, m_transition_time.m_dx);
+    for (uint32_t i = 0; i < msg->macros.size(); i++) {
+        globalParRcl(msg->macros[i]);
     }
-    // start transitions: local modulateables
-    for(uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++)
-    {
-      auto param = m_params.get_local_target(layerId, i);
-      localTransition(layerId, param, m_transition_time.m_dx);
+    for (uint32_t i = 0; i < msg->macrotimes.size(); i++) {
+        globalTimeRcl(msg->macrotimes[i]);
     }
-  }
-  // logging levels after recall for debugging switching dual modes
-  if(LOG_RECALL_LEVELS)
-  {
-    debugLevels();
-  }
+    // global updates: parameters
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: global params (unmodulateables):");
+    }
+    for (uint32_t i = 0; i < msg->globalparams.size(); i++) {
+        globalParRcl(msg->globalparams[i]);
+    }
+    // local updates: unison, mono
+    localPolyRcl(0, msg->unison, msg->mono);
+    // local updates (each layer)
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        // local updates: unmodulateables
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local unmodulateables/mc_times:");
+        }
+        for (uint32_t i = 0; i < msg->unmodulateables[layerId].size(); i++) {
+            localParRcl(layerId, msg->unmodulateables[layerId][i]);
+        }
+        // local updates: modulateables
+        if (LOG_RECALL) {
+            nltools::Log::info("recall: local modulateables:");
+        }
+        for (uint32_t i = 0; i < msg->modulateables[layerId].size(); i++) {
+            localParRcl(layerId, msg->modulateables[layerId][i]);
+        }
+    }
+    if (LOG_RECALL) {
+        nltools::Log::info("recall: start transitions:");
+    }
+    // start transitions: global unmodulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_direct_count; i++) {
+        auto param = m_params.get_global_direct(i);
+        if (i == static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Scale_Base_Key)) {
+            m_global.start_base_key(m_transition_time.m_dx.m_dx_slow, param->m_scaled);
+        } else {
+            globalTransition(param, m_transition_time.m_dx);
+        }
+    }
+    // start transitions: global modulateables
+    for (uint32_t i = 0; i < m_params.m_global.m_target_count; i++) {
+        auto param = m_params.get_global_target(i);
+        globalTransition(param, m_transition_time.m_dx);
+    }
+    for (uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++) {
+        // start transitions: local unmodulateables
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_direct_count; i++) {
+            auto param = m_params.get_local_direct(layerId, i);
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+        // start transitions: local modulateables
+        for (uint32_t i = 0; i < m_params.m_layer[0].m_target_count; i++) {
+            auto param = m_params.get_local_target(layerId, i);
+            localTransition(layerId, param, m_transition_time.m_dx);
+        }
+    }
+    // logging levels after recall for debugging switching dual modes
+    if (LOG_RECALL_LEVELS) {
+        debugLevels();
+    }
 }
 
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareSourceParameter &_param)
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareSourceParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Source)
-  {
-    auto param = m_params.get_hw_src(element.m_param.m_index);
-    param->update_behavior(getBehavior(_param.returnMode));
-    param->update_position(static_cast<float>(_param.controlPosition));
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall HW Source(id:", _param.id, ")");
-  }
-}
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareAmountParameter &_param)
-{
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Amount)
-  {
-    auto param = m_params.get_hw_amt(element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall HW Amount(id:", _param.id, ")");
-  }
-}
-
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::MacroParameter &_param)
-{
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Control)
-  {
-    auto param = m_params.get_macro(element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Macro(id:", _param.id, ")");
-  }
-}
-
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::ModulateableParameter &_param)
-{
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Global_Modulateable)
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Source) {
+        auto param = m_params.get_hw_src(element.m_param.m_index);
+        param->update_behavior(getBehavior(_param.returnMode));
+        param->update_position(static_cast<float>(_param.controlPosition));
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall HW Source(id:", _param.id, ")");
     }
-    auto param = m_params.get_global_target(element.m_param.m_index);
-    param->update_source(getMacro(_param.mc));
-    param->update_amount(static_cast<float>(_param.modulationAmount));
-    param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
-    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-    const uint32_t macroId = getMacroId(_param.mc);
-    m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    if(_param.id == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point))
-    {
-      m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
-      nltools::Log::info("recall split:", m_alloc.m_splitPoint);
+}
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareAmountParameter& _param)
+{
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Hardware_Amount) {
+        auto param = m_params.get_hw_amt(element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall HW Amount(id:", _param.id, ")");
     }
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Global Modulateable(id:", _param.id, ")");
-  }
 }
 
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::SplitPoint &_param)
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::MacroParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_index == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point))
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Control) {
+        auto param = m_params.get_macro(element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Macro(id:", _param.id, ")");
     }
-    auto param = m_params.get_global_target(element.m_param.m_index);
-    param->update_source(getMacro(_param.mc));
-    param->update_amount(static_cast<float>(_param.modulationAmount));
-    param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
-    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-    const uint32_t macroId = getMacroId(_param.mc);
-    m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-    m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Global Modulateable(id:", _param.id, ")");
-  }
 }
 
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter &_param)
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::ModulateableParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Global_Unmodulateable)
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Global_Modulateable) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_global_target(element.m_param.m_index);
+        param->update_source(getMacro(_param.mc));
+        param->update_amount(static_cast<float>(_param.modulationAmount));
+        param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
+        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+        const uint32_t macroId = getMacroId(_param.mc);
+        m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        if (_param.id == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point)) {
+            m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
+            nltools::Log::info("recall split:", m_alloc.m_splitPoint);
+        }
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Global Modulateable(id:", _param.id, ")");
     }
-    auto param = m_params.get_global_direct(element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Global Unmodulateable(id:", _param.id, ")");
-  }
 }
 
-void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::GlobalParameter &_param)
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::SplitPoint& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Global_Unmodulateable)
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_index == static_cast<uint32_t>(C15::Parameters::Global_Modulateables::Split_Split_Point)) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_global_target(element.m_param.m_index);
+        param->update_source(getMacro(_param.mc));
+        param->update_amount(static_cast<float>(_param.modulationAmount));
+        param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
+        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+        const uint32_t macroId = getMacroId(_param.mc);
+        m_params.m_global.m_assignment.reassign(element.m_param.m_index, macroId);
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+        m_alloc.setSplitPoint(static_cast<uint32_t>(param->m_scaled));
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Global Modulateable(id:", _param.id, ")");
     }
-    auto param = m_params.get_global_direct(element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall GlobalParameter(id:", _param.id, ")");
-  }
 }
 
-void dsp_host_dual::globalTimeRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter &_param)
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Time)
-  {
-    auto param = m_params.get_macro_time(element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-    updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Macro Time(id:", _param.id, ")");
-  }
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Global_Unmodulateable) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_global_direct(element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Global Unmodulateable(id:", _param.id, ")");
+    }
+}
+
+void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::GlobalParameter& _param)
+{
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Global_Unmodulateable) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_global_direct(element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall GlobalParameter(id:", _param.id, ")");
+    }
+}
+
+void dsp_host_dual::globalTimeRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter& _param)
+{
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Macro_Time) {
+        auto param = m_params.get_macro_time(element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+        updateTime(&param->m_dx, scale(param->m_scaling, param->m_position));
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Macro Time(id:", _param.id, ")");
+    }
 }
 void dsp_host_dual::localParRcl(const uint32_t _layerId,
-                                const nltools::msg::ParameterGroups::ModulateableParameter &_param)
+    const nltools::msg::ParameterGroups::ModulateableParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Local_Modulateable)
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Local_Modulateable) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_local_target(_layerId, element.m_param.m_index);
+        param->update_source(getMacro(_param.mc));
+        param->update_amount(static_cast<float>(_param.modulationAmount));
+        param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
+        param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
+        const uint32_t macroId = getMacroId(_param.mc);
+        m_params.m_layer[_layerId].m_assignment.reassign(element.m_param.m_index, macroId);
+        param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Local Target(id:", _param.id, ")");
     }
-    auto param = m_params.get_local_target(_layerId, element.m_param.m_index);
-    param->update_source(getMacro(_param.mc));
-    param->update_amount(static_cast<float>(_param.modulationAmount));
-    param->update_position(param->depolarize(static_cast<float>(_param.controlPosition)));
-    param->m_scaled = scale(param->m_scaling, param->polarize(param->m_position));
-    const uint32_t macroId = getMacroId(_param.mc);
-    m_params.m_layer[_layerId].m_assignment.reassign(element.m_param.m_index, macroId);
-    param->update_modulation_aspects(m_params.get_macro(macroId)->m_position);
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Local Target(id:", _param.id, ")");
-  }
 }
 
 void dsp_host_dual::localParRcl(const uint32_t _layerId,
-                                const nltools::msg::ParameterGroups::UnmodulateableParameter &_param)
+    const nltools::msg::ParameterGroups::UnmodulateableParameter& _param)
 {
-  auto element = getParameter(_param.id);
-  if(element.m_param.m_type == C15::Descriptors::ParameterType::Local_Unmodulateable)
-  {
-    if(LOG_RECALL_COMPARE_INITIAL)
-    {
-      nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
-                         element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
-                         ", initial:", element.m_initial, ")");
+    auto element = getParameter(_param.id);
+    if (element.m_param.m_type == C15::Descriptors::ParameterType::Local_Unmodulateable) {
+        if (LOG_RECALL_COMPARE_INITIAL) {
+            nltools::Log::info("recall(id:", _param.id, ", label:", element.m_pg.m_group_label_short,
+                element.m_pg.m_param_label_short, ", value:", _param.controlPosition,
+                ", initial:", element.m_initial, ")");
+        }
+        auto param = m_params.get_local_direct(_layerId, element.m_param.m_index);
+        param->update_position(static_cast<float>(_param.controlPosition));
+        param->m_scaled = scale(param->m_scaling, param->m_position);
+    } else if (LOG_FAIL) {
+        nltools::Log::warning("failed to recall Local Direct(id:", _param.id, ")");
     }
-    auto param = m_params.get_local_direct(_layerId, element.m_param.m_index);
-    param->update_position(static_cast<float>(_param.controlPosition));
-    param->m_scaled = scale(param->m_scaling, param->m_position);
-  }
-  else if(LOG_FAIL)
-  {
-    nltools::Log::warning("failed to recall Local Direct(id:", _param.id, ")");
-  }
 }
 
-void dsp_host_dual::localPolyRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnisonGroup &_unison,
-                                 const nltools::msg::ParameterGroups::MonoGroup &_mono)
+void dsp_host_dual::localPolyRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnisonGroup& _unison,
+    const nltools::msg::ParameterGroups::MonoGroup& _mono)
 {
-  localParRcl(_layerId, _unison.detune);
-  localParRcl(_layerId, _unison.pan);
-  localParRcl(_layerId, _unison.phase);
-  localParRcl(_layerId, _mono.priority);
-  const C15::Properties::LayerId layerId = static_cast<C15::Properties::LayerId>(_layerId);
-  m_alloc.setMonoPriority(_layerId, m_params.get_local_mono_priority(layerId)->m_scaled);
-  localParRcl(_layerId, _mono.legato);
-  m_alloc.setMonoLegato(_layerId, m_params.get_local_mono_legato(layerId)->m_scaled);
-  localParRcl(_layerId, _mono.glide);
+    localParRcl(_layerId, _unison.detune);
+    localParRcl(_layerId, _unison.pan);
+    localParRcl(_layerId, _unison.phase);
+    localParRcl(_layerId, _mono.priority);
+    const C15::Properties::LayerId layerId = static_cast<C15::Properties::LayerId>(_layerId);
+    m_alloc.setMonoPriority(_layerId, m_params.get_local_mono_priority(layerId)->m_scaled);
+    localParRcl(_layerId, _mono.legato);
+    m_alloc.setMonoLegato(_layerId, m_params.get_local_mono_legato(layerId)->m_scaled);
+    localParRcl(_layerId, _mono.glide);
 }
 
 void dsp_host_dual::debugLevels()
 {
-  nltools::Log::info(
-      "MasterLevel:",
-      m_params.get_global_direct(static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Master_Volume))
-          ->m_scaled);
-  nltools::Log::info(
-      "VoiceGroupLevel[I]:",
-      m_params.get_local_target(0, static_cast<uint32_t>(C15::Parameters::Local_Modulateables::Voice_Grp_Volume))
-          ->m_scaled);
-  nltools::Log::info(
-      "VoiceGroupLevel[II]:",
-      m_params.get_local_target(0, static_cast<uint32_t>(C15::Parameters::Local_Modulateables::Voice_Grp_Volume))
-          ->m_scaled);
+    nltools::Log::info(
+        "MasterLevel:",
+        m_params.get_global_direct(static_cast<uint32_t>(C15::Parameters::Global_Unmodulateables::Master_Volume))
+            ->m_scaled);
+    nltools::Log::info(
+        "VoiceGroupLevel[I]:",
+        m_params.get_local_target(0, static_cast<uint32_t>(C15::Parameters::Local_Modulateables::Voice_Grp_Volume))
+            ->m_scaled);
+    nltools::Log::info(
+        "VoiceGroupLevel[II]:",
+        m_params.get_local_target(0, static_cast<uint32_t>(C15::Parameters::Local_Modulateables::Voice_Grp_Volume))
+            ->m_scaled);
 }

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -10,21 +10,21 @@
 *******************************************************************************/
 
 #include <c15_config.h>
-#include <parameter_list.h>
 #include <nltools/messaging/Message.h>
+#include <parameter_list.h>
 
 #include "parameter_handle.h"
 #include "pe_exponentiator.h"
 #include "voice_allocation.h"
 
-#include "ae_global_section.h"
-#include "ae_poly_section.h"
-#include "ae_mono_section.h"
 #include "ae_fadepoint.h"
+#include "ae_global_section.h"
+#include "ae_mono_section.h"
+#include "ae_poly_section.h"
 
 // basic logging switches
-inline constexpr bool LOG_MISSING = true;
-inline constexpr bool LOG_FAIL = true;
+inline constexpr bool LOG_MISSING = false;
+inline constexpr bool LOG_FAIL = false;
 inline constexpr bool LOG_INIT = true;
 inline constexpr bool LOG_MIDI = false;
 inline constexpr bool LOG_MIDI_DETAIL = false;
@@ -47,123 +47,122 @@ inline constexpr uint32_t LOG_PARAMS_LENGTH = 3;
 // use tcd ids here (currently: Split Point, Unison Detune)
 static const uint32_t LOG_PARAMS[LOG_PARAMS_LENGTH] = { 356, 250, 367 };
 
-class dsp_host_dual
-{
- public:
-  // public members
-  float m_mainOut_R, m_mainOut_L;
-  // constructor
-  dsp_host_dual();
-  // public methods
-  void init(const uint32_t _samplerate, const uint32_t _polyphony);
-  // handles for inconvenient stuff
-  C15::ParameterDescriptor getParameter(const int _id);
-  // event bindings: debug
-  void logStatus();
-  // event bindings: LPC or MIDI Device (in Dev_PC mode)
-  void onMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1);
-  void onRawMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1);
-  // event bindings: Preset Messages
-  void onPresetMessage(const nltools::msg::SinglePresetMessage &_msg);
-  void onPresetMessage(const nltools::msg::SplitPresetMessage &_msg);
-  void onPresetMessage(const nltools::msg::LayerPresetMessage &_msg);
-  // event bindings: Parameter Changed Messages
-  void globalParChg(const uint32_t _id, const nltools::msg::HWSourceChangedMessage &_msg);
-  void globalParChg(const uint32_t _id, const nltools::msg::HWAmountChangedMessage &_msg);
-  void globalParChg(const uint32_t _id, const nltools::msg::MacroControlChangedMessage &_msg);
-  void globalParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage &_msg);
-  void globalParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void globalTimeChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void localParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage &_msg);
-  void localParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void localUnisonVoicesChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void localMonoEnableChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void localMonoPriorityChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  void localMonoLegatoChg(const nltools::msg::UnmodulateableParameterChangedMessage &_msg);
-  // evend bindings: Settings
-  void onSettingEditTime(const float _position);
-  void onSettingTransitionTime(const float _position);
-  void onSettingNoteShift(const float _shift);
-  void onSettingGlitchSuppr(const bool _enabled);
-  void onSettingTuneReference(const float _position);
-  void onSettingInitialSinglePreset();
-  uint32_t onSettingToneToggle();
-  // dsp-related
-  void render();
-  void reset();
+class dsp_host_dual {
+public:
+    // public members
+    float m_mainOut_R, m_mainOut_L;
+    // constructor
+    dsp_host_dual();
+    // public methods
+    void init(const uint32_t _samplerate, const uint32_t _polyphony);
+    // handles for inconvenient stuff
+    C15::ParameterDescriptor getParameter(const int _id);
+    // event bindings: debug
+    void logStatus();
+    // event bindings: LPC or MIDI Device (in Dev_PC mode)
+    void onMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1);
+    void onRawMidiMessage(const uint32_t _status, const uint32_t _data0, const uint32_t _data1);
+    // event bindings: Preset Messages
+    void onPresetMessage(const nltools::msg::SinglePresetMessage& _msg);
+    void onPresetMessage(const nltools::msg::SplitPresetMessage& _msg);
+    void onPresetMessage(const nltools::msg::LayerPresetMessage& _msg);
+    // event bindings: Parameter Changed Messages
+    void globalParChg(const uint32_t _id, const nltools::msg::HWSourceChangedMessage& _msg);
+    void globalParChg(const uint32_t _id, const nltools::msg::HWAmountChangedMessage& _msg);
+    void globalParChg(const uint32_t _id, const nltools::msg::MacroControlChangedMessage& _msg);
+    void globalParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage& _msg);
+    void globalParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void globalTimeChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void localParChg(const uint32_t _id, const nltools::msg::ModulateableParameterChangedMessage& _msg);
+    void localParChg(const uint32_t _id, const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void localUnisonVoicesChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void localMonoEnableChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void localMonoPriorityChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    void localMonoLegatoChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg);
+    // evend bindings: Settings
+    void onSettingEditTime(const float _position);
+    void onSettingTransitionTime(const float _position);
+    void onSettingNoteShift(const float _shift);
+    void onSettingGlitchSuppr(const bool _enabled);
+    void onSettingTuneReference(const float _position);
+    void onSettingInitialSinglePreset();
+    uint32_t onSettingToneToggle();
+    // dsp-related
+    void render();
+    void reset();
 
- private:
-  // preloadable preset buffers
-  nltools::msg::SinglePresetMessage m_preloaded_single_data;
-  nltools::msg::SplitPresetMessage m_preloaded_split_data;
-  nltools::msg::LayerPresetMessage m_preloaded_layer_data;
-  // parameters
-  Engine::Param_Handle m_params;
-  Time_Param m_edit_time, m_transition_time;
-  Setting_Param m_reference;
-  const C15::ParameterDescriptor m_invalid_param = { C15::None };
-  // essential tools
-  exponentiator m_convert;
-  Engine::Handle::Clock_Handle m_clock;
-  Engine::Handle::Time_Handle m_time;
-  // layer handling
-  C15::Properties::LayerMode m_layer_mode, m_preloaded_layer_mode;
-  uint32_t m_layer_focus;  // probably obsolete
-  // global dsp components
-  GlobalSection m_global;
-  VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
-  // dsp components
-  ae_fade_table m_fade;
-  ae_fader m_output_mute;
-  PolySection m_poly[2];
-  MonoSection m_mono[2];
-  LayerSignalCollection m_z_layers[2];
-  // helper values
-  const float m_format_vel = 16383.0f / 127.0f, m_format_hw = 16000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
-              m_norm_vel = 1.0f / 16383.0f, m_norm_hw = 1.0f / 16000.0f;
-  uint32_t m_key_pos = 0, m_tone_state = 0;
-  bool m_key_valid = false, m_layer_changed = false, m_glitch_suppression = false;
-  // handles for inconvenient stuff
-  C15::Properties::HW_Return_Behavior getBehavior(const ReturnMode _mode);
-  C15::Properties::HW_Return_Behavior getBehavior(const RibbonReturnMode _mode);
-  C15::Parameters::Macro_Controls getMacro(const MacroControls _mc);
-  uint32_t getMacroId(const MacroControls _mc);
-  C15::Properties::LayerId getLayer(const VoiceGroup _vg);
-  uint32_t getLayerId(const VoiceGroup _vg);
-  // key events
-  void keyDown(const float _vel);
-  void keyUp(const float _vel);
-  float scale(const Scale_Aspect _scl, float _value);
-  // inner event flow
-  void updateHW(const uint32_t _id, const float _raw);
-  void updateTime(Time_Aspect *_param, const float _ms);
-  void hwModChain(HW_Src_Param *_src, const uint32_t _id, const float _inc);
-  void globalModChain(Macro_Param *_mc);
-  void localModChain(Macro_Param *_mc);
-  void localModChain(const uint32_t _layer, Macro_Param *_mc);
-  void globalTransition(const Target_Param *_param, const Time_Aspect _time);
-  void globalTransition(const Direct_Param *_param, const Time_Aspect _time);
-  void localTransition(const uint32_t _layer, const Direct_Param *_param, const Time_Aspect _time);
-  void localTransition(const uint32_t _layer, const Target_Param *_param, const Time_Aspect _time);
-  void evalFadePoint();
-  void evalPolyChg(const C15::Properties::LayerId _layerId,
-                   const nltools::msg::ParameterGroups::UnmodulateableParameter &_unisonVoices,
-                   const nltools::msg::ParameterGroups::UnmodulateableParameter &_monoEnable);
-  void evalVoiceFadeChg(const uint32_t _layer);
-  void recallSingle();
-  void recallSplit();
-  void recallLayer();
-  void globalParRcl(const nltools::msg::ParameterGroups::HardwareSourceParameter &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::HardwareAmountParameter &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::MacroParameter &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::ModulateableParameter &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::SplitPoint &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter &_param);
-  void globalParRcl(const nltools::msg::ParameterGroups::GlobalParameter &_param);
-  void globalTimeRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter &_param);
-  void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::ModulateableParameter &_param);
-  void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnmodulateableParameter &_param);
-  void localPolyRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnisonGroup &_unison,
-                    const nltools::msg::ParameterGroups::MonoGroup &_mono);
-  void debugLevels();
+private:
+    // preloadable preset buffers
+    nltools::msg::SinglePresetMessage m_preloaded_single_data;
+    nltools::msg::SplitPresetMessage m_preloaded_split_data;
+    nltools::msg::LayerPresetMessage m_preloaded_layer_data;
+    // parameters
+    Engine::Param_Handle m_params;
+    Time_Param m_edit_time, m_transition_time;
+    Setting_Param m_reference;
+    const C15::ParameterDescriptor m_invalid_param = { C15::None };
+    // essential tools
+    exponentiator m_convert;
+    Engine::Handle::Clock_Handle m_clock;
+    Engine::Handle::Time_Handle m_time;
+    // layer handling
+    C15::Properties::LayerMode m_layer_mode, m_preloaded_layer_mode;
+    uint32_t m_layer_focus; // probably obsolete
+    // global dsp components
+    GlobalSection m_global;
+    VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
+    // dsp components
+    ae_fade_table m_fade;
+    ae_fader m_output_mute;
+    PolySection m_poly[2];
+    MonoSection m_mono[2];
+    LayerSignalCollection m_z_layers[2];
+    // helper values
+    const float m_format_vel = 16383.0f / 127.0f, m_format_hw = 16000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
+                m_norm_vel = 1.0f / 16383.0f, m_norm_hw = 1.0f / 16000.0f;
+    uint32_t m_key_pos = 0, m_tone_state = 0;
+    bool m_key_valid = false, m_layer_changed = false, m_glitch_suppression = false;
+    // handles for inconvenient stuff
+    C15::Properties::HW_Return_Behavior getBehavior(const ReturnMode _mode);
+    C15::Properties::HW_Return_Behavior getBehavior(const RibbonReturnMode _mode);
+    C15::Parameters::Macro_Controls getMacro(const MacroControls _mc);
+    uint32_t getMacroId(const MacroControls _mc);
+    C15::Properties::LayerId getLayer(const VoiceGroup _vg);
+    uint32_t getLayerId(const VoiceGroup _vg);
+    // key events
+    void keyDown(const float _vel);
+    void keyUp(const float _vel);
+    float scale(const Scale_Aspect _scl, float _value);
+    // inner event flow
+    void updateHW(const uint32_t _id, const float _raw);
+    void updateTime(Time_Aspect* _param, const float _ms);
+    void hwModChain(HW_Src_Param* _src, const uint32_t _id, const float _inc);
+    void globalModChain(Macro_Param* _mc);
+    void localModChain(Macro_Param* _mc);
+    void localModChain(const uint32_t _layer, Macro_Param* _mc);
+    void globalTransition(const Target_Param* _param, const Time_Aspect _time);
+    void globalTransition(const Direct_Param* _param, const Time_Aspect _time);
+    void localTransition(const uint32_t _layer, const Direct_Param* _param, const Time_Aspect _time);
+    void localTransition(const uint32_t _layer, const Target_Param* _param, const Time_Aspect _time);
+    void evalFadePoint();
+    void evalPolyChg(const C15::Properties::LayerId _layerId,
+        const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,
+        const nltools::msg::ParameterGroups::UnmodulateableParameter& _monoEnable);
+    void evalVoiceFadeChg(const uint32_t _layer);
+    void recallSingle();
+    void recallSplit();
+    void recallLayer();
+    void globalParRcl(const nltools::msg::ParameterGroups::HardwareSourceParameter& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::HardwareAmountParameter& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::MacroParameter& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::ModulateableParameter& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::SplitPoint& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter& _param);
+    void globalParRcl(const nltools::msg::ParameterGroups::GlobalParameter& _param);
+    void globalTimeRcl(const nltools::msg::ParameterGroups::UnmodulateableParameter& _param);
+    void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::ModulateableParameter& _param);
+    void localParRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnmodulateableParameter& _param);
+    void localPolyRcl(const uint32_t _layerId, const nltools::msg::ParameterGroups::UnisonGroup& _unison,
+        const nltools::msg::ParameterGroups::MonoGroup& _mono);
+    void debugLevels();
 };

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -42,7 +42,7 @@ inline constexpr bool LOG_RESET = true;
 inline constexpr bool LOG_HW = false;
 // more detailed logging of specific parameters
 inline constexpr bool LOG_ENGINE_STATUS = false;
-inline constexpr bool LOG_ENGINE_EDITS = true;
+inline constexpr bool LOG_ENGINE_EDITS = false;
 inline constexpr uint32_t LOG_PARAMS_LENGTH = 3;
 // use tcd ids here (currently: Split Point, Unison Detune)
 static const uint32_t LOG_PARAMS[LOG_PARAMS_LENGTH] = { 356, 250, 367 };


### PR DESCRIPTION
- Fade From, Fade Range now are properly recalled when receiving a Layer Preset Msg
- Single/Split Preset Msg will update the Parameters themselves, but won't have any effect
- editing of the Parameters when NOT in Layer mode will also be without effect