### PR TITLE
In order to measure the cpu load our ePC is capable to handle,

### DIFF
--- a/projects/audio-engine/src/AudioEngineOptions.cpp
+++ b/projects/audio-engine/src/AudioEngineOptions.cpp
@@ -38,6 +38,8 @@ AudioEngineOptions::AudioEngineOptions(int &argc, char **&argv)
   add(mainGroup, m_numPeriods, "num-periods", 'n', "alsa audio input number of periods");
   add(mainGroup, m_alsaBufferSize, "buffer-size", 'b', "alsa audio input ring buffer size");
   add(mainGroup, m_playgroundHost, "playground-host", 'x', "Where to find the playground");
+  add(mainGroup, m_cpuBurningSines, "num-sines", 'u',
+      "Do not run the c15 synth, but run a lot of sines in order to burn CPU.");
 
   ctx.set_main_group(mainGroup);
   ctx.set_help_enabled(true);
@@ -116,4 +118,9 @@ int AudioEngineOptions::getPolyphony() const
 bool AudioEngineOptions::doMeasurePerformance()
 {
   return m_measurePerformance;
+}
+
+int AudioEngineOptions::getNumCpuBurningSines() const
+{
+  return m_cpuBurningSines;
 }

--- a/projects/audio-engine/src/AudioEngineOptions.h
+++ b/projects/audio-engine/src/AudioEngineOptions.h
@@ -25,6 +25,7 @@ class AudioEngineOptions
   int getAlsaRingBufferSize() const;
 
   std::string getPlaygroundHost() const;
+  int getNumCpuBurningSines() const;
 
  private:
   bool m_fatalXRuns = false;
@@ -41,4 +42,5 @@ class AudioEngineOptions
   int m_framesPerPeriod = 96;
   int m_numPeriods = 2;
   int m_alsaBufferSize = 96 * 2;
+  int m_cpuBurningSines = 0;
 };

--- a/projects/audio-engine/src/synth/CPUBurningSynth.cpp
+++ b/projects/audio-engine/src/synth/CPUBurningSynth.cpp
@@ -1,0 +1,32 @@
+#include "CPUBurningSynth.h"
+#include "AudioEngineOptions.h"
+#include <math.h>
+
+CPUBurningSynth::CPUBurningSynth(const AudioEngineOptions *options)
+    : Synth(options)
+{
+}
+
+void CPUBurningSynth::doMidi(const MidiEvent &)
+{
+}
+
+void CPUBurningSynth::doAudio(SampleFrame *target, size_t numFrames)
+{
+  for(size_t i = 0; i < numFrames; i++)
+  {
+    target[i].left = target[i].right = 0;
+
+    for(int j = 0; j < getOptions()->getNumCpuBurningSines(); j++)
+    {
+      target[i].left += 0.000001f * std::sin(m_phase++ / 1000);
+      target[i].right += 0.000001f * std::sin(m_phase++ / 1000);
+
+      if(m_phase > 1000)
+        m_phase = 0;
+    }
+
+    target[i].left *= 0.000001f;
+    target[i].right *= 0.000001f;
+  }
+}

--- a/projects/audio-engine/src/synth/CPUBurningSynth.h
+++ b/projects/audio-engine/src/synth/CPUBurningSynth.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Synth.h"
+
+class CPUBurningSynth : public Synth
+{
+ public:
+  CPUBurningSynth(const AudioEngineOptions *options);
+
+  void doMidi(const MidiEvent &event) override;
+  void doAudio(SampleFrame *target, size_t numFrames) override;
+
+ private:
+  float m_phase = 0;
+};

--- a/projects/nltools/src/nltools/messaging/Messaging.cpp
+++ b/projects/nltools/src/nltools/messaging/Messaging.cpp
@@ -31,7 +31,9 @@ namespace nltools
         gsize numBytes = 0;
         auto data = reinterpret_cast<const uint16_t *>(s->get_data(numBytes));
         auto type = static_cast<MessageType>(data[0]);
-        signals.at(std::make_pair(type, endPoint))(s);
+        auto it = signals.find(std::make_pair(type, endPoint));
+        if(it != signals.end())
+          it->second(s);
       }
 
       static void createInChannels(const Configuration &conf)


### PR DESCRIPTION
this patch adds a CpuBurningSynth. If commandline parameter "-u N"
is used, the CpuBuringSynth will be installed instead of the C15Synth.
The synth will then create a signal of N stereo sines (= 2 x N sine
computations per sample frame). By experimenting with "-u"-parameter,
developers can measure, how buffer sizes (latency),
buffer underruns, and CPU load (CPU load can be monitored in the shell)
depend on each other.