### PR TITLE
Fixing this in a clean way is nearly impossible: buildroot just does

### DIFF
--- a/build-tools/bbb/CMakeLists.txt
+++ b/build-tools/bbb/CMakeLists.txt
@@ -106,6 +106,7 @@ add_custom_command(
         "make lpc_bb_driver-rebuild"
         "make espi_driver-clean-for-reconfigure"
         "make espi_driver-rebuild"
+        "rm -rf /fs/nonlinux/output/target/mnt/.not-mounted"
         "make"
         "cp /fs/nonlinux/output/images/rootfs.tar.gz /workdir/"
         "chown ${USER_ID}.${GROUP_ID} /workdir/rootfs.tar.gz"


### PR DESCRIPTION
not support cleaning the target dir. Thus, old artifacts that
we want to be sure to wipe away, have to be removed in the build rule.
Otherwise, switching between branches while re-using the pre-built buildroot
in fs.ext4 will create zombies in the final builds. (#1859)