### PR TITLE
start bbbb after install update

### DIFF
--- a/projects/bbbb/systemd/bbbb.service.in
+++ b/projects/bbbb/systemd/bbbb.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nonlinear-Labs BeagleBoneBlackBridge
-After=syslog.target network.target systemd-modules-load.service
+After=syslog.target network.target systemd-modules-load.service install-update-from-usb.service
 
 [Service]
 ExecStart=@C15_INSTALL_PATH@/bbbb/bbbb --playground-host=192.168.10.10


### PR DESCRIPTION
fixes bug where epc starts loading banks and displays them via bbbb even though the install-update-from-usb.service yet has to run -> bbbb should start after install-update completed

@hhoegelo or was there a particular reason to remove that dependency in the first place? 