### PR TITLE
Issue 2198

### DIFF
--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -170,12 +170,19 @@ bool Parameter::isDisabledForType(SoundType type) const
     case SoundType::Invalid:
       return true;
   }
+  return false;
 }
 
 void Parameter::loadDefault(UNDO::Transaction *transaction, Defaults mode)
 {
-  if(!isDisabled() && !isLocked())
-    loadFromPreset(transaction, mode == Defaults::UserDefault ? getDefaultValue() : getFactoryDefaultValue());
+  if(mode == Defaults::FactoryDefault)
+  {
+    loadFromPreset(transaction, getFactoryDefaultValue());
+  }
+  else if(!isLocked())
+  {
+    loadFromPreset(transaction, getDefaultValue());
+  }
 }
 
 bool Parameter::isDefaultLoaded() const

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -1368,7 +1368,6 @@ void EditBuffer::undoableConvertSplitToLayer(UNDO::Transaction *transaction)
 {
   auto currentVG = Application::get().getHWUI()->getCurrentVoiceGroup();
   copyVoicesGroups(transaction, currentVG, invert(currentVG));
-  undoableUnisonMonoLoadDefaults(transaction, VoiceGroup::II);
   calculateFadeParamsFromSplitPoint(transaction);
   undoableUnisonMonoLoadDefaults(transaction, VoiceGroup::II);
   initSplitPoint(transaction);

--- a/projects/epc/playground/src/proxies/hwui/OLEDProxy.cpp
+++ b/projects/epc/playground/src/proxies/hwui/OLEDProxy.cpp
@@ -62,6 +62,12 @@ void OLEDProxy::reset(tLayoutPtr layout)
   if(!layout->isInitialized())
     layout->init();
 
+  if(m_onLayoutInstalledCB)
+  {
+    m_onLayoutInstalledCB(layout.get());
+    m_onLayoutInstalledCB = nullptr;
+  }
+
   DebugLevel::info(G_STRLOC, typeid(layout.get()).name());
   invalidate();
 }
@@ -112,4 +118,13 @@ void OLEDProxy::clear()
   auto &fb = FrameBuffer::get();
   fb.setColor(FrameBufferColors::C43);
   fb.fillRect(Rect(0, 0, m_posInFrameBuffer.getWidth(), m_posInFrameBuffer.getHeight()));
+}
+
+void OLEDProxy::onLayoutInstalled(std::function<void(Layout *)> cb)
+{
+  if(m_onLayoutInstalledCB != nullptr)
+  {
+    nltools::Log::warning("removing non called onLayoutInstalled Callback!", __LINE__, __PRETTY_FUNCTION__, __FILE__);
+  }
+  m_onLayoutInstalledCB = cb;
 }

--- a/projects/epc/playground/src/proxies/hwui/OLEDProxy.h
+++ b/projects/epc/playground/src/proxies/hwui/OLEDProxy.h
@@ -4,6 +4,7 @@
 #include <nltools/Uncopyable.h>
 #include <proxies/hwui/controls/Rect.h>
 #include <memory>
+#include <functional>
 
 class Application;
 class Layout;
@@ -25,6 +26,8 @@ class OLEDProxy : public Uncopyable
 
   virtual void reset(tLayoutPtr layout);
 
+  void onLayoutInstalled(std::function<void(Layout *)> cb);
+
   void setOverlay(Layout *layout);
   void setOverlay(tLayoutPtr layout);
 
@@ -38,6 +41,8 @@ class OLEDProxy : public Uncopyable
   const Rect &getPosInFrameBuffer() const;
 
  private:
+  std::function<void(Layout *)> m_onLayoutInstalledCB;
+
   tLayoutPtr m_layout;
   tLayoutPtr m_overlay;
   Rect m_posInFrameBuffer;

--- a/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
@@ -13,9 +13,9 @@ Slider::Slider(Parameter *param, const Rect &rect)
     , m_value(0)
     , m_bipolar(false)
 {
+  setParameter(param);
   Application::get().getPresetManager()->getEditBuffer()->onSoundTypeChanged(
       sigc::hide(sigc::mem_fun(this, &Slider::onSoundTypeChanged)), false);
-  setParameter(param);
 }
 
 Slider::Slider(const Rect &rect)
@@ -53,7 +53,7 @@ void Slider::onParamValueChanged(const Parameter *param)
 
 void Slider::onSoundTypeChanged()
 {
-  setVisible(!m_param->isDisabled());
+  setVisible(m_param && !m_param->isDisabled());
 }
 
 void Slider::setValue(tDisplayValue v, bool bipolar)

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
@@ -65,14 +65,15 @@ PanelUnit::PanelUnit()
         editBuffer->undoableSelectParameter(scope->getTransaction(), modParam);
 
         auto hwui = Application::get().getHWUI();
-        auto layout = hwui->getPanelUnit().getEditPanel().getBoled().getLayout();
-
-        if(auto modParamLayout = dynamic_cast<ModulateableParameterSelectLayout2 *>(layout.get()))
-        {
-          modParamLayout->installMcAmountScreen();
-          m_macroControlAssignmentStateMachine.setState(MacroControlAssignmentStates::Initial);
-          return true;
-        }
+        auto &boled = hwui->getPanelUnit().getEditPanel().getBoled();
+        boled.onLayoutInstalled([&](Layout *l) {
+          if(auto modParamLayout = dynamic_cast<ModulateableParameterSelectLayout2 *>(l))
+          {
+            modParamLayout->installMcAmountScreen();
+            m_macroControlAssignmentStateMachine.setState(MacroControlAssignmentStates::Initial);
+            return true;
+          }
+        });
       }
     }
     return true;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLED.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLED.h
@@ -26,7 +26,6 @@ class BOLED : public OLEDProxy, public sigc::trackable
   void onRotary(signed char i);
 
   void setupFocusAndMode(FocusAndMode focusAndMode);
-
   void showUndoScreen();
 
   void bruteForce();

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
@@ -15,7 +15,7 @@ MCSelectButton::~MCSelectButton() = default;
 
 void MCSelectButton::update(const Parameter *parameter)
 {
-  if(parameter->isDisabled())
+  if(parameter == nullptr || parameter->isDisabled())
   {
     setText("");
     return;


### PR DESCRIPTION
with the introduction of an delayed job to install the layout, subsequent checks for layout type after `setFocusAndMode`, `undoableSelectParameter` and similar have to be passed into `onLayoutInstalled`, as upon returning of `setFocusAndMode` the layout must not be installed yet