### PR TITLE
it is not easily possible to reproduce #1978, but from looking

### DIFF
--- a/projects/playground/src/parameters/UnisonVoicesParameter.h
+++ b/projects/playground/src/parameters/UnisonVoicesParameter.h
@@ -5,14 +5,13 @@ class UnisonVoicesParameter : public UnmodulateableUnisonParameter
 {
  public:
   explicit UnisonVoicesParameter(ParameterGroup *group, VoiceGroup vg);
-  void updateScaling(UNDO::Transaction *transaction, SoundType type);
+  void updateScaling(SoundType type);
 
   void copyFrom(UNDO::Transaction *transaction, const PresetParameter *other) override;
   void copyTo(UNDO::Transaction *transaction, PresetParameter *other) const override;
 
  protected:
   bool shouldWriteDocProperties(tUpdateID knownRevision) const override;
-  bool didScalingChange() const;
 
   mutable bool m_scalingChanged = false;
 };

--- a/projects/playground/src/presets/EditBuffer.cpp
+++ b/projects/playground/src/presets/EditBuffer.cpp
@@ -880,11 +880,11 @@ void EditBuffer::undoableSetType(UNDO::Transaction *transaction, SoundType type)
   {
     auto swap = UNDO::createSwapData(type);
 
-    initUnisonVoicesScaling(transaction, type);
     cleanupParameterSelection(transaction, m_type, type);
 
     transaction->addSimpleCommand([=](auto state) {
       swap->swapWith(m_type);
+      initUnisonVoicesScaling(m_type);
       m_signalTypeChanged.send(m_type);
       onChange();
     });
@@ -1034,11 +1034,11 @@ void EditBuffer::undoableLoadPresetPartIntoPart(UNDO::Transaction *transaction, 
   }
 }
 
-void EditBuffer::initUnisonVoicesScaling(UNDO::Transaction *transaction, SoundType newType)
+void EditBuffer::initUnisonVoicesScaling(SoundType newType)
 {
   for(auto vg : { VoiceGroup::I, VoiceGroup::II })
     if(auto unisonParam = dynamic_cast<UnisonVoicesParameter *>(findParameterByID({ 249, vg })))
-      unisonParam->updateScaling(transaction, newType);
+      unisonParam->updateScaling(newType);
 }
 
 bool EditBuffer::isDualParameterForSoundType(const Parameter *parameter, SoundType type)

--- a/projects/playground/src/presets/EditBuffer.h
+++ b/projects/playground/src/presets/EditBuffer.h
@@ -193,7 +193,7 @@ class EditBuffer : public ParameterDualGroupSet
 
   friend class PresetManager;
   friend class LastLoadedPresetInfoSerializer;
-  void initUnisonVoicesScaling(UNDO::Transaction *transaction, SoundType newType);
+  void initUnisonVoicesScaling(SoundType newType);
 
   void initToFX(UNDO::Transaction *transaction);
   void copyAndInitGlobalMasterGroupToPartMasterGroups(UNDO::Transaction *transaction);

--- a/projects/playground/systemd/playground.service.in
+++ b/projects/playground/systemd/playground.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nonlinear-Labs Playground
-After=syslog.target network.target systemd-modules-load.service persistent.mount fix-overlay-order.service
+After=network.target systemd-modules-load.service persistent.mount fix-overlay-order.service
 
 [Service]
 ExecStart=@C15_INSTALL_PATH@/playground/playground --bbbb-host=192.168.10.11 --layouts=@C15_INSTALL_PATH@/playground/resources/templates


### PR DESCRIPTION
at the code I found that at least with undo of sound type
conversions, there should be issues. (Undo restores a hard coded
state, independent from what the previous sound type was).
There is a small chance that this patch maybe fixes #1978, but
as I can't reproduce it, I can not proof its fix.