### PR TITLE
hotfix bank delete + undo / import + undo

### DIFF
--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
@@ -96,8 +96,6 @@ public class ServerProxy {
 			
 			Document xml = XMLParser.parse(responseText);
 			Node world = xml.getElementsByTagName("nonlinear-world").item(0);
-			if(omitOracles(world))
-				return;
 				
 			Node editBufferNode = xml.getElementsByTagName("edit-buffer").item(0);
 			Node settingsNode = xml.getElementsByTagName("settings").item(0);
@@ -122,9 +120,11 @@ public class ServerProxy {
 			DeviceInfoUpdater deviceInfoUpdater = new DeviceInfoUpdater(deviceInfo);
 			deviceInfoUpdater.doUpdate();
 
-			EditBufferModelUpdater ebu = new EditBufferModelUpdater(editBufferNode);
-			ebu.doUpdate();
-
+			if(!omitOracles(world)) {
+				EditBufferModelUpdater ebu = new EditBufferModelUpdater(editBufferNode);
+				ebu.doUpdate();
+			}
+			
 			PresetManagerUpdater pmu = new PresetManagerUpdater(presetManagerNode, PresetManagerModel.get());
 			pmu.doUpdate();
 

--- a/projects/playground/src/presets/PresetManager.cpp
+++ b/projects/playground/src/presets/PresetManager.cpp
@@ -40,6 +40,7 @@ PresetManager::PresetManager(UpdateDocumentContributor *parent, bool readOnly)
   m_actionManagers.emplace_back(new PresetManagerActions(*this));
   m_actionManagers.emplace_back(new BankActions(*this));
   m_actionManagers.emplace_back(new EditBufferActions(m_editBuffer.get()));
+  onRestoreHappened([&]() { invalidate(); });
 }
 
 PresetManager::~PresetManager()


### PR DESCRIPTION
added invalidate content manager for preset manager on restore happened, and prevent only editbuffer model from update on emit oracles