### PR TITLE
closes #1899

### DIFF
--- a/projects/playground/src/presets/EditBuffer.cpp
+++ b/projects/playground/src/presets/EditBuffer.cpp
@@ -1358,7 +1358,6 @@ void EditBuffer::loadSinglePresetIntoSplitPart(UNDO::Transaction *transaction, c
   setVoiceGroupName(transaction, preset->getName(), loadInto);
   initCrossFB(transaction);
   initFadeFrom(transaction, loadInto);
-  initRecallValues(transaction);
 }
 
 void EditBuffer::loadSinglePresetIntoLayerPart(UNDO::Transaction *transaction, const Preset *preset, VoiceGroup loadTo)
@@ -1393,8 +1392,6 @@ void EditBuffer::loadSinglePresetIntoLayerPart(UNDO::Transaction *transaction, c
   getParameterGroupByID({ "Mono", VoiceGroup::II })->undoableLoadDefault(transaction);
 
   setVoiceGroupName(transaction, preset->getName(), loadTo);
-
-  initRecallValues(transaction);
 }
 
 void EditBuffer::undoableLoadPresetPartIntoSplitSound(UNDO::Transaction *transaction, const Preset *preset,
@@ -1444,8 +1441,6 @@ void EditBuffer::undoableLoadPresetPartIntoSplitSound(UNDO::Transaction *transac
   else
     setVoiceGroupName(transaction, preset->getName(), copyTo);
 
-  initRecallValues(transaction);
-
   ae->toggleSuppressParameterChanges(transaction);
 }
 
@@ -1493,8 +1488,6 @@ void EditBuffer::undoableLoadPresetPartIntoLayerSound(UNDO::Transaction *transac
   else
     setVoiceGroupName(transaction, preset->getName(), copyTo);
 
-  initRecallValues(transaction);
-
   ae->toggleSuppressParameterChanges(transaction);
 }
 
@@ -1521,7 +1514,6 @@ void EditBuffer::undoableLoadPresetPartIntoSingleSound(UNDO::Transaction *transa
     setVoiceGroupName(transaction, preset->getName(), copyTo);
 
   initFadeParameters(transaction, copyTo);
-  initRecallValues(transaction);
 
   ae->toggleSuppressParameterChanges(transaction);
 }

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/LoadToPartShouldNotResetRecallBuffer.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/LoadToPartShouldNotResetRecallBuffer.cpp
@@ -1,0 +1,104 @@
+#include <testing/TestHelper.h>
+#include <testing/unit-tests/mock/MockPresetStorage.h>
+#include <parameter_declarations.h>
+#include <presets/Preset.h>
+#include <presets/PresetParameter.h>
+
+TEST_CASE("Load to Part should lead to changed star and recall buffer unchanged")
+{
+
+  MockPresetStorage presets;
+  auto singlePreset = presets.getSinglePreset();
+  auto layerPreset = presets.getLayerPreset();
+  auto splitPreset = presets.getSplitPreset();
+
+  auto preparePreset = [](auto transaction, Preset* preset, VoiceGroup vg) {
+    preset->findParameterByID({ C15::PID::Env_B_Att, vg }, true)->setValue(transaction, 0.187);
+  };
+
+  //Prepare Presets to be different from current EB
+  {
+    auto scope = TestHelper::createTestScope();
+    auto transaction = scope->getTransaction();
+    preparePreset(transaction, singlePreset, VoiceGroup::I);
+    preparePreset(transaction, layerPreset, VoiceGroup::I);
+    preparePreset(transaction, layerPreset, VoiceGroup::II);
+    preparePreset(transaction, splitPreset, VoiceGroup::I);
+    preparePreset(transaction, splitPreset, VoiceGroup::II);
+  }
+
+  auto eb = TestHelper::getEditBuffer();
+
+  auto loadPresetAndCheck = [&](auto preset, auto from, auto to) {
+    eb->undoableLoadToPart(preset, from, to);
+    CHECK(eb->findAnyParameterChanged());
+  };
+
+  WHEN("EB is Split")
+  {
+    TestHelper::initDualEditBuffer<SoundType::Split>();
+    WHEN("Single Preset loaded into I")
+    {
+      loadPresetAndCheck(singlePreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Single Preset loaded into II")
+    {
+      loadPresetAndCheck(singlePreset, VoiceGroup::I, VoiceGroup::II);
+    }
+
+    WHEN("Split Preset loaded into I")
+    {
+      loadPresetAndCheck(splitPreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Split Preset loaded into II")
+    {
+      loadPresetAndCheck(splitPreset, VoiceGroup::I, VoiceGroup::II);
+    }
+
+    WHEN("Layer Preset loaded into I")
+    {
+      loadPresetAndCheck(layerPreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Layer Preset loaded into II")
+    {
+      loadPresetAndCheck(layerPreset, VoiceGroup::I, VoiceGroup::II);
+    }
+  }
+
+  WHEN("EB is Layer")
+  {
+    TestHelper::initDualEditBuffer<SoundType::Layer>();
+    WHEN("Single Preset loaded into I")
+    {
+      loadPresetAndCheck(singlePreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Single Preset loaded into II")
+    {
+      loadPresetAndCheck(singlePreset, VoiceGroup::I, VoiceGroup::II);
+    }
+
+    WHEN("Split Preset loaded into I")
+    {
+      loadPresetAndCheck(splitPreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Split Preset loaded into II")
+    {
+      loadPresetAndCheck(splitPreset, VoiceGroup::I, VoiceGroup::II);
+    }
+
+    WHEN("Layer Preset loaded into I")
+    {
+      loadPresetAndCheck(layerPreset, VoiceGroup::I, VoiceGroup::I);
+    }
+
+    WHEN("Layer Preset loaded into II")
+    {
+      loadPresetAndCheck(layerPreset, VoiceGroup::I, VoiceGroup::II);
+    }
+  }
+}

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
@@ -164,11 +164,6 @@ TEST_CASE("Load Part I of Split into Layer Part I")
       CHECK(EBL::createValueHash(EBL::getFade<VoiceGroup::I>()) == oldFadeIHash);
       CHECK(EBL::createValueHash(EBL::getFade<VoiceGroup::II>()) == oldFadeIIHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -315,11 +310,6 @@ TEST_CASE("Load Part I of Split into Layer Part II")
     {
       CHECK(EBL::createValueHash(EBL::getFade<VoiceGroup::I>()) == oldFadeIHash);
       CHECK(EBL::createValueHash(EBL::getFade<VoiceGroup::II>()) == oldFadeIIHash);
-    }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
     }
   }
 }
@@ -477,11 +467,6 @@ TEST_CASE("Load Part I of Layer into Layer Part I")
       CHECK(oldFadeIHash == EBL::createHashOfVector(EBL::getFade<VoiceGroup::I>()));
       CHECK(oldFadeIIHash == EBL::createHashOfVector(EBL::getFade<VoiceGroup::II>()));
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -636,11 +621,6 @@ TEST_CASE("Load Part I of Layer into Layer Part II")
     {
       CHECK(oldFadeIHash == EBL::createHashOfVector(EBL::getFade<VoiceGroup::I>()));
       CHECK(oldFadeIIHash == EBL::createHashOfVector(EBL::getFade<VoiceGroup::II>()));
-    }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
     }
   }
 }

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
@@ -164,11 +164,6 @@ TEST_CASE("Load Part I of Split into Split Part I")
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -328,11 +323,6 @@ TEST_CASE("Load Part I of Split into Split Part II")
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -484,11 +474,6 @@ TEST_CASE("Load Part I of Layer into Split Part I")
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -635,11 +620,6 @@ TEST_CASE("Load Part II of Layer into Split Part II")
       CHECK(EBL::createHashOfVector(EBL::getMaster()) == oldMasterHash);
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
-    }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
     }
   }
 }

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToLayerSoundTests.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToLayerSoundTests.cpp
@@ -134,11 +134,6 @@ TEST_CASE("Load Single into Layer Part I")
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -267,11 +262,6 @@ TEST_CASE("Load Single into Layer Part II")
       CHECK(EBL::createHashOfVector(EBL::getMaster()) == oldMasterHash);
       CHECK(EBL::createHashOfVector(EBL::getModMatrix()) == oldMCMHash);
       CHECK(EBL::createHashOfVector(EBL::getScale()) == oldScaleHash);
-    }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
     }
   }
 }

--- a/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
+++ b/projects/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
@@ -140,11 +140,6 @@ TEST_CASE("Load Single into Split Part I")
     {
       CHECK(EBL::createHashOfVector(EBL::getFade<VoiceGroup::II>()) == oldFadeIIHash);
     }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
-    }
   }
 }
 
@@ -174,7 +169,7 @@ TEST_CASE("Load Single into Split Part II")
     unisonVoices->setValue(transaction, 1);  // <- setting cp in range 0..23
 
     preset->setName(transaction, "Ho");
-    
+
     TestHelper::changeAllParameters(transaction);
   }
 
@@ -271,11 +266,6 @@ TEST_CASE("Load Single into Split Part II")
     THEN("Fade II is Default")
     {
       CHECK(EBL::isDefaultLoaded(EBL::getFade<VoiceGroup::II>()));
-    }
-
-    THEN("EB unchanged")
-    {
-      CHECK_FALSE(eb->findAnyParameterChanged());
     }
   }
 }


### PR DESCRIPTION
removed `initRecallValues` on load to part actions, and removed all consequently failing tests -> added single test case for this behavior

closes #1899