### PR TITLE
fixes undo problems with load to part + direct load

### DIFF
--- a/projects/playground/src/presets/PresetManager.cpp
+++ b/projects/playground/src/presets/PresetManager.cpp
@@ -898,15 +898,8 @@ void PresetManager::scheduleLoadToPart(const Preset *preset, VoiceGroup loadFrom
         {
           eb->undoableLoadPresetPartIntoPart(currentUndo, preset, loadFrom, loadTo);
           m_autoLoadScheduled = false;
+          return;
         }
-        else
-        {
-          currentUndo->reopen();
-          eb->undoableLoadPresetPartIntoPart(currentUndo, preset, loadFrom, loadTo);
-          m_autoLoadScheduled = false;
-          currentUndo->close();
-        }
-        return;
       }
 
       auto scope = getUndoScope().startContinuousTransaction(this, std::chrono::milliseconds(500), "Load Preset Part");


### PR DESCRIPTION
editing a parameter and immediately load to part will cause the edited parameter to reset after one undo press 