### PR TITLE
WebUI: Close Load To Part if no longer applicable

### DIFF
--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
@@ -18,6 +18,7 @@ import com.nonlinearlabs.client.Renameable;
 import com.nonlinearlabs.client.ServerProxy;
 import com.nonlinearlabs.client.StoreSelectMode;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel;
+import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.SoundType;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.VoiceGroup;
 import com.nonlinearlabs.client.dataModel.presetManager.PresetSearch;
 import com.nonlinearlabs.client.dataModel.setup.SetupModel.BooleanValues;
@@ -121,6 +122,14 @@ public class PresetManager extends MapsLayout {
 
 		PresetSearch.get().results.onChange(b -> {
 			zoomToAllFilterMatches();
+			return true;
+		});
+
+		EditBufferModel.get().soundType.onChange(type -> {
+			if(type == SoundType.Single) {
+				endLoadToPartMode();
+				return true;
+			}
 			return true;
 		});
 


### PR DESCRIPTION
close load to part on editbuffer type change that can happen if editbuffer was converted or a whole preset was loaded