### PR TITLE
tackling #1600

### DIFF
--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -29,9 +29,24 @@ void atomic_fade_table::init(const float _samplerate)
   }
 }
 
-uint32_t atomic_fade_table::getTargetRampIndex() const
+bool atomic_fade_table::getTaskStatus()
 {
-  return m_muteTasks ? 0 : m_finalMuteRampIndex;
+  const uint32_t targetRampIndex = m_muteTasks ? 0 : m_finalMuteRampIndex;
+  if(m_currentMuteRampIndex != targetRampIndex)
+  {
+    if(m_currentMuteRampIndex > targetRampIndex)
+    {
+      // fade out
+      m_currentMuteRampIndex--;
+      return m_currentMuteRampIndex == targetRampIndex;  // return true if fade out completed
+    }
+    else
+    {
+      // fade in
+      m_currentMuteRampIndex++;
+    }
+  }
+  return false;
 }
 
 void atomic_fade_table::setTask(const MuteTask _task)

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -13,69 +13,69 @@
 
 // current FadeTable implementation
 
-ae_fade_table::ae_fade_table()
-{
-}
+//ae_fade_table::ae_fade_table()
+//{
+//}
 
-void ae_fade_table::init(const float _samplerate)
-{
-  float fade_time = 1e-3f * C15::Config::fade_time_ms * _samplerate, fade_dx = 1.0f / (fade_time - 1.0f);
+//void ae_fade_table::init(const float _samplerate)
+//{
+//  float fade_time = 1e-3f * C15::Config::fade_time_ms * _samplerate, fade_dx = 1.0f / (fade_time - 1.0f);
 
-  m_table_index = 0;
-  m_trigger = false;
-  m_trigger_index = static_cast<uint32_t>(fade_time);
-  m_data.resize(2 * m_trigger_index);
-  m_event = FadeEvent::None;
-  m_value = 0.0f;
+//  m_table_index = 0;
+//  m_trigger = false;
+//  m_trigger_index = static_cast<uint32_t>(fade_time);
+//  m_data.resize(2 * m_trigger_index);
+//  m_event = FadeEvent::None;
+//  m_value = 0.0f;
 
-  uint32_t i;
-  for(i = 0; i < m_trigger_index - 1; i++)
-  {
-    float x = std::cos(1.5707963f * static_cast<float>(i) * fade_dx);
-    m_data[i] = x * x;
-  }
-  m_data[i] = 0.0f;
-  for(i = 0; i < m_trigger_index; i++)
-  {
-    m_data[m_trigger_index + i] = m_data[m_trigger_index - i - 1];
-  }
-}
+//  uint32_t i;
+//  for(i = 0; i < m_trigger_index - 1; i++)
+//  {
+//    float x = std::cos(1.5707963f * static_cast<float>(i) * fade_dx);
+//    m_data[i] = x * x;
+//  }
+//  m_data[i] = 0.0f;
+//  for(i = 0; i < m_trigger_index; i++)
+//  {
+//    m_data[m_trigger_index + i] = m_data[m_trigger_index - i - 1];
+//  }
+//}
 
-bool ae_fade_table::enable(const FadeEvent _event, const uint32_t _in_or_out)
-{
-  if(m_event == FadeEvent::None)
-  {
-    m_event = _event;
-    m_trigger = true;
-    m_table_offset = _in_or_out * m_trigger_index;
-    m_table_index = 0;
-    m_value = m_data[m_table_offset];
-    return true;
-  }
-  return false;
-}
+//bool ae_fade_table::enable(const FadeEvent _event, const uint32_t _in_or_out)
+//{
+//  if(m_event == FadeEvent::None)
+//  {
+//    m_event = _event;
+//    m_trigger = true;
+//    m_table_offset = _in_or_out * m_trigger_index;
+//    m_table_index = 0;
+//    m_value = m_data[m_table_offset];
+//    return true;
+//  }
+//  return false;
+//}
 
-bool ae_fade_table::get_state()
-{
-  return m_table_index == m_trigger_index;
-}
+//bool ae_fade_table::get_state()
+//{
+//  return m_table_index == m_trigger_index;
+//}
 
