### PR TITLE
fix layer-sound specific param smoother issue

### DIFF
--- a/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2215,6 +2215,11 @@ void dsp_host_dual::recallLayer(const nltools::msg::LayerPresetMessage& _msg)
   }
   // local updates: unison, mono
   localPolyRcl(0, msg->unison, msg->mono);
+  // transfer unison detune, phase, pan and mono glide to other part for proper smoother values
+  localParRcl(1, msg->unison.detune);
+  localParRcl(1, msg->unison.phase);
+  localParRcl(1, msg->unison.pan);
+  localParRcl(1, msg->mono.glide);
   // local updates (each layer)
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {


### PR DESCRIPTION
In the Audio Engine, the internal smoothers were not started for Part II,  when a Layer Preset arrives. This caused Unison Clusters to only work properly in one Part. This PR here fixes that and a merge yields the following todo list in our main PR #1690 :

![Conversion_4](https://user-images.githubusercontent.com/37212609/79491825-4baa1280-801f-11ea-9cd6-4bee9e750bed.png)
