### PR TITLE
fix missing u and m indicators after sound name and pixel jump w/o indication

### DIFF
--- a/projects/playground/resources/templates/sound/select/single/SingleSoundLayout_A.json
+++ b/projects/playground/resources/templates/sound/select/single/SingleSoundLayout_A.json
@@ -18,7 +18,7 @@
         "Name": {
           "Class": "WideHighlightLabel",
           "Position": "64, 0",
-          "Events": "EditBufferName => Text[Text]"
+          "Events": "EditBufferNameWithSuffix => Text[Text]"
         },
         "ButtonA": {
           "Class": "HighlightButton",


### PR DESCRIPTION
closes #2081 