-void ae_fade_table::render()
-{
-  m_value = m_data[m_table_offset + m_table_index];
-  if(m_trigger)
-  {
-    m_table_index++;
-    m_trigger = m_table_index < m_trigger_index;
-  }
-}
+//void ae_fade_table::render()
+//{
+//  m_value = m_data[m_table_offset + m_table_index];
+//  if(m_trigger)
+//  {
+//    m_table_index++;
+//    m_trigger = m_table_index < m_trigger_index;
+//  }
+//}
 
-void ae_fade_table::stop()
-{
-  m_table_index = 0;
-  m_event = FadeEvent::None;
-  m_trigger = false;
-}
+//void ae_fade_table::stop()
+//{
+//  m_table_index = 0;
+//  m_event = FadeEvent::None;
+//  m_trigger = false;
+//}
 
 // std::atomic variation of FadeTable
 
@@ -114,30 +114,30 @@ float atomic_fade_table::getValue()
 
 // current Fader implementation
 
-ae_fader::ae_fader()
-{
-}
+//ae_fader::ae_fader()
+//{
+//}
 
-void ae_fader::init(float *_fade_table)
-{
-  m_data[0] = &m_zero;
-  m_data[1] = _fade_table;
-  m_data[2] = &m_one;
-  m_index = m_current = 2;
-}
+//void ae_fader::init(float *_fade_table)
+//{
+//  m_data[0] = &m_zero;
+//  m_data[1] = _fade_table;
+//  m_data[2] = &m_one;
+//  m_index = m_current = 2;
+//}
 
-void ae_fader::pick(const uint32_t _index)
-{
-  m_index = _index;
-  m_current = 1;
-}
+//void ae_fader::pick(const uint32_t _index)
+//{
+//  m_index = _index;
+//  m_current = 1;
+//}
 
-float ae_fader::get_value()
-{
-  return *m_data[m_current];
-}
+//float ae_fader::get_value()
+//{
+//  return *m_data[m_current];
+//}
 
-void ae_fader::stop()
-{
-  m_current = m_index;
-}
+//void ae_fader::stop()
+//{
+//  m_current = m_index;
+//}

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -3,13 +3,15 @@
 /******************************************************************************/
 /** @file       ae_fadepoint.cpp
     @date
-    @version    1.7-0
+    @version    1.7-4
     @author     M. Seeber
     @brief      fadepoint generator
     @todo
 *******************************************************************************/
 
 #include <cmath>
+
+// current FadeTable implementation
 
 ae_fade_table::ae_fade_table()
 {
@@ -74,6 +76,43 @@ void ae_fade_table::stop()
   m_event = FadeEvent::None;
   m_trigger = false;
 }
