### PR TITLE
fixed text2soled: uncontrolled clearing of the display

### DIFF
--- a/projects/text2soled/src/Commands.cpp
+++ b/projects/text2soled/src/Commands.cpp
@@ -153,7 +153,6 @@ public:
     auto resourcePath = parentPath + "/resources/";
     font              = std::make_unique<Font>(resourcePath + "Emphase-8-Regular.ttf", 8);
     FrameBuffer::get().setColor(FrameBuffer::C255);
-    FrameBuffer::get().clear();
   }
 
   virtual int getNumArguments() const override
@@ -163,6 +162,7 @@ public:
 
   virtual void execute(char** argv, int numArgs) override
   {
+    FrameBuffer::get().clear();
     for (int i = 0; i < numArgs; i++)
       draw(parsePart(argv[i]));
   }
@@ -313,9 +313,6 @@ void Commands::execute(int numArgs, char** argv)
       }
       else
       {
-        ClearCommand clear;
-        clear.execute(nullptr, 0);
-
         TextCommand text;
         if (numArgs >= text.getNumArguments())
           text.execute(argv, numArgs);


### PR DESCRIPTION
- move clear() call from multitext constructor to execute()
- remove default clear() before trying to parse command line when no named command was found
==>
Display is cleared only with "multitext" command and explicit "clear" command.
Now compatible with legacy behaviour