### PR TITLE
added chkphy service and scrpt

### DIFF
--- a/projects/bbbb/CMakeLists.txt
+++ b/projects/bbbb/CMakeLists.txt
@@ -46,12 +46,14 @@ configure_file(${PROJECT_SOURCE_DIR}/systemd/install-update-from-usb.service.in 
 configure_file(${PROJECT_SOURCE_DIR}/systemd/splash-screen.service.in ${PROJECT_BINARY_DIR}/systemd/splash-screen.service @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/systemd/handle-mmc-device-appeared-twice.service.in ${PROJECT_BINARY_DIR}/systemd/handle-mmc-device-appeared-twice.service @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/systemd/gettimefromepc.service.in ${PROJECT_BINARY_DIR}/systemd/gettimefromepc.service @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/systemd/chkphy.service.in ${PROJECT_BINARY_DIR}/systemd/chkphy.service @ONLY)
 
 install(FILES ${PROJECT_BINARY_DIR}/systemd/${PROJECT_NAME}.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 install(FILES ${PROJECT_BINARY_DIR}/systemd/install-update-from-usb.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 install(FILES ${PROJECT_BINARY_DIR}/systemd/splash-screen.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 install(FILES ${PROJECT_BINARY_DIR}/systemd/handle-mmc-device-appeared-twice.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 install(FILES ${PROJECT_BINARY_DIR}/systemd/gettimefromepc.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
+install(FILES ${PROJECT_BINARY_DIR}/systemd/chkphy.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 
 install(DIRECTORY DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}/multi-user.target.wants)
 install(DIRECTORY DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}/sysinit.target.wants)
@@ -65,6 +67,7 @@ install(CODE "execute_process(
     ln -sf ../splash-screen.service $DESTDIR/${SYSTEMD_SERVICES_INSTALL_DIR}/sysinit.target.wants/splash-screen.service
     ln -sf ../handle-mmc-device-appeared-twice.service $DESTDIR/${SYSTEMD_SERVICES_INSTALL_DIR}/sysinit.target.wants/handle-mmc-device-appeared-twice.service
     ln -sf ../gettimefromepc.service $DESTDIR/${SYSTEMD_SERVICES_INSTALL_DIR}/sysinit.target.wants/gettimefromepc.service
+    ln -sf ../chkphy.service $DESTDIR/${SYSTEMD_SERVICES_INSTALL_DIR}/sysinit.target.wants/chkphy.service
     \")")
 
 install(TARGETS ${PROJECT_NAME} DESTINATION ${C15_INSTALL_PATH}/${PROJECT_NAME})

--- a/projects/bbbb/systemd/chkphy.service.in
+++ b/projects/bbbb/systemd/chkphy.service.in
@@ -1,0 +1,18 @@
+[Unit]
+Description=Check BBB phy on boot and repower if PHY failed
+After=local-fs.target
+Before=
+Requires=
+Wants=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=@C15_INSTALL_PATH@/scripts/bbb-check-phy.sh
+RemainAfterExit=yes
+TimeoutSec=0
+
+# Output needs to appear in instance console output
+StandardOutput=journal+console
+
+[Install]
+WantedBy=network-online.target

--- a/projects/scripts/bbb/bbb-check-phy.sh
+++ b/projects/scripts/bbb/bbb-check-phy.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# first we sleep.
+# this gives plently of time for linux to mess with the RTC
+# (where does it do that set?) before we touch it. Otherwise it
+# occasionally updates it right between when we are doing our sets.
+
+# This also gives you a chance to abort in case something goes wrong
+# and avoid a infinite loop
+
+
+sleep 30
+
+if [ "$(phyreg test 18 13)" = "1" ]; then
+
+        sleep 1
+
+        NOW=$(date +%s)
+        echo "chkphy:Rebooting NOW=$NOW"
+        echo "Rebooting $NOW" >>/var/tmp/chkphy.log
+        # make sure that log message actually gets written before we pull the plug
+        sync
+
+        /usr/sbin/bbb-long-reset
+
+        while true;
+          do echo waiting to reboot
+          sleep 10
+        done
+fi
+
+echo "chkphy:eth0 good"


### PR DESCRIPTION
So, this is the implementation we found on the all mighty internet, which checks whether the ethernet port is dead and if it is, it power cycles the BBB.
https://wp.josh.com/2018/06/04/a-software-only-solution-to-the-vexing-beagle-bone-black-phy-issue/

at the moment the script waits for 30 (!!!) seconds. We should check, if that is really necessary. 