### PR TITLE
fix empty bank label alignment

### DIFF
--- a/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/EmptyBankLabel.cpp
+++ b/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/EmptyBankLabel.cpp
@@ -20,6 +20,6 @@ bool EmptyBankLabel::redraw(FrameBuffer &fb)
   super::redraw(fb);
   fb.setColor(FrameBufferColors::C179);
   const Rect &r = getPosition();
-  fb.drawRect(r.getLeft() + 1, r.getTop(), r.getWidth() - 2, r.getHeight());
+  fb.drawRect(r.getLeft(), r.getTop(), r.getWidth(), r.getHeight());
   return true;
 }

--- a/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListContent.cpp
+++ b/projects/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListContent.cpp
@@ -62,7 +62,7 @@ void PresetListContent::setup(Bank *bank, size_t focussedPresetPos)
   else if((hasBank && !hasEmptyBankLabel) || (!hasBank && !hasNoBankLabel))
   {
     clear();
-    m_emptyLabel = addControl(new EmptyBankLabel(Rect(0, 16, 126, 16)));
+    m_emptyLabel = addControl(new EmptyBankLabel(Rect(0, 16, 128, 16)));
 
     m_firstPreset = nullptr;
     m_secondPreset = nullptr;


### PR DESCRIPTION
Before: 
![Boled-Tue-Aug--4-12:32:21-2020
](https://user-images.githubusercontent.com/15381257/89285358-7d87c900-d650-11ea-9ee9-ac5bff828fd9.png)
With this PR: 
![Boled-Tue-Aug--4-12:45:22-2020
](https://user-images.githubusercontent.com/15381257/89285381-87113100-d650-11ea-8fae-88b609ecf398.png)