+
+// std::atomic variation of FadeTable
+
+atomic_fade_table::atomic_fade_table()
+{
+}
+
+void atomic_fade_table::init(const float _samplerate)
+{
+  const float fade_time = 1e-3f * C15::Config::fade_time_ms * _samplerate;
+  const float fade_dx = 1.0f / (fade_time - 1.0f);
+  const uint32_t data_size = static_cast<uint32_t>(fade_time);
+  m_finalMuteRampIndex = data_size - 1;
+  m_data.resize(data_size);
+  for(uint32_t i = 0; i < data_size; i++)
+  {
+    const float fade_value = std::sin(1.5707963f * static_cast<float>(i) * fade_dx);
+    m_data[i] = fade_value * fade_value;
+  }
+}
+
+uint32_t atomic_fade_table::getTargetRampIndex() const
+{
+  return m_muteTasks ? 0 : m_finalMuteRampIndex;
+}
+
+void atomic_fade_table::setTask(const MuteTask _task)
+{
+  m_muteTasks |= _task;
+}
+
+void atomic_fade_table::updateValue(const uint32_t _index)
+{
+  m_value = m_data[_index];
+}
+
+// current Fader implementation
 
 ae_fader::ae_fader()
 {

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -11,74 +11,6 @@
 
 #include <cmath>
 
-// current FadeTable implementation
-
-//ae_fade_table::ae_fade_table()
-//{
-//}
-
-//void ae_fade_table::init(const float _samplerate)
-//{
-//  float fade_time = 1e-3f * C15::Config::fade_time_ms * _samplerate, fade_dx = 1.0f / (fade_time - 1.0f);
-
-//  m_table_index = 0;
-//  m_trigger = false;
-//  m_trigger_index = static_cast<uint32_t>(fade_time);
-//  m_data.resize(2 * m_trigger_index);
-//  m_event = FadeEvent::None;
-//  m_value = 0.0f;
-
-//  uint32_t i;
-//  for(i = 0; i < m_trigger_index - 1; i++)
-//  {
-//    float x = std::cos(1.5707963f * static_cast<float>(i) * fade_dx);
-//    m_data[i] = x * x;
-//  }
-//  m_data[i] = 0.0f;
-//  for(i = 0; i < m_trigger_index; i++)
-//  {
-//    m_data[m_trigger_index + i] = m_data[m_trigger_index - i - 1];
-//  }
-//}
-
-//bool ae_fade_table::enable(const FadeEvent _event, const uint32_t _in_or_out)
-//{
-//  if(m_event == FadeEvent::None)
-//  {
-//    m_event = _event;
-//    m_trigger = true;
-//    m_table_offset = _in_or_out * m_trigger_index;
-//    m_table_index = 0;
-//    m_value = m_data[m_table_offset];
-//    return true;
-//  }
-//  return false;
-//}
-
-//bool ae_fade_table::get_state()
-//{
-//  return m_table_index == m_trigger_index;
-//}
-
-//void ae_fade_table::render()
-//{
-//  m_value = m_data[m_table_offset + m_table_index];
-//  if(m_trigger)
-//  {
-//    m_table_index++;
-//    m_trigger = m_table_index < m_trigger_index;
-//  }
-//}
-
-//void ae_fade_table::stop()
-//{
-//  m_table_index = 0;
-//  m_event = FadeEvent::None;
-//  m_trigger = false;
-//}
-
-// std::atomic variation of FadeTable
-
 atomic_fade_table::atomic_fade_table()
 {
 }
@@ -111,33 +43,3 @@ float atomic_fade_table::getValue()
 {
   return m_data[m_currentMuteRampIndex];
 }
-
-// current Fader implementation
-
-//ae_fader::ae_fader()
-//{
-//}
-
-//void ae_fader::init(float *_fade_table)
-//{
-//  m_data[0] = &m_zero;
-//  m_data[1] = _fade_table;
-//  m_data[2] = &m_one;
-//  m_index = m_current = 2;
-//}
-
-//void ae_fader::pick(const uint32_t _index)
-//{
-//  m_index = _index;
-//  m_current = 1;
-//}
-
-//float ae_fader::get_value()
-//{
-//  return *m_data[m_current];
-//}
-
-//void ae_fader::stop()
-//{
-//  m_current = m_index;
-//}

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -88,7 +88,7 @@ void atomic_fade_table::init(const float _samplerate)
   const float fade_time = 1e-3f * C15::Config::fade_time_ms * _samplerate;
   const float fade_dx = 1.0f / (fade_time - 1.0f);
   const uint32_t data_size = static_cast<uint32_t>(fade_time);
-  m_finalMuteRampIndex = data_size - 1;
+  m_currentMuteRampIndex = m_finalMuteRampIndex = data_size - 1;
   m_data.resize(data_size);
   for(uint32_t i = 0; i < data_size; i++)
   {
@@ -107,9 +107,9 @@ void atomic_fade_table::setTask(const MuteTask _task)
   m_muteTasks |= _task;
 }
 
-void atomic_fade_table::updateValue(const uint32_t _index)
+float atomic_fade_table::getValue()
 {
-  m_value = m_data[_index];
+  return m_data[m_currentMuteRampIndex];
 }
 
 // current Fader implementation

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -64,10 +64,7 @@ void ae_fade_table::render()
   if(m_trigger)
   {
     m_table_index++;
-    if(m_table_index == m_trigger_index)
-    {
-      m_trigger = false;
-    }
+    m_trigger = m_table_index < m_trigger_index;
   }
 }
 
@@ -75,6 +72,7 @@ void ae_fade_table::stop()
 {
   m_table_index = 0;
   m_event = FadeEvent::None;
+  m_trigger = false;
 }
 
 ae_fader::ae_fader()

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.cpp
@@ -29,7 +29,7 @@ void atomic_fade_table::init(const float _samplerate)
   }
 }
 
