### PR TITLE
rework preset drag behavior and add open tab behavior on preset drag

### DIFF
--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/DragProxy.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/DragProxy.java
@@ -256,11 +256,8 @@ public class DragProxy extends OverlayControl {
 	}
 
 	private AutoScrollDirection getDesiredAutoScrollDirection(Position newPoint) {
-		Rect r = NonMaps.theMaps.getNonLinearWorld().getViewport().getPixRectWithoutBelt();
+		Rect r = NonMaps.theMaps.getNonLinearWorld().getViewport().getPixRect();
 		Rect beltRect = NonMaps.theMaps.getNonLinearWorld().getViewport().getOverlay().getBelt().getPixRect();
-
-		if (beltRect.contains(newPoint))
-			return AutoScrollDirection.None;
 
 		double borderSize = Millimeter.toPixels(10);
 

--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/PresetBeltButton.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/PresetBeltButton.java
@@ -1,13 +1,19 @@
 package com.nonlinearlabs.client.world.overlay.belt;
 
 import com.nonlinearlabs.client.world.Control;
+import com.nonlinearlabs.client.world.IPreset;
 import com.nonlinearlabs.client.world.Position;
+import com.nonlinearlabs.client.world.overlay.DragProxy;
 import com.nonlinearlabs.client.world.overlay.OverlayLayout;
+import com.nonlinearlabs.client.world.overlay.belt.Belt.BeltTab;
 
 public class PresetBeltButton extends BeltButton {
 
+	private Belt m_belt;
+
 	public PresetBeltButton(OverlayLayout parent, Belt belt) {
 		super(parent, belt, "Preset_Tab_Enabled.svg", "Preset_Tab_Disabled.svg");
+		m_belt = belt;
 	}
 
 	@Override
@@ -23,5 +29,18 @@ public class PresetBeltButton extends BeltButton {
 	@Override
 	public boolean isActive() {
 		return belt.isPresetView();
+	}
+
+	@Override
+	public Control drag(Position p, DragProxy dragProxy) {
+		if(getPixRect().contains(p) && dragProxy.getOrigin() instanceof IPreset)
+		{
+			if(m_belt.isHidden())
+				m_belt.toggle();
+				
+			m_belt.openTab(BeltTab.Preset);
+			return this;
+		}
+		return super.drag(p, dragProxy);
 	}
 }

--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/PresetBeltButton.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/PresetBeltButton.java
@@ -9,11 +9,8 @@ import com.nonlinearlabs.client.world.overlay.belt.Belt.BeltTab;
 
 public class PresetBeltButton extends BeltButton {
 
-	private Belt m_belt;
-
 	public PresetBeltButton(OverlayLayout parent, Belt belt) {
 		super(parent, belt, "Preset_Tab_Enabled.svg", "Preset_Tab_Disabled.svg");
-		m_belt = belt;
 	}
 
 	@Override
@@ -35,10 +32,10 @@ public class PresetBeltButton extends BeltButton {
 	public Control drag(Position p, DragProxy dragProxy) {
 		if(getPixRect().contains(p) && dragProxy.getOrigin() instanceof IPreset)
 		{
-			if(m_belt.isHidden())
-				m_belt.toggle();
+			if(belt.isHidden())
+				belt.toggle();
 				
-			m_belt.openTab(BeltTab.Preset);
+			belt.openTab(BeltTab.Preset);
 			return this;
 		}
 		return super.drag(p, dragProxy);

--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/SoundBeltButton.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/SoundBeltButton.java
@@ -10,11 +10,8 @@ import com.nonlinearlabs.client.world.overlay.belt.Belt.BeltTab;
 
 public class SoundBeltButton extends BeltButton {
 
-	private Belt m_belt;
-
 	public SoundBeltButton(OverlayLayout parent, Belt belt) {
 		super(parent, belt, "Sound_Tab_Enabled_A.svg", "Sound_Tab_Disabled_A.svg");
-		m_belt = belt;
 	}
 
 	@Override
@@ -37,10 +34,10 @@ public class SoundBeltButton extends BeltButton {
 	public Control drag(Position p, DragProxy dragProxy) {
 		if(getPixRect().contains(p) && dragProxy.getOrigin() instanceof IPreset)
 		{
-			if(m_belt.isHidden())
-				m_belt.toggle();
+			if(belt.isHidden())
+				belt.toggle();
 				
-			m_belt.openTab(BeltTab.Sound);
+			belt.openTab(BeltTab.Sound);
 			return this;
 		}
 		return super.drag(p, dragProxy);

--- a/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/SoundBeltButton.java
+++ b/projects/NonMaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/SoundBeltButton.java
@@ -1,13 +1,20 @@
 package com.nonlinearlabs.client.world.overlay.belt;
 
 import com.nonlinearlabs.client.world.Control;
+import com.nonlinearlabs.client.world.IPreset;
 import com.nonlinearlabs.client.world.Position;
+import com.nonlinearlabs.client.world.Rect;
+import com.nonlinearlabs.client.world.overlay.DragProxy;
 import com.nonlinearlabs.client.world.overlay.OverlayLayout;
+import com.nonlinearlabs.client.world.overlay.belt.Belt.BeltTab;
 
 public class SoundBeltButton extends BeltButton {
 
+	private Belt m_belt;
+
 	public SoundBeltButton(OverlayLayout parent, Belt belt) {
 		super(parent, belt, "Sound_Tab_Enabled_A.svg", "Sound_Tab_Disabled_A.svg");
+		m_belt = belt;
 	}
 
 	@Override
@@ -23,5 +30,19 @@ public class SoundBeltButton extends BeltButton {
 	@Override
 	public boolean isActive() {
 		return belt.isSoundView();
+	}
+
+
+	@Override
+	public Control drag(Position p, DragProxy dragProxy) {
+		if(getPixRect().contains(p) && dragProxy.getOrigin() instanceof IPreset)
+		{
+			if(m_belt.isHidden())
+				m_belt.toggle();
+				
+			m_belt.openTab(BeltTab.Sound);
+			return this;
+		}
+		return super.drag(p, dragProxy);
 	}
 }


### PR DESCRIPTION
added drag handler for belt preset/sound button -> enables opening / switching to belt preset/sound tab for dropping into that list / loading to part

fixes #2068