### PR TITLE
Just re-building the rootfs does not remove previously installed file…

### DIFF
--- a/build-tools/bbb/CMakeLists.txt
+++ b/build-tools/bbb/CMakeLists.txt
@@ -100,6 +100,8 @@ add_custom_command(
         'rm -rf /fs/nonlinux/output/target/usr/C15'
         'rm -rf /fs/nonlinux/output/target/usr/C15-\*'
         "cd /fs/nonlinux"
+        "rm -rf /fs/nonlinux/output/target"
+        "find /fs/nonlinux/output/ -name .stamp_target_installed -delete"
         "make C15-clean-for-reconfigure"
         "make C15-rebuild"
         "make lpc_bb_driver-clean-for-reconfigure"


### PR DESCRIPTION
…s from

output/target and thus from rootfs.
The only known generic solution is to always assemble the target dir from scratch
on a clean slate whenever something changes. Of course, this will increase
build times drastically, but reliability beats speed in this case.

fixes #1859 