### PR TITLE
added sda4 fix if broken

### DIFF
--- a/build-tools/create-c15-update/Installer_Error_Codes.txt
+++ b/build-tools/create-c15-update/Installer_Error_Codes.txt
@@ -16,8 +16,9 @@ List of current Error Messages
 4. ePC
 - 45 :: "E45 ePC update: Reboot taking too long... timed out"
 - 46 :: "E46 ePC update: Could not start server on BBB..."
-- 47 :: "E47 ePC update: deploying update failed ..."
-- 48 :: "E48 ePC update: "fixing Overlay order failed" or "setting Kernel Params failed"
+- 47 :: "E47 ePC update: pulling update failed ..."
+- 48 :: "E48 ePC update: "fixing Overlay order failed" or "setting Kernel Params failed" or "fixing sda4 failed"
+- 49 :: "E49 ePC update: pushing update failed ..."
 
 5. BBB
 - 54 :: "E54 BBB update: User partition not mounted om ePC ..."

--- a/build-tools/create-c15-update/update_scripts/epc_fix.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_fix.sh
@@ -42,6 +42,7 @@ epc_fix() {
     fi
 
     if ! fsck /dev/sda4 -n; then
+        umount /dev/sda4
         if ! mkfs.ext4 /dev/sda4; then
             printf "E48 ePC update: fixing sda4 failed" >> /tmp/fix_error.log && ((fix_errors++))
         fi
@@ -55,6 +56,7 @@ epc_fix() {
 
 main() {
     epc_fix
+    return $?
 }
 
 main

--- a/build-tools/create-c15-update/update_scripts/epc_fix.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_fix.sh
@@ -41,6 +41,12 @@ epc_fix() {
         fi
     fi
 
+    if ! fsck /dev/sda4 -n; then
+        if ! mkfs.ext4 /dev/sda4; then
+            printf "E48 ePC update: fixing sda4 failed" >> /tmp/fix_error.log && ((fix_errors++))
+        fi
+    fi
+
     if [ $fix_errors -gt 0 ]; then
          return 48
     fi

--- a/build-tools/create-c15-update/update_scripts/epc_pull_update.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_pull_update.sh
@@ -33,7 +33,6 @@ wait4playground() {
     return 1
 }
 
-
 check_preconditions(){
     [ -z "$EPC_IP" ] && report_and_quit "E81: Usage: $EPC_IP <IP-of-ePC> wrong ..." "81"
     ping -c1 $EPC_IP 1>&2 > /dev/null || report_and_quit "E82: Can't ping ePC on $EPC_IP ..." "82"
@@ -64,7 +63,8 @@ update(){
 
     killall thttpd
     rm /update/EPC/server.log
-    report_and_quit "E47 ePC update: deploying update failed ..." "47"
+    report_and_quit "E47 ePC update: pulling update failed ..." "47"
+    return 0
 }
 
 main () {

--- a/build-tools/create-c15-update/update_scripts/epc_push_update.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_push_update.sh
@@ -42,7 +42,7 @@ update(){
        return 0
     fi
 
-    return 1
+    report_and_quit "E49 ePC update: pushing update failed ..." "49"
 }
 
 main () {

--- a/build-tools/create-c15-update/update_scripts/run.sh
+++ b/build-tools/create-c15-update/update_scripts/run.sh
@@ -71,9 +71,8 @@ executeOnWin() {
     return $?
 }
 
-TIMEOUT=10
-
 wait4epc() {
+    TIMEOUT=$1
     for COUNTER in $(seq 1 $TIMEOUT); do
         echo "waiting for OS response ... $COUNTER/$TIMEOUT"
         sleep 1
@@ -83,7 +82,7 @@ wait4epc() {
 }
 
 check_preconditions() {
-    if ! wait4epc; then
+    if ! wait4epc 10; then
         if [ -z "$EPC_IP" ]; then report "" "E81: Usage: $EPC_IP <IP-of-ePC> wrong ..." "Please retry update!" && return 1; fi
         if ! ping -c1 $EPC_IP 1>&2 > /dev/null; then  report "" "E82: Cannot ping ePC on $EPC_IP ..." "Please retry update!" && return 1; fi
         if executeOnWin "mountvol p: /s & p: & DIR P:\nonlinear"; then
@@ -119,6 +118,9 @@ epc_fix() {
     if [ $result -ne 0 ]; then
         executeAsRoot "cat /tmp/fix_error.log" >> /update/errors.log && return $result
     fi
+
+    executeAsRoot "reboot"
+    wait4epc 60
     return 0
 }
 


### PR DESCRIPTION
Apparently /dev/sda4 is not always properly installed on the ePC. (I have not yet found out why). Coming from 1.5 to 1.7 this can be crucial, since /persistent is not always mounted and we cannot transfer data from the BBB.

Worked manually, have to check in context of an update on Monday.

