### PR TITLE
WebUI created a new web-socket whenever the connection broke and closed

### DIFF
--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/WebSocketConnection.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/WebSocketConnection.java
@@ -15,6 +15,7 @@ import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.nonlinearlabs.client.dataModel.setup.SetupModel;
+import com.nonlinearlabs.client.world.Uuid;
 import com.nonlinearlabs.client.world.overlay.GWTDialog;
 
 class WebSocketConnection {
@@ -60,18 +61,19 @@ class WebSocketConnection {
 	}
 
 	ServerListener listener;
+	static String clientId = Uuid.random();
 
 	public void startPolling(ServerListener listener) {
 		Tracer.log("startPolling");
 		this.listener = listener;
 		if (Window.Location.getPort() == "8888") {
-			webSocketOpen(Window.Location.getHostName() + ":8080");
+			webSocketOpen(Window.Location.getHostName() + ":8080", clientId);
 		} else {
-			webSocketOpen(Window.Location.getHost());
+			webSocketOpen(Window.Location.getHost(), clientId);
 		}
 
 		SetupModel.get().systemSettings.deviceName.onChange(t -> {
-			if(lastDeviceName != null && !lastDeviceName.isEmpty() && !t.isEmpty() && lastDeviceName != t) {
+			if (lastDeviceName != null && !lastDeviceName.isEmpty() && !t.isEmpty() && lastDeviceName != t) {
 				notifyHostChanged(lastDeviceName, t);
 			}
 
@@ -85,9 +87,9 @@ class WebSocketConnection {
 		return self.@com.nonlinearlabs.client.WebSocketConnection::webSocketConnection.bufferedAmount;
 	}-*/;
 
-	public native void webSocketOpen(String host)
+	public native void webSocketOpen(String host, String path)
 	/*-{
-		var address = 'ws://' + host + '/ws/';
+		var address = 'ws://' + host + '/ws/' + path;
 		var connection = new WebSocket(address);
 		var self = this;
 	
@@ -243,15 +245,17 @@ class WebSocketConnection {
 			setModal(true);
 			setWidth("20em");
 			addHeader("C15 SSID change detected!");
-	
+
 			HTMLPanel panel = new HTMLPanel("");
 			HTMLPanel buttons = new HTMLPanel("");
-			panel.add(new Label("The SSID of the connected C15 instrument has changed. Do you want to reload the Graphical User Interface now?", true));
-	
+			panel.add(new Label(
+					"The SSID of the connected C15 instrument has changed. Do you want to reload the Graphical User Interface now?",
+					true));
+
 			Button yes, cancelButton;
-	
+
 			buttons.add(cancelButton = new Button("Cancel", new ClickHandler() {
-	
+
 				@Override
 				public void onClick(ClickEvent arg0) {
 					commit();
@@ -259,7 +263,7 @@ class WebSocketConnection {
 			}));
 
 			buttons.add(yes = new Button("Reload", new ClickHandler() {
-	
+
 				@Override
 				public void onClick(ClickEvent arg0) {
 					Window.Location.reload();

--- a/projects/playground/src/http/ContentManager.h
+++ b/projects/playground/src/http/ContentManager.h
@@ -28,7 +28,7 @@ class ContentManager : public PendingHTTPRequests, public UpdateDocumentMaster, 
 
   UNDO::Scope &getUndoScope() override;
   const UNDO::Scope &getUndoScope() const override;
-  void connectWebSocket(SoupWebsocketConnection *connection);
+  void connectWebSocket(const std::string &path, SoupWebsocketConnection *connection);
 
   bool isSendResponsesScheduled() const;
 
@@ -89,5 +89,5 @@ class ContentManager : public PendingHTTPRequests, public UpdateDocumentMaster, 
                                          UpdateDocumentContributor::tUpdateID oldUpdateID,
                                          UpdateDocumentContributor::tUpdateID newUpdateID);
 
-  std::list<tWebsocketConnection> m_webSockets;
+  std::map<std::string, tWebsocketConnection> m_webSockets;
 };

--- a/projects/playground/src/http/HTTPServer.cpp
+++ b/projects/playground/src/http/HTTPServer.cpp
@@ -62,10 +62,10 @@ void HTTPServer::initializeServer()
   }
 }
 
-void HTTPServer::webSocket(SoupServer *, SoupWebsocketConnection *connection, const char *, SoupClientContext *,
+void HTTPServer::webSocket(SoupServer *, SoupWebsocketConnection *connection, const char *path, SoupClientContext *,
                            HTTPServer *pThis)
 {
-  pThis->m_contentManager.connectWebSocket(connection);
+  pThis->m_contentManager.connectWebSocket(path, connection);
 }
 
 void HTTPServer::mcWebSocket(SoupServer *, SoupWebsocketConnection *connection, const char *, SoupClientContext *,


### PR DESCRIPTION
the old one. It seems that sometimes the closed web sockets are able to recover
somehow, which results in a set of web sockets, one for each broken connection.
The web sockets have all been processed leading to 'ghost moves' of knobs and faders.
Now, each webUI instance uses a random id to connect to playuground, playground only
uses exactly one web socket per client id.