-bool atomic_fade_table::getTaskStatus()
+bool atomic_fade_table::evalTaskStatus()
 {
   const uint32_t targetRampIndex = m_muteTasks ? 0 : m_finalMuteRampIndex;
   if(m_currentMuteRampIndex != targetRampIndex)

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -3,7 +3,7 @@
 /******************************************************************************/
 /** @file       ae_fadepoint.h
     @date
-    @version    1.7-0
+    @version    1.7-4
     @author     M. Seeber
     @brief      fadepoint generator
     @todo
@@ -11,6 +11,9 @@
 
 #include <c15_config.h>
 #include <vector>
+#include <atomic>
+
+// current FadeTable implementation
 
 enum class FadeEvent
 {
@@ -39,6 +42,37 @@ class ae_fade_table
   uint32_t m_table_index, m_table_offset, m_trigger_index;
   bool m_trigger;
 };
+
+// std::atomic variation of FadeTable
+
+enum MuteTask
+{
+  Trigger_Tone = 1 << 0,
+  Trigger_Unison = 1 << 1,
+  Trigger_Mono = 1 << 2,
+  Recall_Single = 1 << 3,
+  Recall_Split = 1 << 4,
+  Recall_Layer = 1 << 5
+};
+
+class atomic_fade_table
+{
+ public:
+  float m_value = 0.0f;
+  uint32_t m_currentMuteRampIndex = 0;
+  std::atomic<uint32_t> m_muteTasks = 0;
+  atomic_fade_table();
+  void init(const float _samplerate);
+  uint32_t getTargetRampIndex() const;
+  void setTask(const MuteTask _task);
+  void updateValue(const uint32_t _index);
+
+ private:
+  uint32_t m_finalMuteRampIndex = 0;
+  std::vector<float> m_data;
+};
+
+// current Fader implementation
 
 class ae_fader
 {

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -47,25 +47,24 @@ class ae_fade_table
 
 enum MuteTask
 {
-  Trigger_Tone = 1 << 0,
-  Trigger_Unison = 1 << 1,
-  Trigger_Mono = 1 << 2,
-  Recall_Single = 1 << 3,
-  Recall_Split = 1 << 4,
-  Recall_Layer = 1 << 5
+  MuteTask_Trigger_Tone = 1 << 0,
+  MuteTask_Trigger_Unison = 1 << 1,
+  MuteTask_Trigger_Mono = 1 << 2,
+  MuteTask_Recall_Single = 1 << 3,
+  MuteTask_Recall_Split = 1 << 4,
+  MuteTask_Recall_Layer = 1 << 5
 };
 
 class atomic_fade_table
 {
  public:
-  float m_value = 0.0f;
   uint32_t m_currentMuteRampIndex = 0;
   std::atomic<uint32_t> m_muteTasks = 0;
   atomic_fade_table();
   void init(const float _samplerate);
   uint32_t getTargetRampIndex() const;
   void setTask(const MuteTask _task);
-  void updateValue(const uint32_t _index);
+  float getValue();
 
  private:
   uint32_t m_finalMuteRampIndex = 0;

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -13,38 +13,6 @@
 #include <vector>
 #include <atomic>
 
-// current FadeTable implementation
-
-//enum class FadeEvent
-//{
-//  None,
-//  RecallMute,
-//  ToneMute,
-//  UnisonMute,
-//  MonoMute,
-//  Unmute  // unmute is common
-//};
-
-//class ae_fade_table
-//{
-// public:
-//  FadeEvent m_event;
-//  float m_value;
-//  ae_fade_table();
-//  void init(const float _samplerate);
-//  bool enable(const FadeEvent _event, const uint32_t _in_or_out);
-//  bool get_state();
-//  void render();
-//  void stop();
-
-// private:
-//  std::vector<float> m_data;
-//  uint32_t m_table_index, m_table_offset, m_trigger_index;
-//  bool m_trigger;
-//};
-
-// std::atomic variation of FadeTable
-
 enum MuteTask
 {
   MuteTask_Trigger_Tone = 1 << 0,
@@ -70,23 +38,3 @@ class atomic_fade_table
   uint32_t m_finalMuteRampIndex = 0;
   std::vector<float> m_data;
 };
-
-// current Fader implementation
-
-//class ae_fader
-//{
-// public:
-//  uint32_t m_preloaded_layerId;  // context-agnostic (mono and unison) latch for layer focus
-//  float m_preloaded_position;    // context-agnostic (mono and unison) latch for changed parameter position
-//  ae_fader();
-//  void init(float* _fade_table);
-//  void pick(const uint32_t _index);
-//  float get_value();
-//  void stop();
-
-// private:
-//  float* m_data[3];
-//  float m_zero = 0.0f;
-//  float m_one = 1.0f;
-//  uint32_t m_index, m_current;
-//};

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -26,15 +26,14 @@ enum MuteTask
 class atomic_fade_table
 {
  public:
-  uint32_t m_currentMuteRampIndex = 0;
   std::atomic<uint32_t> m_muteTasks = 0;
   atomic_fade_table();
   void init(const float _samplerate);
-  uint32_t getTargetRampIndex() const;
+  bool getTaskStatus();
   void setTask(const MuteTask _task);
   float getValue();
 
  private:
-  uint32_t m_finalMuteRampIndex = 0;
+  uint32_t m_currentMuteRampIndex = 0, m_finalMuteRampIndex = 0;
   std::vector<float> m_data;
 };

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -15,33 +15,33 @@
 
 // current FadeTable implementation
 
-enum class FadeEvent
-{
-  None,
-  RecallMute,
-  ToneMute,
-  UnisonMute,
-  MonoMute,
-  Unmute  // unmute is common
-};
+//enum class FadeEvent
+//{
+//  None,
+//  RecallMute,
+//  ToneMute,
+//  UnisonMute,
+//  MonoMute,
+//  Unmute  // unmute is common
+//};
 
-class ae_fade_table
-{
- public:
-  FadeEvent m_event;
-  float m_value;
-  ae_fade_table();
-  void init(const float _samplerate);
-  bool enable(const FadeEvent _event, const uint32_t _in_or_out);
-  bool get_state();
-  void render();
-  void stop();
+//class ae_fade_table
+//{
+// public:
+//  FadeEvent m_event;
+//  float m_value;
+//  ae_fade_table();
+//  void init(const float _samplerate);
+//  bool enable(const FadeEvent _event, const uint32_t _in_or_out);
+//  bool get_state();
+//  void render();
+//  void stop();
 
- private:
-  std::vector<float> m_data;
-  uint32_t m_table_index, m_table_offset, m_trigger_index;
-  bool m_trigger;
-};
+// private:
+//  std::vector<float> m_data;
+//  uint32_t m_table_index, m_table_offset, m_trigger_index;
+//  bool m_trigger;
+//};
 
 // std::atomic variation of FadeTable
 
@@ -73,20 +73,20 @@ class atomic_fade_table
 
 // current Fader implementation
 
-class ae_fader
-{
- public:
-  uint32_t m_preloaded_layerId;  // context-agnostic (mono and unison) latch for layer focus
-  float m_preloaded_position;    // context-agnostic (mono and unison) latch for changed parameter position
-  ae_fader();
-  void init(float* _fade_table);
-  void pick(const uint32_t _index);
-  float get_value();
-  void stop();
+//class ae_fader
+//{
+// public:
+//  uint32_t m_preloaded_layerId;  // context-agnostic (mono and unison) latch for layer focus
+//  float m_preloaded_position;    // context-agnostic (mono and unison) latch for changed parameter position
+//  ae_fader();
+//  void init(float* _fade_table);
+//  void pick(const uint32_t _index);
+//  float get_value();
+//  void stop();
 
- private:
-  float* m_data[3];
-  float m_zero = 0.0f;
-  float m_one = 1.0f;
-  uint32_t m_index, m_current;
-};
+// private:
+//  float* m_data[3];
+//  float m_zero = 0.0f;
+//  float m_one = 1.0f;
+//  uint32_t m_index, m_current;
+//};

--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_fadepoint.h
@@ -29,7 +29,7 @@ class atomic_fade_table
   std::atomic<uint32_t> m_muteTasks = 0;
   atomic_fade_table();
   void init(const float _samplerate);
-  bool getTaskStatus();
+  bool evalTaskStatus();
   void setTask(const MuteTask _task);
   float getValue();
 

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1096,7 +1096,7 @@ void dsp_host_dual::render()
 {
   // clock rendering & fadepoint muteTasks
   m_clock.render();
-  if(m_fade.getTaskStatus())
+  if(m_fade.evalTaskStatus())
   {
     evalMuteTasks();
   }

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -868,9 +868,9 @@ void dsp_host_dual::localUnisonVoicesChg(const nltools::msg::UnmodulateableParam
       nltools::Log::info("unison_voices_edit(layer:", layerId, ", pos:", param->m_position, ")");
     }
     // application now via fade point
-    m_new_fade.setTask(MuteTask_Trigger_Unison);
     m_preloaded_layerId = layerId;
     m_preloaded_position = param->m_position;
+    m_new_fade.setTask(MuteTask_Trigger_Unison);
   }
 }
 
@@ -886,9 +886,9 @@ void dsp_host_dual::localMonoEnableChg(const nltools::msg::UnmodulateableParamet
     }
     param->m_scaled = scale(param->m_scaling, param->m_position);
     // application now via fade point
-    m_new_fade.setTask(MuteTask_Trigger_Mono);
     m_preloaded_layerId = layerId;
     m_preloaded_position = param->m_scaled;
+    m_new_fade.setTask(MuteTask_Trigger_Mono);
   }
 }
 void dsp_host_dual::localMonoPriorityChg(const nltools::msg::UnmodulateableParameterChangedMessage& _msg)
@@ -1096,7 +1096,6 @@ void dsp_host_dual::render()
 {
   // clock & fadepoint rendering
   m_clock.render();
-  //  evalFadePoint();
   const uint32_t targetRampIndex = m_new_fade.getTargetRampIndex();
   if(targetRampIndex != m_new_fade.m_currentMuteRampIndex)
   {

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1094,26 +1094,11 @@ uint32_t dsp_host_dual::onSettingToneToggle()
 
 void dsp_host_dual::render()
 {
-  // clock & fadepoint rendering
+  // clock rendering & fadepoint muteTasks
   m_clock.render();
-  const uint32_t targetRampIndex = m_fade.getTargetRampIndex();
-  if(targetRampIndex != m_fade.m_currentMuteRampIndex)
+  if(m_fade.getTaskStatus())
   {
-    if(m_fade.m_currentMuteRampIndex > targetRampIndex)
-    {
-      // fade out
-      m_fade.m_currentMuteRampIndex--;
-      if(m_fade.m_currentMuteRampIndex == targetRampIndex)
-      {
-        // fade out completed -> mute tasks
-        evalMuteTasks();
-      }
-    }
-    else
-    {
-      // fade in
-      m_fade.m_currentMuteRampIndex++;
-    }
+    evalMuteTasks();
   }
   // slow rendering
   if(m_clock.m_slow)

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -577,6 +577,7 @@ void dsp_host_dual::onPresetMessage(const nltools::msg::SinglePresetMessage& _ms
   if(m_glitch_suppression)
   {
     // glitch suppression: start outputMute fade
+    m_fade.stop();
     m_fade.enable(FadeEvent::RecallMute, 0);  // enable fader with event
     m_output_mute.pick(0);                    // pickup fade-out
   }
@@ -599,6 +600,7 @@ void dsp_host_dual::onPresetMessage(const nltools::msg::SplitPresetMessage& _msg
   }
   if(m_glitch_suppression)
   {
+    m_fade.stop();
     m_fade.enable(FadeEvent::RecallMute, 0);
     m_output_mute.pick(0);
   }
@@ -620,6 +622,7 @@ void dsp_host_dual::onPresetMessage(const nltools::msg::LayerPresetMessage& _msg
   }
   if(m_glitch_suppression)
   {
+    m_fade.stop();
     m_fade.enable(FadeEvent::RecallMute, 0);
     m_output_mute.pick(0);
   }

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -118,6 +118,7 @@ class dsp_host_dual
   // dsp components
   ae_fade_table m_fade;
   ae_fader m_output_mute;
+  atomic_fade_table m_new_fade;
   PolySection m_poly[2];
   MonoSection m_mono[2];
   LayerSignalCollection m_z_layers[2];
@@ -149,6 +150,7 @@ class dsp_host_dual
   void localTransition(const uint32_t _layer, const Direct_Param* _param, const Time_Aspect _time);
   void localTransition(const uint32_t _layer, const Target_Param* _param, const Time_Aspect _time);
   void evalFadePoint();
+  void evalMuteTasks();
   void evalPolyChg(const C15::Properties::LayerId _layerId,
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _monoEnable);

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -111,13 +111,10 @@ class dsp_host_dual
   Engine::Handle::Time_Handle m_time;
   // layer handling
   C15::Properties::LayerMode m_layer_mode, m_preloaded_layer_mode;
-  //  uint32_t m_layer_focus = 0;  // probably obsolete
   // global dsp components
   GlobalSection m_global;
   VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
   // dsp components
-  //  ae_fade_table m_fade;
-  //  ae_fader m_output_mute;
   atomic_fade_table m_new_fade;
   PolySection m_poly[2];
   MonoSection m_mono[2];
@@ -150,7 +147,6 @@ class dsp_host_dual
   void globalTransition(const Direct_Param* _param, const Time_Aspect _time);
   void localTransition(const uint32_t _layer, const Direct_Param* _param, const Time_Aspect _time);
   void localTransition(const uint32_t _layer, const Target_Param* _param, const Time_Aspect _time);
-  //  void evalFadePoint();
   void evalMuteTasks();
   void evalPolyChg(const C15::Properties::LayerId _layerId,
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -111,7 +111,7 @@ class dsp_host_dual
   Engine::Handle::Time_Handle m_time;
   // layer handling
   C15::Properties::LayerMode m_layer_mode, m_preloaded_layer_mode;
-  uint32_t m_layer_focus = 0;  // probably obsolete
+  //  uint32_t m_layer_focus = 0;  // probably obsolete
   // global dsp components
   GlobalSection m_global;
   VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
@@ -125,7 +125,8 @@ class dsp_host_dual
   // helper values
   const float m_format_vel = 16383.0f / 127.0f, m_format_hw = 16000.0f / 127.0f, m_format_pb = 16000.0f / 16383.0f,
               m_norm_vel = 1.0f / 16383.0f, m_norm_hw = 1.0f / 16000.0f;
-  uint32_t m_key_pos = 0, m_tone_state = 0;
+  uint32_t m_key_pos = 0, m_tone_state = 0, m_preloaded_layerId = 0;
+  float m_preloaded_position = 0.0f;
   bool m_key_valid = false, m_layer_changed = false, m_glitch_suppression = false;
   // handles for inconvenient stuff
   C15::Properties::HW_Return_Behavior getBehavior(const ReturnMode _mode);

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -116,8 +116,8 @@ class dsp_host_dual
   GlobalSection m_global;
   VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
   // dsp components
-  ae_fade_table m_fade;
-  ae_fader m_output_mute;
+  //  ae_fade_table m_fade;
+  //  ae_fader m_output_mute;
   atomic_fade_table m_new_fade;
   PolySection m_poly[2];
   MonoSection m_mono[2];
@@ -150,7 +150,7 @@ class dsp_host_dual
   void globalTransition(const Direct_Param* _param, const Time_Aspect _time);
   void localTransition(const uint32_t _layer, const Direct_Param* _param, const Time_Aspect _time);
   void localTransition(const uint32_t _layer, const Target_Param* _param, const Time_Aspect _time);
-  void evalFadePoint();
+  //  void evalFadePoint();
   void evalMuteTasks();
   void evalPolyChg(const C15::Properties::LayerId _layerId,
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,

--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -115,7 +115,7 @@ class dsp_host_dual
   GlobalSection m_global;
   VoiceAllocation<C15::Config::total_polyphony, C15::Config::local_polyphony, C15::Config::key_count> m_alloc;
   // dsp components
-  atomic_fade_table m_new_fade;
+  atomic_fade_table m_fade;
   PolySection m_poly[2];
   MonoSection m_mono[2];
   LayerSignalCollection m_z_layers[2];


### PR DESCRIPTION
Trying to tackle and make sense of Recall-Related Bugs (see #1600):
- fadepoint: sometimes fails to recover, staying muted
- voice reset: recalling between Layer Presets with the same Unison Voices resets Envelopes nevertheless (it shouldn't)
- wrong sound: sometimes, loaded Presets seem to fail to produce the right sound (observed with Layer <--> Layer, Layer <--> Single, Single <--> Single Presets)