### PR TITLE
1568 - Animation Vs Action

### DIFF
--- a/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
+++ b/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
@@ -21,7 +21,7 @@ float Animator::getAnimationPosition() const  // 0 ... 1
 {
   auto now = std::chrono::steady_clock::now();
   auto diff = now - m_animationStartedAt;
-  return CLAMP(1.0f * diff / m_animationLength, 0.0f, 1.0f);
+  return std::clamp(1.0f * diff / m_animationLength, 0.0f, 1.0f);
 }
 
 bool Animator::doAnimation()
@@ -84,6 +84,5 @@ bool AnimatedGenericItem::redraw(FrameBuffer &fb)
 
 void AnimatedGenericItem::doAction()
 {
-  GenericItem::doAction();
   startAnimation();
 }

--- a/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
+++ b/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
@@ -29,13 +29,12 @@ class Animator
 class AnimatedGenericItem : public GenericItem
 {
  public:
-  template <class tCap, class tCB, class tCB2>
-  AnimatedGenericItem(tCap caption, const Rect &r, tCB cb, tCB2 onAnimationFinishedCB = nullptr)
-      : GenericItem(caption, r, cb)
+  template <class tCap, class tCB>
+  AnimatedGenericItem(tCap caption, const Rect &r, tCB cb)
+      : GenericItem(caption, r, [] {})
   {
-    m_animationFinishedCB = onAnimationFinishedCB;
+    m_animationFinishedCB = cb;
   }
-
 
   void startAnimation();
   bool drawAnimationZug(FrameBuffer &buffer);

--- a/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
+++ b/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
@@ -8,32 +8,30 @@
 #include "ConvertToSoundTypeItem.h"
 
 ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toType)
-    : AnimatedGenericItem(
-          nltools::string::concat("Convert to ", toString(toType)), rect,
-          [=] {
-            auto scope = Application::get().getPresetManager()->getUndoScope().startTransaction(
-                nltools::string::concat("Convert Sound to ", toString(toType)));
-            auto transaction = scope->getTransaction();
-            auto currentVoiceGroup = Application::get().getHWUI()->getCurrentVoiceGroup();
+    : AnimatedGenericItem(nltools::string::concat("Convert to ", toString(toType)), rect, [=] {
+      auto scope = Application::get().getPresetManager()->getUndoScope().startTransaction(
+          nltools::string::concat("Convert Sound to ", toString(toType)));
+      auto transaction = scope->getTransaction();
+      auto currentVoiceGroup = Application::get().getHWUI()->getCurrentVoiceGroup();
 
-            switch(toType)
-            {
-              case SoundType::Single:
-                Application::get().getPresetManager()->getEditBuffer()->undoableConvertToSingle(transaction,
-                                                                                                currentVoiceGroup);
-                break;
+      switch(toType)
+      {
+        case SoundType::Single:
+          Application::get().getPresetManager()->getEditBuffer()->undoableConvertToSingle(transaction,
+                                                                                          currentVoiceGroup);
+          break;
 
-              case SoundType::Split:
-              case SoundType::Layer:
-                Application::get().getPresetManager()->getEditBuffer()->undoableConvertToDual(transaction, toType);
-                break;
+        case SoundType::Split:
+        case SoundType::Layer:
+          Application::get().getPresetManager()->getEditBuffer()->undoableConvertToDual(transaction, toType);
+          break;
 
-              case SoundType::Invalid:
-                assert(false);
-            }
-          },
-          [] {
-            Application::get().getHWUI()->setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-          })
+        case SoundType::Invalid:
+          assert(false);
+      }
+
+      Application::get().getHWUI()->undoableSetFocusAndMode(transaction,
+                                                            { UIFocus::Sound, UIMode::Select, UIDetail::Init });
+    })
 {
 }

--- a/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/InitSound.cpp
+++ b/projects/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/InitSound.cpp
@@ -6,32 +6,24 @@
 #include <libundo/undo/Scope.h>
 
 InitSound::InitSound(const Rect& rect)
-    : AnimatedGenericItem(
-        "Init Sound", rect,
-        [] {
-          auto pm = Application::get().getPresetManager();
-          auto scope = pm->getUndoScope().startTransaction("Init Sound");
-          pm->getEditBuffer()->undoableInitSound(scope->getTransaction());
-        },
-        []() {
-          auto hwui = Application::get().getHWUI();
-          hwui->setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-        })
+    : AnimatedGenericItem("Init Sound", rect, [] {
+      auto pm = Application::get().getPresetManager();
+      auto scope = pm->getUndoScope().startTransaction("Init Sound");
+      pm->getEditBuffer()->undoableInitSound(scope->getTransaction());
+      auto hwui = Application::get().getHWUI();
+      hwui->undoableSetFocusAndMode(scope->getTransaction(), { UIFocus::Sound, UIMode::Select, UIDetail::Init });
+    })
 {
 }
 
 InitPart::InitPart(const Rect& r)
-    : AnimatedGenericItem(
-        "Init Part", r,
-        []() {
-          auto pm = Application::get().getPresetManager();
-          auto scope = pm->getUndoScope().startTransaction("Init Part");
-          auto sel = Application::get().getHWUI()->getCurrentVoiceGroup();
-          pm->getEditBuffer()->undoableInitPart(scope->getTransaction(), sel);
-        },
-        []() {
-          auto hwui = Application::get().getHWUI();
-          hwui->setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-        })
+    : AnimatedGenericItem("Init Part", r, []() {
+      auto pm = Application::get().getPresetManager();
+      auto scope = pm->getUndoScope().startTransaction("Init Part");
+      auto sel = Application::get().getHWUI()->getCurrentVoiceGroup();
+      pm->getEditBuffer()->undoableInitPart(scope->getTransaction(), sel);
+      auto hwui = Application::get().getHWUI();
+      hwui->setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
+    })
 {
 }


### PR DESCRIPTION
@hhoegelo 

adresses #1568 

I changed implementation of animated generic item to execute the action only after the animation played, aborting the animation by eg changing focus will not execute the action. If this behaviour is wanted problems arise about open transactions and creating transactions inside the animation callback. EG: if i press convert to single and be quick about selecting a parameter the sound type is not changed. But if we wanted to execute the callback from the destructor of the animation then the open transaction from setFocusAndMode -> reset -> animation destructor will lead to an crash. This is not an trivial problem.