### PR TITLE
Simplify lower ribbon to parameter connection

### DIFF
--- a/projects/playground/src/proxies/hwui/base-unit/LowerRibbon.cpp
+++ b/projects/playground/src/proxies/hwui/base-unit/LowerRibbon.cpp
@@ -9,35 +9,21 @@
 #include <glib.h>
 #include <math.h>
 
+static Parameter *getParameter()
+{
+  return Application::get().getPresetManager()->getEditBuffer()->findParameterByID(
+      HardwareSourcesGroup::getLowerRibbonParameterID());
+}
+
 LowerRibbon::LowerRibbon()
 {
   initLEDs();
-  Application::get().getPresetManager()->getEditBuffer()->onSelectionChanged(
-      sigc::mem_fun(this, &LowerRibbon::onParamSelectionChanged), {});
+  getParameter()->onParameterChanged(sigc::mem_fun(this, &LowerRibbon::onParamValueChanged));
 }
 
 int LowerRibbon::posToLedID(int pos) const
 {
   return pos * 2;
-}
-
-void LowerRibbon::onParamSelectionChanged(Parameter *oldOne, Parameter *newOne)
-{
-  reconnect();
-}
-
-void LowerRibbon::reconnect()
-{
-  m_paramConnection.disconnect();
-
-  if(auto p = getResponsibleParameter())
-    m_paramConnection = p->onParameterChanged(sigc::mem_fun(this, &LowerRibbon::onParamValueChanged));
-}
-
-Parameter *LowerRibbon::getResponsibleParameter()
-{
-  return Application::get().getPresetManager()->getEditBuffer()->findParameterByID(
-      HardwareSourcesGroup::getLowerRibbonParameterID());
 }
 
 void LowerRibbon::onParamValueChanged(const Parameter *param)
@@ -72,6 +58,6 @@ void LowerRibbon::indicateBlockingMainThread(bool onOff)
   }
   else
   {
-    onParamValueChanged(getResponsibleParameter());
+    onParamValueChanged(getParameter());
   }
 }

--- a/projects/playground/src/proxies/hwui/base-unit/LowerRibbon.h
+++ b/projects/playground/src/proxies/hwui/base-unit/LowerRibbon.h
@@ -2,13 +2,14 @@
 
 #include "playground.h"
 #include "Ribbon.h"
-#include <sigc++/connection.h>
+
+#include <sigc++/trackable.h>
 
 class Application;
 class Parameter;
 class Setting;
 
-class LowerRibbon : public Ribbon
+class LowerRibbon : public Ribbon, public sigc::trackable
 {
   typedef Ribbon super;
 
@@ -19,12 +20,8 @@ class LowerRibbon : public Ribbon
  private:
   void onParamSelectionChanged(Parameter* oldOne, Parameter* newOne);
   void onParamValueChanged(const Parameter* param);
-  void reconnect();
-
-  static Parameter* getResponsibleParameter();
 
   int posToLedID(int pos) const;
 
-  sigc::connection m_paramConnection;
   bool m_indicateBlockingMainThread = false;
 };


### PR DESCRIPTION
The parameter is always the same so we don't need to connect to
edit buffers selection actually.