### PR TITLE
system call 'sync' hangs up to 10 seconds when called immediately

### DIFF
--- a/projects/bbbb/src/Application.cpp
+++ b/projects/bbbb/src/Application.cpp
@@ -1,14 +1,11 @@
 #include "Application.h"
 #include "io/Bridges.h"
-#include <fcntl.h>
 #include "BBBBOptions.h"
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include <nltools/messaging/Messaging.h>
 #include <giomm.h>
 #include <io/WiFiManager.h>
 #include <io/USBManager.h>
+#include <FileSystemSync.h>
 
 #ifdef _DEVELOPMENT_PC
 #include <ui/Window.h>
@@ -36,12 +33,8 @@ Application::Application(int numArgs, char **argv)
     , m_bridges(std::make_unique<Bridges>())
     , m_wifiManager(std::make_unique<WiFiManager>())
     , m_usbManager(std::make_unique<USBManager>())
+    , m_fsSync(std::make_unique<FileSystemSync>())
 {
-
-  nltools::msg::receive<nltools::msg::FileSystem::Sync>(nltools::msg::EndPoint::BeagleBone, [this](const auto &msg) {
-    sync();
-    nltools::Log::warning("Synced file system.");
-  });
 }
 
 Application::~Application() = default;

--- a/projects/bbbb/src/Application.h
+++ b/projects/bbbb/src/Application.h
@@ -8,6 +8,7 @@ class BBBBOptions;
 class Bridges;
 class WiFiManager;
 class USBManager;
+class FileSystemSync;
 
 class Application
 {
@@ -34,4 +35,5 @@ class Application
   std::unique_ptr<Bridges> m_bridges;
   std::unique_ptr<WiFiManager> m_wifiManager;
   std::unique_ptr<USBManager> m_usbManager;
+  std::unique_ptr<FileSystemSync> m_fsSync;
 };

--- a/projects/bbbb/src/FileSystemSync.cpp
+++ b/projects/bbbb/src/FileSystemSync.cpp
@@ -1,0 +1,49 @@
+#include "FileSystemSync.h"
+#include <nltools/messaging/Messaging.h>
+#include <nltools/messaging/Message.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+FileSystemSync::FileSystemSync()
+    : m_task(std::async(std::launch::async, [this] { doBackgroundSyncing(); }))
+{
+  nltools::msg::receive<nltools::msg::FileSystem::Sync>(nltools::msg::EndPoint::BeagleBone, [this](const auto &) {
+    nltools::Log::warning("Notify syncing file system ...");
+    std::unique_lock<std::mutex> l(m_mutex);
+    m_dirty = true;
+    m_cond.notify_all();
+    nltools::Log::warning("Notify syncing file system done.");
+  });
+}
+
+FileSystemSync::~FileSystemSync()
+{
+  nltools::Log::warning(__PRETTY_FUNCTION__, __LINE__);
+  {
+    std::unique_lock<std::mutex> l(m_mutex);
+    m_cancel = true;
+  }
+  m_cond.notify_all();
+  m_task.wait();
+  nltools::Log::warning(__PRETTY_FUNCTION__, __LINE__);
+}
+
+void FileSystemSync::doBackgroundSyncing()
+{
+  std::unique_lock<std::mutex> l(m_mutex);
+
+  while(!m_cancel)
+  {
+    if(!m_dirty)
+      m_cond.wait(l, [this] { return m_dirty || m_cancel; });
+
+    m_dirty = false;
+    l.unlock();
+    nltools::Log::warning("Syncing file system ...");
+    sync();
+    nltools::Log::warning("Syncing file system done.");
+    l.lock();
+  }
+}

--- a/projects/bbbb/src/FileSystemSync.h
+++ b/projects/bbbb/src/FileSystemSync.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <future>
+#include <condition_variable>
+#include <mutex>
+
+class FileSystemSync
+{
+ public:
+  FileSystemSync();
+  ~FileSystemSync();
+
+ private:
+  void doBackgroundSyncing();
+
+  std::future<void> m_task;
+  std::condition_variable m_cond;
+  std::mutex m_mutex;
+  bool m_cancel { false };
+  bool m_dirty { false };
+};

--- a/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankEditButtonMenu.cpp
+++ b/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankEditButtonMenu.cpp
@@ -18,6 +18,7 @@
 #include <device-info/DateTimeInfo.h>
 #include <xml/VersionAttribute.h>
 #include <tools/TimeTools.h>
+#include <nltools/GenericScopeGuard.h>
 
 static size_t s_lastSelectedButton = 0;
 
@@ -173,6 +174,7 @@ void BankEditButtonMenu::exportBank()
 
 void BankEditButtonMenu::writeSelectedBankToFile(Bank* selBank, const std::string& outFile)
 {
+  GenericScopeGuard syncAfterAllFileOperation([] {}, FileSystem::syncAll);
   SplashLayout::addStatus("Exporting " + selBank->getName(true));
   auto scope = UNDO::Scope::startTrashTransaction();
   selBank->setAttribute(scope->getTransaction(), "Date of Export File", TimeTools::getAdjustedIso());

--- a/projects/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
+++ b/projects/playground/src/proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.cpp
@@ -14,10 +14,12 @@
 #include <tools/TimeTools.h>
 #include <algorithm>
 #include <filesystem>
+#include <tools/FileSystem.h>
 #include <tools/StringTools.h>
 #include "USBStickAvailableView.h"
 #include <device-settings/DebugLevel.h>
 #include <iostream>
+#include <nltools/GenericScopeGuard.h>
 
 static const Rect c_fullRightSidePosition(129, 16, 126, 48);
 static constexpr const char c_tempBackupFile[] = "/nonlinear/nonlinear-c15-banks.xml.tar.gz";
@@ -80,6 +82,7 @@ void ExportBackupEditor::writeBackupToStream(std::unique_ptr<OutStream> stream)
 
 void ExportBackupEditor::exportBanks()
 {
+  GenericScopeGuard syncAfterAllFileOperation([] {}, FileSystem::syncAll);
   Application::get().stopWatchDog();
   writeBackupFileXML();
 

--- a/projects/playground/src/tools/FileSystem.cpp
+++ b/projects/playground/src/tools/FileSystem.cpp
@@ -133,7 +133,8 @@ Glib::ustring FileSystem::getFullPath(const Glib::RefPtr<Gio::File> &file)
 
 void FileSystem::syncAll()
 {
-  nltools::Log::warning("Syncing file systems");
+  nltools::Log::warning("Syncing file systems ...");
   sync();
   nltools::msg::send(nltools::msg::EndPoint::BeagleBone, nltools::msg::FileSystem::Sync());
+  nltools::Log::warning("Syncing file systems done.");
 }

--- a/projects/playground/src/xml/FileOutStream.cpp
+++ b/projects/playground/src/xml/FileOutStream.cpp
@@ -96,7 +96,6 @@ void FileOutStream::commit()
 
     auto oldName = getTmpFileName();
     FileSystem::rename(oldName, m_filename);
-    FileSystem::syncAll();
   }
 }
 


### PR DESCRIPTION
after booting the bbb.

Now, bbb's sync is called only if there is actually a chance that
the write operations target is the usb stick.

Also, syncing is done in background thread without blocking the main
thread anymore.