### PR TITLE
enabled ae improvements

### DIFF
--- a/projects/audio-engine/src/synth/c15-audio-engine/ae_potential_improvements.h
+++ b/projects/audio-engine/src/synth/c15-audio-engine/ae_potential_improvements.h
@@ -23,7 +23,7 @@
 
 // proposal declaration
 
-#define __POTENTIAL_IMPROVEMENT_PROPOSAL__ __POTENTIAL_IMPROVEMENT_DISABLED__
+#define __POTENTIAL_IMPROVEMENT_PROPOSAL__ __POTENTIAL_IMPROVEMENT_ENABLED__
 #define __POTENTIAL_IMPROVEMENT_NUMERIC_TESTS__ __POTENTIAL_IMPROVEMENT_DISABLED__
 // - enable or disable:
 //   1) implementations of potential improvements


### PR DESCRIPTION
At this Point, we are confident enough to have the latest Optimizations for the AudioEngine enabled by default, reliably reducing CPU consumption significantly.

For now, all optimization features still are optional and could still be disbabled.
When thorough testing with these features for a while reveals no issues, the features will be made permanent, and the code will be cleaned up.

If a direct comparison of a particular master commit needs to be done (comparing optimizations enabled versus disabled), I suggest to branch off from the commit, and disabling the optimizations in order to generate a non-optimized comparison build. (See Usage)