### PR TITLE
Comb Filter Hotfix 2206

### DIFF
--- a/projects/bbb/bridge/src/ui/Boled.cpp
+++ b/projects/bbb/bridge/src/ui/Boled.cpp
@@ -10,10 +10,10 @@ constexpr auto frameBufferDimY = 96;
 
 typedef std::tuple<uint8_t, uint8_t, uint8_t> RGB;
 static std::map<uint8_t, RGB> colorMap
-    = { { 0x00, std::make_tuple(43, 32, 21) },   { 0x02, std::make_tuple(77, 60, 10) },
-        { 0x05, std::make_tuple(103, 81, 12) },  { 0x06, std::make_tuple(128, 102, 16) },
-        { 0x0A, std::make_tuple(179, 142, 21) }, { 0x0B, std::make_tuple(204, 162, 24) },
-        { 0x0F, std::make_tuple(255, 203, 31) } };
+    = { { 0x00, std::make_tuple(0, 0, 0) },       { 0x02, std::make_tuple(73, 73, 73) },
+        { 0x05, std::make_tuple(110, 110, 110) }, { 0x06, std::make_tuple(146, 146, 146) },
+        { 0x0A, std::make_tuple(183, 183, 183) }, { 0x0B, std::make_tuple(219, 219, 219) },
+        { 0x0F, std::make_tuple(255, 255, 255) } };
 
 Boled::Boled()
 {

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -228,33 +228,18 @@ void Engine::PolyCombFilter::set(PolySignals &_signals, const float _samplerate,
   }
   // lp influence
   frequency *= m_sampleInterval;
-#if COMB_FIX_2206
-  float stateVar_r = NlToolbox::Math::sinP3_wrap(frequency - 0.25f);
-  float stateVar_i = NlToolbox::Math::sinP3_wrap(frequency);
-#else
   float stateVar_r = NlToolbox::Math::sinP3_wrap(frequency);
   float stateVar_i = NlToolbox::Math::sinP3_wrap(frequency + 0.25f);
-#endif
   stateVar_r = stateVar_r * m_lpCoeff[_voiceId];
   stateVar_i = stateVar_i * -m_lpCoeff[_voiceId] + 1.0f;
   tmpVar = NlToolbox::Math::arctan(stateVar_r / stateVar_i) * -0.159155f;  // (1.f / -6.28318f)
   m_delaySamples[_voiceId] = m_delaySamples[_voiceId] * tmpVar + m_delaySamples[_voiceId];
   // ap influence
-#if COMB_FIX_2206
-  stateVar_i = NlToolbox::Math::sinP3_wrap(frequency - 0.25f) * -1.0f * m_apCoeff_1[_voiceId];
-  stateVar_r = NlToolbox::Math::sinP3_wrap(frequency) * m_apCoeff_1[_voiceId];
-#else
   stateVar_i = NlToolbox::Math::sinP3_wrap(frequency) * -1.0f * m_apCoeff_1[_voiceId];
   stateVar_r = NlToolbox::Math::sinP3_wrap(frequency + 0.25f) * m_apCoeff_1[_voiceId];
-#endif
   frequency += frequency;
-#if COMB_FIX_2206
-  float stateVar2_i = NlToolbox::Math::sinP3_wrap(frequency - 0.25f);
-  float stateVar2_r = NlToolbox::Math::sinP3_wrap(frequency);
-#else
   float stateVar2_i = NlToolbox::Math::sinP3_wrap(frequency);
   float stateVar2_r = NlToolbox::Math::sinP3_wrap(frequency + 0.25f);
-#endif
   float var1_i = stateVar_i - stateVar2_i;
   float var2_i = (stateVar_i - (m_apCoeff_2[_voiceId] * stateVar2_i)) * -1.0f;
   float var1_r = stateVar_r + stateVar2_r + m_apCoeff_2[_voiceId];

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -80,7 +80,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
   m_apStateVar_1 = tmpOut;
   m_apStateVar_4 = m_apStateVar_3;
   m_apStateVar_3 = m_out;
-#endif
+#endif  // (excl. LP, AP end)
 #if POTENTIAL_IMPROVEMENT_COMB_REDUCE_VOICE_LOOP_1
   // POTENTIAL_IMPROVEMENT_COMB_REDUCE_VOICE_LOOP_1: provide a parallel implementation for "para d"
   auto para_d = std::abs(m_out);
@@ -144,6 +144,22 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
     m_buffer[m_buffer_indx][v] = m_out[v];
   }
 #endif
+  // debugging saturation
+  m_debug_sat_max *= 0.999999f;
+  m_debug_sat_min *= 0.999999f;
+  for(uint32_t v = 0; v < C15::Config::local_polyphony; v++)
+  {
+    if(m_out[v] > 0.0f)
+    {
+      if(m_out[v] > m_debug_sat_max[v])
+        m_debug_sat_max[v] = m_out[v];
+    }
+    else
+    {
+      if(m_out[v] < m_debug_sat_min[v])
+        m_debug_sat_min[v] = m_out[v];
+    }
+  }
   /// hier kommt voicestealing hin!!
   tmpSmooth -= 1.0f;
   tmpSmooth = std::clamp(tmpSmooth, 1.0f, 8189.f);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -166,6 +166,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
   m_debug_delay = tmpSmooth;
   auto ind_t0 = std::round<int32_t>(tmpSmooth - 0.5f);
   tmpSmooth = tmpSmooth - static_cast<PolyValue>(ind_t0);
+  m_debug_fract = tmpSmooth;  // fractional: checked range [0 ... 1] OK
   auto ind_tm1 = ind_t0 - 1;
   auto ind_tp1 = ind_t0 + 1;
   auto ind_tp2 = ind_t0 + 2;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -56,6 +56,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
 #endif
   m_out = tmpHP;
   m_out += m_decayStateVar;
+#if 1  // excluding LP and AP still produces offset...
   // 1-pole lp
   m_out *= (1.0f - m_lpCoeff);
   m_out += (m_lpCoeff * m_lpStateVar);
@@ -79,6 +80,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
   m_apStateVar_1 = tmpOut;
   m_apStateVar_4 = m_apStateVar_3;
   m_apStateVar_3 = m_out;
+#endif
 #if POTENTIAL_IMPROVEMENT_COMB_REDUCE_VOICE_LOOP_1
   // POTENTIAL_IMPROVEMENT_COMB_REDUCE_VOICE_LOOP_1: provide a parallel implementation for "para d"
   auto para_d = std::abs(m_out);
@@ -145,6 +147,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
   /// hier kommt voicestealing hin!!
   tmpSmooth -= 1.0f;
   tmpSmooth = std::clamp(tmpSmooth, 1.0f, 8189.f);
+  m_debug_delay = tmpSmooth;
   auto ind_t0 = std::round<int32_t>(tmpSmooth - 0.5f);
   tmpSmooth = tmpSmooth - static_cast<PolyValue>(ind_t0);
   auto ind_tm1 = ind_t0 - 1;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -228,18 +228,33 @@ void Engine::PolyCombFilter::set(PolySignals &_signals, const float _samplerate,
   }
   // lp influence
   frequency *= m_sampleInterval;
+#if COMB_FIX_2206
+  float stateVar_r = NlToolbox::Math::sinP3_wrap(frequency - 0.25f);
+  float stateVar_i = NlToolbox::Math::sinP3_wrap(frequency);
+#else
   float stateVar_r = NlToolbox::Math::sinP3_wrap(frequency);
   float stateVar_i = NlToolbox::Math::sinP3_wrap(frequency + 0.25f);
+#endif
   stateVar_r = stateVar_r * m_lpCoeff[_voiceId];
   stateVar_i = stateVar_i * -m_lpCoeff[_voiceId] + 1.0f;
   tmpVar = NlToolbox::Math::arctan(stateVar_r / stateVar_i) * -0.159155f;  // (1.f / -6.28318f)
   m_delaySamples[_voiceId] = m_delaySamples[_voiceId] * tmpVar + m_delaySamples[_voiceId];
   // ap influence
+#if COMB_FIX_2206
+  stateVar_i = NlToolbox::Math::sinP3_wrap(frequency - 0.25f) * -1.0f * m_apCoeff_1[_voiceId];
+  stateVar_r = NlToolbox::Math::sinP3_wrap(frequency) * m_apCoeff_1[_voiceId];
+#else
   stateVar_i = NlToolbox::Math::sinP3_wrap(frequency) * -1.0f * m_apCoeff_1[_voiceId];
   stateVar_r = NlToolbox::Math::sinP3_wrap(frequency + 0.25f) * m_apCoeff_1[_voiceId];
+#endif
   frequency += frequency;
+#if COMB_FIX_2206
+  float stateVar2_i = NlToolbox::Math::sinP3_wrap(frequency - 0.25f);
+  float stateVar2_r = NlToolbox::Math::sinP3_wrap(frequency);
+#else
   float stateVar2_i = NlToolbox::Math::sinP3_wrap(frequency);
   float stateVar2_r = NlToolbox::Math::sinP3_wrap(frequency + 0.25f);
+#endif
   float var1_i = stateVar_i - stateVar2_i;
   float var2_i = (stateVar_i - (m_apCoeff_2[_voiceId] * stateVar2_i)) * -1.0f;
   float var1_r = stateVar_r + stateVar2_r + m_apCoeff_2[_voiceId];

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.cpp
@@ -164,6 +164,7 @@ void Engine::PolyCombFilter::apply(PolySignals &_signals, const PolyValue &_samp
   tmpSmooth -= 1.0f;
   tmpSmooth = std::clamp(tmpSmooth, 1.0f, 8189.f);
   m_debug_delay = tmpSmooth;
+  // int/fract ??
   auto ind_t0 = std::round<int32_t>(tmpSmooth - 0.5f);
   tmpSmooth = tmpSmooth - static_cast<PolyValue>(ind_t0);
   m_debug_fract = tmpSmooth;  // fractional: checked range [0 ... 1] OK

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
@@ -15,8 +15,6 @@
 
 #define COMB_BUFFER_SIZE 8192
 
-#define COMB_FIX_2206 1
-
 namespace Engine
 {
   class PolyCombFilter

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
@@ -20,7 +20,7 @@ namespace Engine
   class PolyCombFilter
   {
    public:
-    PolyValue m_out = {}, m_debug_delay = {};
+    PolyValue m_out = {}, m_debug_delay = {}, m_debug_sat_min = {}, m_debug_sat_max = {};
     PolyCombFilter();
     void init(const float _samplerate, const uint32_t _upsampleFactor);
     void apply(PolySignals &_signals, const PolyValue &_sampleA, const PolyValue &_sampleB);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
@@ -20,7 +20,7 @@ namespace Engine
   class PolyCombFilter
   {
    public:
-    PolyValue m_out = {};
+    PolyValue m_out = {}, m_debug_delay = {};
     PolyCombFilter();
     void init(const float _samplerate, const uint32_t _upsampleFactor);
     void apply(PolySignals &_signals, const PolyValue &_sampleA, const PolyValue &_sampleB);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
@@ -20,7 +20,8 @@ namespace Engine
   class PolyCombFilter
   {
    public:
-    PolyValue m_out = {}, m_debug_delay = {}, m_debug_sat_min = {}, m_debug_sat_max = {};
+    PolyValue m_out = {}, m_debug_delay = {}, m_debug_sat_min = {}, m_debug_sat_max = {}, m_debug_fract = {},
+              m_debug_dt = {};
     PolyCombFilter();
     void init(const float _samplerate, const uint32_t _upsampleFactor);
     void apply(PolySignals &_signals, const PolyValue &_sampleA, const PolyValue &_sampleB);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_comb.h
@@ -15,6 +15,8 @@
 
 #define COMB_BUFFER_SIZE 8192
 
+#define COMB_FIX_2206 1
+
 namespace Engine
 {
   class PolyCombFilter

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -630,8 +630,9 @@ void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
       = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId];  // decay now fully formed as min/max
   m_comb_decay_times[0][_voiceId]
       = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
-  m_comb_decay_times[1][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
+  auto tmp = m_convert->eval_level(unitPitch + unitMod) * unitSign;
+  m_combfilter.m_debug_dt[_voiceId] = tmp;
+  m_comb_decay_times[1][_voiceId] = m_combfilter.calcDecayGain(tmp, unitValue);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
   unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
@@ -732,8 +733,9 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
       = m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Freq)[_voiceId];  // decay now fully formed as min/max
   m_comb_decay_times[0][_voiceId]
       = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + (unitMod * envMod)) * unitSign, unitValue);
-  m_comb_decay_times[1][_voiceId]
-      = m_combfilter.calcDecayGain(m_convert->eval_level(unitPitch + unitMod) * unitSign, unitValue);
+  auto tmp = m_convert->eval_level(unitPitch + unitMod) * unitSign;
+  m_combfilter.m_debug_dt[_voiceId] = tmp;
+  m_comb_decay_times[1][_voiceId] = m_combfilter.calcDecayGain(tmp, unitValue);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_KT);
   unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_AP_Tune);
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.h
@@ -31,6 +31,7 @@ class PolySection
         m_millisecond = 0.0f;
   uint32_t m_uVoice = 0, m_key_active = 0;
   int32_t m_fadeStart = 0, m_fadeEnd = 0, m_fadeIncrement = 0;
+  Engine::PolyCombFilter m_combfilter;
   PolySection();
   void init(GlobalSignals *_globalsignals, exponentiator *_convert, Engine::Handle::Time_Handle *_time,
             LayerSignalCollection *_z_self, float *_reference, const float _ms, const float _gateRelease,
@@ -71,7 +72,6 @@ class PolySection
   Engine::Envelopes::RetriggerEnvelope<C15::Config::local_polyphony> m_env_c;
   Engine::Envelopes::GateEnvelope<C15::Config::local_polyphony> m_env_g;
   Engine::PolySoundGenerator m_soundgenerator;
-  Engine::PolyCombFilter m_combfilter;
   Engine::PolyStateVariableFilter m_svfilter;
   Engine::PolyFeedbackMixer m_feedbackmixer;
   Engine::PolyOutputMixer m_outputmixer;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -244,6 +244,7 @@ void dsp_host_dual::init(const uint32_t _samplerate, const uint32_t _polyphony)
     //nltools::Log::info("dsp_host_dual::init - engine dsp status: global");
     //nltools::Log::info("missing: nltools::msg - reference, initial:", m_reference.m_scaled);
   }
+  TestCommonFunctions();
 }
 
 C15::ParameterDescriptor dsp_host_dual::getParameter(const int _id)
@@ -2856,3 +2857,19 @@ void dsp_host_dual::PotentialImprovements_RunNumericTests()
   nltools::Log::info(__PRETTY_FUNCTION__, "finished tests");
 }
 #endif
+
+void dsp_host_dual::TestCommonFunctions()
+{
+  nltools::Log::info("testing common functions");
+  for(int32_t i = -50; i < 51; i++)
+  {
+    const float normed = 1000.0f + (static_cast<float>(i) * 0.1f);
+    const int32_t round = std::round<int32_t>(normed - 0.5f);
+    const float fract = normed - static_cast<float>(round);
+    const PolyValue normed2 = 1000.0f + (static_cast<float>(i) * 0.1f);
+    const PolyInt round2 = std::round<int32_t>(normed2 - 0.5f);
+    const PolyValue fract2 = normed - static_cast<PolyValue>(round2);
+    nltools::Log::info("\t", normed, "\t", round, "\t", fract, "\t", normed2[0], "\t", round2[0], "\t", fract2[0]);
+  }
+  nltools::Log::info("done testing common functions");
+}

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -291,6 +291,8 @@ void dsp_host_dual::logStatus()
           dly = m_poly[event->m_localIndex].m_combfilter.m_debug_delay[event->m_voiceId];
       nltools::Log::info("dly:", dly);
       nltools::Log::info("dec:", dec);
+      nltools::Log::info("dt:", m_poly[event->m_localIndex].m_combfilter.m_debug_dt[event->m_voiceId]);
+      nltools::Log::info("fract:", m_poly[event->m_localIndex].m_combfilter.m_debug_fract[event->m_voiceId]);
       nltools::Log::info("sat (min, max):", m_poly[event->m_localIndex].m_combfilter.m_debug_sat_min[event->m_voiceId],
                          ", ", m_poly[event->m_localIndex].m_combfilter.m_debug_sat_max[event->m_voiceId]);
     }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -291,6 +291,8 @@ void dsp_host_dual::logStatus()
           dly = m_poly[event->m_localIndex].m_combfilter.m_debug_delay[event->m_voiceId];
       nltools::Log::info("dly:", dly);
       nltools::Log::info("dec:", dec);
+      nltools::Log::info("sat (min, max):", m_poly[event->m_localIndex].m_combfilter.m_debug_sat_min[event->m_voiceId],
+                         ", ", m_poly[event->m_localIndex].m_combfilter.m_debug_sat_max[event->m_voiceId]);
     }
   }
   else if(LOG_ENGINE_EDITS)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2866,10 +2866,15 @@ void dsp_host_dual::TestCommonFunctions()
     const float normed = 1000.0f + (static_cast<float>(i) * 0.1f);
     const int32_t round = std::round<int32_t>(normed - 0.5f);
     const float fract = normed - static_cast<float>(round);
-    const PolyValue normed2 = 1000.0f + (static_cast<float>(i) * 0.1f);
-    const PolyInt round2 = std::round<int32_t>(normed2 - 0.5f);
-    const PolyValue fract2 = normed - static_cast<PolyValue>(round2);
-    nltools::Log::info("\t", normed, "\t", round, "\t", fract, "\t", normed2[0], "\t", round2[0], "\t", fract2[0]);
+    //    const PolyValue normed2 = 1000.0f + (static_cast<float>(i) * 0.1f);
+    //    const PolyInt round2 = std::round<int32_t>(normed2 - 0.5f);
+    //    const PolyValue fract2 = normed - static_cast<PolyValue>(round2);
+    //    nltools::Log::info("\t", normed, "\t", round, "\t", fract, "\t", normed2[0], "\t", round2[0], "\t", fract2[0]);
+    /* still used in Mono Section: */
+    const int32_t round3 = static_cast<int32_t>(std::round(normed - 0.5f));
+    const float fract3 = normed - static_cast<float>(round3);
+    nltools::Log::info("\t", normed, "\t", round, "\t", fract, "\t", round3, "\t", fract3);
+    /* result: mono fractionals seem to be within valid range [0 ... 1] */
   }
   nltools::Log::info("done testing common functions");
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -280,6 +280,19 @@ void dsp_host_dual::logStatus()
     nltools::Log::info("-output(left:", m_mainOut_L, ", right:", m_mainOut_R, ", mute:", m_fade.getValue(), ")");
     nltools::Log::info("-dsp(dx:", m_time.m_sample_inc, ", ms:", m_time.m_millisecond, ")");
   }
+  else if(LOG_COMB)
+  {
+    nltools::Log::info("comb status:");
+    for(auto event = m_alloc.m_traversal.first(); m_alloc.m_traversal.running(); event = m_alloc.m_traversal.next())
+    {
+      nltools::Log::info("voice:", event->m_voiceId, event->m_localIndex);
+      auto dec
+          = m_poly[event->m_localIndex].m_signals.get(C15::Signals::Truepoly_Signals::Comb_Flt_Decay, event->m_voiceId),
+          dly = m_poly[event->m_localIndex].m_combfilter.m_debug_delay[event->m_voiceId];
+      nltools::Log::info("dly:", dly);
+      nltools::Log::info("dec:", dec);
+    }
+  }
   else if(LOG_ENGINE_EDITS)
   {
     nltools::Log::info("Engine Param Status - - - - - - - - - - - - - - - \n\n");
@@ -2571,7 +2584,7 @@ void dsp_host_dual::PotentialImprovements_RunNumericTests()
   nltools::Log::info(__PRETTY_FUNCTION__, "starting tests (proposal_enabled:", __POTENTIAL_IMPROVEMENT_PROPOSAL__, ")");
   const float TestGroup_Pattern_data[12]
       = { -1.0f, -0.99f, -0.75f, -0.5f, -0.3f, -0.0f, 0.0f, 0.3f, 0.5f, 0.75f, 0.99f, 1.0f };
-  const PolyValue TestGroup_Pattern { TestGroup_Pattern_data };
+  const PolyValue TestGroup_Pattern{ TestGroup_Pattern_data };
   const size_t TestGroups = 4;
   const char* RunInfo[TestGroups] = { "big", "unclamped", "clamped", "small" };
   const PolyValue TestGroup[TestGroups]

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -48,6 +48,7 @@ inline constexpr bool LOG_RESET = false;
 inline constexpr bool LOG_HW = false;
 // more detailed logging of specific parameters
 inline constexpr bool LOG_ENGINE_STATUS = false;
+inline constexpr bool LOG_COMB = true;
 inline constexpr bool LOG_ENGINE_EDITS = false;
 inline constexpr uint32_t LOG_PARAMS_LENGTH = 3;
 // use tcd ids here (currently: Split Point, Unison Detune)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -173,4 +173,5 @@ class dsp_host_dual
 #if __POTENTIAL_IMPROVEMENT_NUMERIC_TESTS__
   void PotentialImprovements_RunNumericTests();
 #endif
+  void TestCommonFunctions();
 };

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/pe_exponentiator.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/pe_exponentiator.cpp
@@ -8,46 +8,50 @@ void exponentiator::init()
   uint32_t i;                         // array index variable
   float exp;                          // exponent variable
   /* construct linear pitch table */  // note: table construction loop goes up to range element (as tables are set to be range+1 in size)
-  for(i = 0; i <= dsp_expon_lin_pitch_range; i++)
+  for(i = 0; i <= dsp_expon_lin_pitch_range * EXPON_PREC; i++)
   {
     /* determine exponent of equation */
-    exp = (static_cast<float>(i) + m_linear_pitch_from - m_freqExponent_offset) * m_scaleFreqExponent;
+    exp = ((static_cast<float>(i) / static_cast<float>(EXPON_PREC)) + m_linear_pitch_from - m_freqExponent_offset)
+        * m_scaleFreqExponent;
     /* determine power (base ^ exponent) */
     m_linear_pitch_table[i] = pow(m_freqBase, exp);
   }
   /* construct oscillator pitch table */
   m_oscillator_pitch_table[0] = 0.f;  // set first table element to zero
   /* construct hyperfloor part of oscillator pitch table (second till 19th element) */
-  for(i = 1; i < 20; i++)
+  for(i = 1; i < 20 * EXPON_PREC; i++)
   {
     /* determine exponent of equation */
-    exp = (hyperfloor(static_cast<float>(i) + m_oscillator_pitch_from) - m_freqExponent_offset) * m_scaleFreqExponent;
+    exp = (hyperfloor((static_cast<float>(i) / static_cast<float>(EXPON_PREC)) + m_oscillator_pitch_from)
+           - m_freqExponent_offset)
+        * m_scaleFreqExponent;
     /* determine power (base ^ exponent) */
     m_oscillator_pitch_table[i] = pow(m_freqBase, exp);
   }
   /* construct remaining (linear) part of oscillator pitch table */
-  for(i = 20; i <= dsp_expon_osc_pitch_range; i++)
+  for(i = 20 * EXPON_PREC; i <= dsp_expon_osc_pitch_range * EXPON_PREC; i++)
   {
     /* determine exponent of equation */
-    exp = (static_cast<float>(i) + m_oscillator_pitch_from - m_freqExponent_offset) * m_scaleFreqExponent;
+    exp = ((static_cast<float>(i) / static_cast<float>(EXPON_PREC)) + m_oscillator_pitch_from - m_freqExponent_offset)
+        * m_scaleFreqExponent;
     /* determine power (base ^ exponent) */
     m_oscillator_pitch_table[i] = pow(m_freqBase, exp);
   }
   /* construct level table */
   m_level_table[0] = 0.f;  // set first table element to zero
-  for(i = 1; i <= dsp_expon_level_range; i++)
+  for(i = 1; i <= dsp_expon_level_range * EXPON_PREC; i++)
   {
     /* determine exponent of equation */
-    exp = (static_cast<float>(i) + m_level_from) * m_scaleGainExponent;
+    exp = ((static_cast<float>(i) / static_cast<float>(EXPON_PREC)) + m_level_from) * m_scaleGainExponent;
     /* determine power (base ^ exponent) */
     m_level_table[i] = pow(m_gainBase, exp);
   }
   /* construct time table */
   m_time_table[0] = 0.f;  // set first table element to zero
-  for(i = 1; i <= dsp_expon_time_range; i++)
+  for(i = 1; i <= dsp_expon_time_range * EXPON_PREC; i++)
   {
     /* determine exponent of equation */
-    exp = (static_cast<float>(i) + m_time_from) * m_scaleGainExponent;
+    exp = ((static_cast<float>(i) / static_cast<float>(EXPON_PREC)) + m_time_from) * m_scaleGainExponent;
     /* determine power (base ^ exponent) */
     m_time_table[i] = pow(m_gainBase, exp);
   }
@@ -68,9 +72,10 @@ float exponentiator::clip(float _min, float _max, float _value)
 
 void exponentiator::setTablePos(float _value)
 {
+  const float pos = _value * EXPON_PREC;
   /* convert floating point table position into integer and fractional parts */
-  m_position_step = static_cast<uint32_t>(floor(_value));
-  m_position_fine = _value - static_cast<float>(m_position_step);
+  m_position_step = static_cast<uint32_t>(floor(pos));
+  m_position_fine = pos - static_cast<float>(m_position_step);
 }
 
 float exponentiator::getInterpolated(float _fade, float _first, float _second)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/pe_exponentiator.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/pe_exponentiator.h
@@ -14,6 +14,8 @@
 #include "pe_defines_config.h"
 #include "nltoolbox.h"
 
+#define EXPON_PREC 1
+
 struct exponentiator
 {
   /* table position variables */
@@ -38,12 +40,13 @@ struct exponentiator
   const float m_time_from = dsp_expon_time_from;
   const float m_time_to = dsp_expon_time_range + dsp_expon_time_from;
   /* conversion tables (constructed on initialization) */  // (note: the additional table element (size + 1) prevents interpolation issues)
-  float m_linear_pitch_table[dsp_expon_lin_pitch_range + 1];  // linear pitch table: [-150, 150] semitones
-  float m_oscillator_pitch_table[dsp_expon_osc_pitch_range
+  float m_linear_pitch_table[dsp_expon_lin_pitch_range * EXPON_PREC + 1];  // linear pitch table: [-150, 150] semitones
+  float m_oscillator_pitch_table[dsp_expon_osc_pitch_range * EXPON_PREC
                                  + 1];  // nonlinear pitch table for oscillators: [-20, 130] semitones
-  float
-      m_level_table[dsp_expon_level_range + 1];  // level conversion table: [-300, 100] decibel (first element is zero)
-  float m_time_table[dsp_expon_time_range + 1];  // time conversion table: [-20, 90] decibel (first element is zero)
+  float m_level_table[dsp_expon_level_range * EXPON_PREC
+                      + 1];  // level conversion table: [-300, 100] decibel (first element is zero)
+  float m_time_table[dsp_expon_time_range * EXPON_PREC
+                     + 1];  // time conversion table: [-20, 90] decibel (first element is zero)
   /* proper init */
   void init();  // perform construction of all four conversion tables
   /* hyperbolic osc pitch function (nonlinear pitch floor) */

--- a/projects/epc/playground/src/groups/ParameterGroup.cpp
+++ b/projects/epc/playground/src/groups/ParameterGroup.cpp
@@ -135,7 +135,7 @@ void ParameterGroup::undoableRandomize(UNDO::Transaction *transaction, Initiator
 {
   for(auto p : getParameters())
   {
-    if(!p->isLocked())
+    if(!p->isLocked() && !p->isDisabled())
     {
       p->undoableRandomize(transaction, initiator, amount);
     }

--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -1,3 +1,4 @@
+
 #include <parameters/names/ParameterDB.h>
 #include "Parameter.h"
 #include "groups/ParameterGroup.h"
@@ -168,7 +169,7 @@ bool Parameter::isDisabledForType(SoundType type) const
       return number == C15::PID::FB_Mix_Osc || number == C15::PID::FB_Mix_Osc_Src;
     case SoundType::Layer:
     case SoundType::Invalid:
-      return true;
+      return false;
   }
   return false;
 }

--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -170,12 +170,19 @@ bool Parameter::isDisabledForType(SoundType type) const
     case SoundType::Invalid:
       return true;
   }
+  return false;
 }
 
 void Parameter::loadDefault(UNDO::Transaction *transaction, Defaults mode)
 {
-  if(!isDisabled() && !isLocked())
-    loadFromPreset(transaction, mode == Defaults::UserDefault ? getDefaultValue() : getFactoryDefaultValue());
+  if(mode == Defaults::FactoryDefault)
+  {
+    loadFromPreset(transaction, getFactoryDefaultValue());
+  }
+  else if(!isLocked())
+  {
+    loadFromPreset(transaction, getDefaultValue());
+  }
 }
 
 bool Parameter::isDefaultLoaded() const

--- a/projects/epc/playground/src/parameters/Parameter.h
+++ b/projects/epc/playground/src/parameters/Parameter.h
@@ -146,6 +146,9 @@ class Parameter : public UpdateDocumentContributor,
   bool isMinimum() const;
   void resetWasDefaulted(UNDO::Transaction* transaction);
 
+  bool isDisabledForType(SoundType type) const;
+  bool isDisabled() const;
+
  protected:
   virtual void sendToPlaycontroller() const;
   void setCpValue(UNDO::Transaction *transaction, Initiator initiator, tControlPositionValue value, bool dosendToPlaycontroller);

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -1368,7 +1368,6 @@ void EditBuffer::undoableConvertSplitToLayer(UNDO::Transaction *transaction)
 {
   auto currentVG = Application::get().getHWUI()->getCurrentVoiceGroup();
   copyVoicesGroups(transaction, currentVG, invert(currentVG));
-  undoableUnisonMonoLoadDefaults(transaction, VoiceGroup::II);
   calculateFadeParamsFromSplitPoint(transaction);
   undoableUnisonMonoLoadDefaults(transaction, VoiceGroup::II);
   initSplitPoint(transaction);

--- a/projects/epc/playground/src/presets/EditBufferActions.cpp
+++ b/projects/epc/playground/src/presets/EditBufferActions.cpp
@@ -262,7 +262,6 @@ EditBufferActions::EditBufferActions(EditBuffer* editBuffer)
     auto transaction = scope->getTransaction();
     auto voiceGroup = to<VoiceGroup>(request->get("voice-group"));
     editBuffer->undoableConvertToSingle(transaction, voiceGroup);
-    Application::get().getHWUI()->setFocusAndMode(FocusAndMode { UIFocus::Sound, UIMode::Select, UIDetail::Init });
     Application::get().getHWUI()->setCurrentVoiceGroupAndUpdateParameterSelection(transaction, VoiceGroup::I);
   });
 
@@ -270,14 +269,12 @@ EditBufferActions::EditBufferActions(EditBuffer* editBuffer)
     auto scope = editBuffer->getUndoScope().startTransaction("Convert to Split");
     auto transaction = scope->getTransaction();
     editBuffer->undoableConvertToDual(transaction, SoundType::Split);
-    Application::get().getHWUI()->setFocusAndMode(FocusAndMode { UIFocus::Sound, UIMode::Select, UIDetail::Init });
   });
 
   addAction("convert-to-layer", [=](auto request) {
     auto scope = editBuffer->getUndoScope().startTransaction("Convert to Layer");
     auto transaction = scope->getTransaction();
     editBuffer->undoableConvertToDual(transaction, SoundType::Layer);
-    Application::get().getHWUI()->setFocusAndMode(FocusAndMode { UIFocus::Sound, UIMode::Select, UIDetail::Init });
   });
 
   addAction("load-selected-preset-part-into-editbuffer-part", [=](auto request) {

--- a/projects/epc/playground/src/presets/PresetManager.cpp
+++ b/projects/epc/playground/src/presets/PresetManager.cpp
@@ -262,16 +262,6 @@ void PresetManager::scheduleAutoLoadPresetAccordingToLoadType()
   });
 }
 
-void PresetManager::TEST_forceScheduledAutoLoad()
-{
-  m_autoLoadThrottler.doActionSync();
-}
-
-bool PresetManager::isAutoLoadScheduled() const
-{
-  return m_autoLoadScheduled;
-}
-
 bool PresetManager::isLoading() const
 {
   return m_isLoading.isLocked();

--- a/projects/epc/playground/src/presets/PresetManager.h
+++ b/projects/epc/playground/src/presets/PresetManager.h
@@ -118,10 +118,6 @@ class PresetManager : public ContentSection
   const Preset *getSelectedPreset() const;
   Preset *getSelectedPreset();
 
-  //Test Helper
-  void TEST_forceScheduledAutoLoad();
-  bool isAutoLoadScheduled() const;
-
   bool currentLoadedPartIsBeforePresetToLoad() const;
 
   void scheduleLoadToPart(const Preset *preset, VoiceGroup loadFrom, VoiceGroup loadTo);

--- a/projects/epc/playground/src/proxies/hwui/HWUI.cpp
+++ b/projects/epc/playground/src/proxies/hwui/HWUI.cpp
@@ -794,10 +794,10 @@ void HWUI::exportOled(uint32_t x, uint32_t y, uint32_t w, uint32_t h, const std:
 {
   typedef std::tuple<uint8_t, uint8_t, uint8_t> RGB;
   static std::map<uint8_t, RGB> colorMap
-      = { { 0x00, std::make_tuple(43, 32, 21) },   { 0x02, std::make_tuple(77, 60, 10) },
-          { 0x05, std::make_tuple(103, 81, 12) },  { 0x06, std::make_tuple(128, 102, 16) },
-          { 0x0A, std::make_tuple(179, 142, 21) }, { 0x0B, std::make_tuple(204, 162, 24) },
-          { 0x0F, std::make_tuple(255, 203, 31) } };
+      = { { 0x00, std::make_tuple(0, 0, 0) },       { 0x02, std::make_tuple(73, 73, 73) },
+          { 0x05, std::make_tuple(110, 110, 110) }, { 0x06, std::make_tuple(146, 146, 146) },
+          { 0x0A, std::make_tuple(183, 183, 183) }, { 0x0B, std::make_tuple(219, 219, 219) },
+          { 0x0F, std::make_tuple(255, 255, 255) } };
 
   constexpr auto frameBufferDimX = 256;
   constexpr auto frameBufferDimY = 96;

--- a/projects/epc/playground/src/proxies/hwui/OLEDProxy.cpp
+++ b/projects/epc/playground/src/proxies/hwui/OLEDProxy.cpp
@@ -62,6 +62,12 @@ void OLEDProxy::reset(tLayoutPtr layout)
   if(!layout->isInitialized())
     layout->init();
 
+  if(m_onLayoutInstalledCB)
+  {
+    m_onLayoutInstalledCB(layout.get());
+    m_onLayoutInstalledCB = nullptr;
+  }
+
   DebugLevel::info(G_STRLOC, typeid(layout.get()).name());
   invalidate();
 }
@@ -112,4 +118,13 @@ void OLEDProxy::clear()
   auto &fb = FrameBuffer::get();
   fb.setColor(FrameBufferColors::C43);
   fb.fillRect(Rect(0, 0, m_posInFrameBuffer.getWidth(), m_posInFrameBuffer.getHeight()));
+}
+
+void OLEDProxy::onLayoutInstalled(std::function<void(Layout *)> cb)
+{
+  if(m_onLayoutInstalledCB != nullptr)
+  {
+    nltools::Log::warning("removing non called onLayoutInstalled Callback!", __LINE__, __PRETTY_FUNCTION__, __FILE__);
+  }
+  m_onLayoutInstalledCB = cb;
 }

--- a/projects/epc/playground/src/proxies/hwui/OLEDProxy.h
+++ b/projects/epc/playground/src/proxies/hwui/OLEDProxy.h
@@ -4,6 +4,7 @@
 #include <nltools/Uncopyable.h>
 #include <proxies/hwui/controls/Rect.h>
 #include <memory>
+#include <functional>
 
 class Application;
 class Layout;
@@ -25,6 +26,8 @@ class OLEDProxy : public Uncopyable
 
   virtual void reset(tLayoutPtr layout);
 
+  void onLayoutInstalled(std::function<void(Layout *)> cb);
+
   void setOverlay(Layout *layout);
   void setOverlay(tLayoutPtr layout);
 
@@ -38,6 +41,8 @@ class OLEDProxy : public Uncopyable
   const Rect &getPosInFrameBuffer() const;
 
  private:
+  std::function<void(Layout *)> m_onLayoutInstalledCB;
+
   tLayoutPtr m_layout;
   tLayoutPtr m_overlay;
   Rect m_posInFrameBuffer;

--- a/projects/epc/playground/src/proxies/hwui/controls/SelectedParameterValue.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/SelectedParameterValue.cpp
@@ -11,7 +11,8 @@ SelectedParameterValue::SelectedParameterValue(const Rect &rect)
     : super(rect)
 {
   Application::get().getPresetManager()->getEditBuffer()->onSelectionChanged(
-      sigc::hide<0>(sigc::mem_fun(this, &SelectedParameterValue::onParameterSelected)), getHWUI()->getCurrentVoiceGroup());
+      sigc::hide<0>(sigc::mem_fun(this, &SelectedParameterValue::onParameterSelected)),
+      getHWUI()->getCurrentVoiceGroup());
 
   Application::get().getHWUI()->onModifiersChanged(sigc::mem_fun(this, &SelectedParameterValue::onModifiersChanged));
 
@@ -28,7 +29,8 @@ SelectedParameterValue::~SelectedParameterValue()
 
 void SelectedParameterValue::onModifiersChanged(ButtonModifiers mods)
 {
-  onParamValueChanged(Application::get().getPresetManager()->getEditBuffer()->getSelected(getHWUI()->getCurrentVoiceGroup()));
+  onParamValueChanged(
+      Application::get().getPresetManager()->getEditBuffer()->getSelected(getHWUI()->getCurrentVoiceGroup()));
 }
 
 void SelectedParameterValue::onParameterSelected(Parameter *parameter)
@@ -40,7 +42,7 @@ void SelectedParameterValue::onParameterSelected(Parameter *parameter)
     m_paramValueConnection
         = parameter->onParameterChanged(sigc::mem_fun(this, &SelectedParameterValue::onParamValueChanged));
 
-    setVisible(ParameterLayout2::isParameterAvailableInSoundType(parameter));
+    setVisible(!parameter->isDisabled());
   }
 }
 
@@ -51,7 +53,11 @@ void SelectedParameterValue::onParamValueChanged(const Parameter *param)
 
 bool SelectedParameterValue::redraw(FrameBuffer &fb)
 {
-  auto amount = Application::get().getPresetManager()->getEditBuffer()->getSelected(getHWUI()->getCurrentVoiceGroup())->getDisplayString();
+  auto amount = Application::get()
+                    .getPresetManager()
+                    ->getEditBuffer()
+                    ->getSelected(getHWUI()->getCurrentVoiceGroup())
+                    ->getDisplayString();
 
   if(Application::get().getHWUI()->isModifierSet(ButtonModifier::FINE))
   {
@@ -77,7 +83,7 @@ void SelectedParameterValue::onVoiceGroupSelectionChanged(VoiceGroup v)
 
 void SelectedParameterValue::onSoundTypeChanged()
 {
-  auto selected = Application::get().getPresetManager()->getEditBuffer()->getSelected(getHWUI()->getCurrentVoiceGroup());
-  auto visible = ParameterSelectLayout2::isParameterAvailableInSoundType(selected);
-  setVisible(visible);
+  auto selected
+      = Application::get().getPresetManager()->getEditBuffer()->getSelected(getHWUI()->getCurrentVoiceGroup());
+  setVisible(!selected->isDisabled());
 }

--- a/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
@@ -13,9 +13,9 @@ Slider::Slider(Parameter *param, const Rect &rect)
     , m_value(0)
     , m_bipolar(false)
 {
+  setParameter(param);
   Application::get().getPresetManager()->getEditBuffer()->onSoundTypeChanged(
       sigc::hide(sigc::mem_fun(this, &Slider::onSoundTypeChanged)), false);
-  setParameter(param);
 }
 
 Slider::Slider(const Rect &rect)
@@ -53,7 +53,7 @@ void Slider::onParamValueChanged(const Parameter *param)
 
 void Slider::onSoundTypeChanged()
 {
-  setVisible(!m_param->isDisabled());
+  setVisible(m_param && !m_param->isDisabled());
 }
 
 void Slider::setValue(tDisplayValue v, bool bipolar)

--- a/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/Slider.cpp
@@ -36,8 +36,7 @@ void Slider::setParameter(Parameter *param)
     else
       setValue(0, false);
 
-    auto visible = ParameterSelectLayout2::isParameterAvailableInSoundType(m_param);
-    setVisible(visible);
+    setVisible(!m_param->isDisabled());
     setDirty();
   }
 }
@@ -54,7 +53,7 @@ void Slider::onParamValueChanged(const Parameter *param)
 
 void Slider::onSoundTypeChanged()
 {
-  setVisible(ParameterLayout2::isParameterAvailableInSoundType(m_param));
+  setVisible(!m_param->isDisabled());
 }
 
 void Slider::setValue(tDisplayValue v, bool bipolar)

--- a/projects/epc/playground/src/proxies/hwui/controls/SwitchVoiceGroupButton.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/SwitchVoiceGroupButton.cpp
@@ -62,7 +62,7 @@ bool SwitchVoiceGroupButton::allowToggling(const Parameter* selected, const Edit
          && (!MonoGroup::isMonoParameter(selected) && !UnisonGroup::isUnisonParameter(selected)))
       || (editBuffer->getType() != SoundType::Layer);
 
-  if(ParameterLayout2::isParameterAvailableInSoundType(selected, editBuffer))
+  if(!selected->isDisabled())
     return layerAndGroupAllowToggling;
   else
     return false;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
@@ -65,14 +65,15 @@ PanelUnit::PanelUnit()
         editBuffer->undoableSelectParameter(scope->getTransaction(), modParam);
 
         auto hwui = Application::get().getHWUI();
-        auto layout = hwui->getPanelUnit().getEditPanel().getBoled().getLayout();
-
-        if(auto modParamLayout = dynamic_cast<ModulateableParameterSelectLayout2 *>(layout.get()))
-        {
-          modParamLayout->installMcAmountScreen();
-          m_macroControlAssignmentStateMachine.setState(MacroControlAssignmentStates::Initial);
-          return true;
-        }
+        auto &boled = hwui->getPanelUnit().getEditPanel().getBoled();
+        boled.onLayoutInstalled([&](Layout *l) {
+          if(auto modParamLayout = dynamic_cast<ModulateableParameterSelectLayout2 *>(l))
+          {
+            modParamLayout->installMcAmountScreen();
+            m_macroControlAssignmentStateMachine.setState(MacroControlAssignmentStates::Initial);
+            return true;
+          }
+        });
       }
     }
     return true;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLED.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLED.h
@@ -26,7 +26,6 @@ class BOLED : public OLEDProxy, public sigc::trackable
   void onRotary(signed char i);
 
   void setupFocusAndMode(FocusAndMode focusAndMode);
-
   void showUndoScreen();
 
   void bruteForce();

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ModulateableParameterLayouts.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ModulateableParameterLayouts.cpp
@@ -537,10 +537,10 @@ void ModulateableParameterSelectLayout2::setMode(Mode desiredMode)
       break;
   }
 }
+
 bool ModulateableParameterSelectLayout2::isCurrentParameterDisabled() const
 {
-  return !isParameterAvailableInSoundType(getCurrentParameter(),
-                                          Application::get().getPresetManager()->getEditBuffer());
+  return getCurrentParameter()->isDisabled();
 }
 
 bool ModulateableParameterSelectLayout2::isModeOf(std::vector<ModulateableParameterSelectLayout2::Mode> modes) const

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
@@ -134,7 +134,7 @@ bool ParameterLayout2::onRotary(int inc, ButtonModifiers modifiers)
 {
   if(auto p = getCurrentEditParameter())
   {
-    if(isParameterAvailableInSoundType(p))
+    if(!p->isDisabled())
     {
       auto name = ParameterId::isGlobal(p->getID().getNumber()) ? p->getGroupAndParameterName()
                                                                 : p->getGroupAndParameterNameWithVoiceGroup();
@@ -160,34 +160,6 @@ void ParameterLayout2::handlePresetValueRecall()
         getOLEDProxy().setOverlay(new ParameterRecallLayout2());
     }
   }
-}
-
-bool ParameterLayout2::isParameterAvailableInSoundType(const Parameter *p, const EditBuffer *eb)
-{
-  auto currentType = eb->getType();
-
-  if(!p)
-    return false;
-
-  auto number = p->getID().getNumber();
-
-  switch(currentType)
-  {
-    case SoundType::Single:
-    case SoundType::Split:
-      return number != 346 && number != 348;
-    case SoundType::Layer:
-    case SoundType::Invalid:
-      break;
-  }
-
-  return true;
-}
-
-bool ParameterLayout2::isParameterAvailableInSoundType(const Parameter *p)
-{
-  auto eb = Application::get().getPresetManager()->getEditBuffer();
-  return isParameterAvailableInSoundType(p, eb);
 }
 
 ParameterSelectLayout2::ParameterSelectLayout2()
@@ -240,7 +212,7 @@ bool ParameterSelectLayout2::onButton(Buttons i, bool down, ButtonModifiers modi
         break;
 
       case Buttons::BUTTON_D:
-        if(m_carousel && isParameterAvailableInSoundType(getCurrentParameter()))
+        if(m_carousel && !getCurrentParameter()->isDisabled())
         {
           if(modifiers[SHIFT] == 1)
           {

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.h
@@ -22,9 +22,6 @@ class ParameterLayout2 : public Layout
   typedef ParameterLayout2 virtual_base;
   ParameterLayout2();
 
-  static bool isParameterAvailableInSoundType(const Parameter *p, const EditBuffer *eb);
-  static bool isParameterAvailableInSoundType(const Parameter *p);
-
  protected:
   void init() override;
   constexpr static int BUTTON_VALUE_Y_POSITION = 34;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
@@ -15,8 +15,7 @@ MCSelectButton::~MCSelectButton() = default;
 
 void MCSelectButton::update(const Parameter *parameter)
 {
-  if(!ParameterLayout2::isParameterAvailableInSoundType(parameter,
-                                                        Application::get().getPresetManager()->getEditBuffer()))
+  if(parameter->isDisabled())
   {
     setText("");
     return;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MCSelectButton.cpp
@@ -15,7 +15,7 @@ MCSelectButton::~MCSelectButton() = default;
 
 void MCSelectButton::update(const Parameter *parameter)
 {
-  if(parameter->isDisabled())
+  if(parameter == nullptr || parameter->isDisabled())
   {
     setText("");
     return;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.cpp
@@ -26,8 +26,7 @@ void ParameterCarousel::setup(Parameter* selectedParameter)
   clear();
 
   auto um = Application::get().getHWUI()->getPanelUnit().getUsageMode();
-  const auto paramAvailable = ParameterSelectLayout2::isParameterAvailableInSoundType(
-      selectedParameter, Application::get().getPresetManager()->getEditBuffer());
+  const auto paramAvailable = !selectedParameter->isDisabled();
 
   if(std::shared_ptr<PanelUnitParameterEditMode> edit = std::dynamic_pointer_cast<PanelUnitParameterEditMode>(um))
   {

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterNotAvailableInSoundInfo.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterNotAvailableInSoundInfo.cpp
@@ -45,8 +45,8 @@ ParameterNotAvailableInSoundInfo::ParameterNotAvailableInSoundInfo(const Rect &r
   addControl(new CenterAlignedLabel("Only available with", { 0, 20, 128, 10 }))->setHighlight(true);
   addControl(new CenterAlignedLabel("Layer Sounds", { 0, 32, 128, 10 }))->setHighlight(true);
 
-  auto vis = !ParameterLayout2::isParameterAvailableInSoundType(eb->getSelected(hwui->getCurrentVoiceGroup()));
-  setVisible(vis);
+  auto selected = eb->getSelected(hwui->getCurrentVoiceGroup());
+  setVisible(selected->isDisabled());
 }
 
 void ParameterNotAvailableInSoundInfo::setBackgroundColor(FrameBuffer &fb) const
@@ -56,16 +56,15 @@ void ParameterNotAvailableInSoundInfo::setBackgroundColor(FrameBuffer &fb) const
 
 void ParameterNotAvailableInSoundInfo::onSelectionChanged(const Parameter *old, const Parameter *newParam)
 {
-  auto vis = !ParameterLayout2::isParameterAvailableInSoundType(newParam);
   m_parameterNameLabel->setText({ newParam->getLongName(), 0 });
-  setVisible(vis);
+  setVisible(newParam->isDisabled());
 }
 
 void ParameterNotAvailableInSoundInfo::onSoundTypeChanged()
 {
   auto eb = Application::get().getPresetManager()->getEditBuffer();
   auto current = eb->getSelected(getHWUI()->getCurrentVoiceGroup());
-  const auto vis = !ParameterLayout2::isParameterAvailableInSoundType(current, eb);
+  const auto vis = current->isDisabled();
   m_parameterNameLabel->setText({ current->getLongName(), 0 });
   setVisible(vis);
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/SelectedParameterModAmount.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/SelectedParameterModAmount.cpp
@@ -28,8 +28,7 @@ void SelectedParameterModAmount::setParameter(Parameter *param)
     m_paramValueConnection
         = param->onParameterChanged(sigc::mem_fun(this, &SelectedParameterModAmount::onParamValueChanged));
 
-    auto eb = Application::get().getPresetManager()->getEditBuffer();
-    auto available = ParameterLayout2::isParameterAvailableInSoundType(param, eb);
+    auto available = !param->isDisabled();
     setVisible(available);
   }
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/SelectedParamsMacroControlSlider.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/SelectedParamsMacroControlSlider.cpp
@@ -59,7 +59,7 @@ void SelectedParamsMacroControlSlider::setParameter(Parameter *param)
   if(param)
   {
     auto eb = Application::get().getPresetManager()->getEditBuffer();
-    setVisible(ParameterLayout2::isParameterAvailableInSoundType(param, eb));
+    setVisible(!param->isDisabled());
   }
 }
 

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/PartOriginAttributeTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/PartOriginAttributeTests.cpp
@@ -113,14 +113,6 @@ auto getOrigins()
   return std::pair { eb->getPartOrigin(VoiceGroup::I), eb->getPartOrigin(VoiceGroup::II) };
 };
 
-auto forceAutoLoadIfPending()
-{
-  auto pm = Application::get().getPresetManager();
-
-  if(pm->isAutoLoadScheduled())
-    pm->TEST_forceScheduledAutoLoad();
-}
-
 TEST_CASE("Step Direct Load and Load to Part Preset List", "[Preset][Loading]")
 {
   DualPresetBank presets;
@@ -159,58 +151,54 @@ TEST_CASE("Step Direct Load and Load to Part Preset List", "[Preset][Loading]")
                                                             { UIFocus::Presets, UIMode::Select, UIDetail::Init });
     }
 
-    forceAutoLoadIfPending();
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&]() {
+      auto uuid = eb->getUUIDOfLastLoadedPreset();
+      return uuid == bank->getPresetAt(0)->getUuid();
+    });
 
-    auto uuid = eb->getUUIDOfLastLoadedPreset();
-    CHECK(uuid == bank->getPresetAt(0)->getUuid());
     hwui->setLoadToPart(true);
 
     detail::pressButton(Buttons::BUTTON_INC);
-    forceAutoLoadIfPending();
-    {
+
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&]() {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(0)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::II);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(0)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::II;
+    });
 
     detail::pressButton(Buttons::BUTTON_INC);
-    forceAutoLoadIfPending();
-    {
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&] {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(1)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::I);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(1)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::I;
+    });
 
     detail::pressButton(Buttons::BUTTON_INC);
-    forceAutoLoadIfPending();
-    {
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&] {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(1)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::II);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(1)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::II;
+    });
 
     detail::pressButton(Buttons::BUTTON_DEC);
-    forceAutoLoadIfPending();
-    {
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&] {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(1)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::I);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(1)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::I;
+    });
 
     detail::pressButton(Buttons::BUTTON_DEC);
-    forceAutoLoadIfPending();
-    {
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&] {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(0)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::II);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(0)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::II;
+    });
 
     detail::pressButton(Buttons::BUTTON_DEC);
-    forceAutoLoadIfPending();
-    {
+    TestHelper::doMainLoop(std::chrono::milliseconds(200), std::chrono::milliseconds(1000), [&] {
       auto [ogI, ogII] = getOrigins();
-      CHECK(ogI.presetUUID == bank->getPresetAt(0)->getUuid());
-      CHECK(ogI.sourceGroup == VoiceGroup::I);
-    }
+      auto x = ogI.presetUUID == bank->getPresetAt(0)->getUuid();
+      return x && ogI.sourceGroup == VoiceGroup::I;
+    });
   }
 }

--- a/projects/epc/playground/src/testing/unit-tests/ui-acceptance/PreviousStateOnSameButtonTest.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/ui-acceptance/PreviousStateOnSameButtonTest.cpp
@@ -30,42 +30,44 @@ TEST_CASE("Test Previous Boled Focus on Button")
 
   auto getFocusAndMode = [&hwui] { return hwui->getFocusAndMode(); };
 
-  CHECK(isParameterLayout(getLayout()));
+  const auto min = std::chrono::milliseconds(200);
+  const auto max = std::chrono::milliseconds(1000);
+
+  TestHelper::doMainLoop(min, max, [&] { return isParameterLayout(getLayout()); });
 
   SECTION("Parameter to Preset and Back")
   {
     auto oldFocus = getFocusAndMode();
     pressButton(Buttons::BUTTON_PRESET);
-    CHECK(isPresetLayout(getLayout()));
+    TestHelper::doMainLoop(min, max, [&] { return isPresetLayout(getLayout()); });
     pressButton(Buttons::BUTTON_PRESET);
-    auto newFocus = getFocusAndMode();
-    CHECK(newFocus == oldFocus);
+    TestHelper::doMainLoop(min, max, [&] { return oldFocus == getFocusAndMode(); });
   }
 
   SECTION("Parameter to Store and Back")
   {
     auto oldFocus = getFocusAndMode();
     pressButton(Buttons::BUTTON_STORE);
-    CHECK(isPresetLayout(getLayout()));
+    TestHelper::doMainLoop(min, max, [&] { return isPresetLayout(getLayout()); });
     pressButton(Buttons::BUTTON_STORE);
-    auto newFocus = getFocusAndMode();
-    CHECK(newFocus == oldFocus);
+    TestHelper::doMainLoop(min, max, [&] { return oldFocus == getFocusAndMode(); });
   }
 
   SECTION("Parameter to Store to Preset")
   {
     pressButton(Buttons::BUTTON_STORE);
-    CHECK(isPresetLayout(getLayout()));
+    TestHelper::doMainLoop(min, max, [&] { return isPresetLayout(getLayout()); });
     pressButton(Buttons::BUTTON_PRESET);
-    CHECK(isPresetLayout(getLayout()));
-    CHECK(getFocusAndMode().mode == UIMode::Select);
+    TestHelper::doMainLoop(min, max,
+                           [&] { return isPresetLayout(getLayout()) && getFocusAndMode().mode == UIMode::Select; });
   }
 
-  SECTION("Parameter to Preset to Store") {
+  SECTION("Parameter to Preset to Store")
+  {
     pressButton(Buttons::BUTTON_PRESET);
-    CHECK(isPresetLayout(getLayout()));
+    TestHelper::doMainLoop(min, max, [&] { return isPresetLayout(getLayout()); });
     pressButton(Buttons::BUTTON_STORE);
-    CHECK(isPresetLayout(getLayout()));
-    CHECK(getFocusAndMode().mode == UIMode::Store);
+    TestHelper::doMainLoop(min, max,
+                           [&] { return isPresetLayout(getLayout()) && getFocusAndMode().mode == UIMode::Store; });
   }
 }

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/useCases/IncrementalChanger.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/useCases/IncrementalChanger.java
@@ -58,6 +58,9 @@ public class IncrementalChanger {
 
 	public void changeBy(boolean fine, double amount) {
 
+		if(amount == 0)
+			return;
+
 		amount /= pixPerRange;
 
 		if (isBipolar)
@@ -68,21 +71,34 @@ public class IncrementalChanger {
 
 		pendingAmount += bendAmount(amount);
 
-		double newVal = getQuantizedValue(lastQuantizedValue + pendingAmount, fine);
-		newVal = clip(newVal);
+		double newValRaw = getQuantizedValue(lastQuantizedValue + amount, fine);
+		double newValPending = getQuantizedValue(lastQuantizedValue + pendingAmount, fine);
 
-		if (newVal != lastQuantizedValue) {
+		newValPending = clip(newValPending);
+
+		if (newValPending != lastQuantizedValue) {
 
 			if (isBoolean) {
-				if (newVal > lastQuantizedValue)
-					newVal = 1.0;
-				else if (newVal < lastQuantizedValue)
-					newVal = 0.0;
+				if (newValPending > lastQuantizedValue)
+					newValPending = 1.0;
+				else if (newValPending < lastQuantizedValue)
+					newValPending = 0.0;
 			}
 
-			callback.accept(newVal, false);
+			callback.accept(newValPending, false);
 			pendingAmount = 0;
-			lastQuantizedValue = newVal;
+			lastQuantizedValue = newValPending;
+		} else if (newValRaw != lastQuantizedValue && (lastQuantizedValue == getLowerBorder() || lastQuantizedValue == getUpperBorder())) {
+			if (isBoolean) {
+				if (newValRaw > lastQuantizedValue)
+					newValRaw = 1.0;
+				else if (newValRaw < lastQuantizedValue)
+					newValRaw = 0.0;
+			}
+
+			callback.accept(newValRaw, false);
+			pendingAmount = 0;
+			lastQuantizedValue = newValRaw;
 		}
 	}
 

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/presets/BankContextMenu.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/presets/BankContextMenu.java
@@ -69,6 +69,16 @@ public abstract class BankContextMenu extends ContextMenu {
 
 		if (bank != null) {
 
+			addChild(new ContextMenuItem(this, "Export Bank as File ...") {
+				@Override
+				public Control click(Position eventPoint) {
+					String bankName = URL.encodePathSegment(bank.getCurrentName());
+					String uri = "/presets/banks/download-bank/" + bankName + ".xml?uuid=" + bank.getUUID();
+					Window.open(uri, "", "");
+					return super.click(eventPoint);
+				}
+			});
+
 			if (!BankInfoDialog.isShown()) {
 				String bankInfoText = "Bank Info ...";
 				addChild(new ContextMenuItem(this, bankInfoText) {
@@ -148,16 +158,6 @@ public abstract class BankContextMenu extends ContextMenu {
 					}
 				});
 			}
-
-			addChild(new ContextMenuItem(this, "Export as File ...") {
-				@Override
-				public Control click(Position eventPoint) {
-					String bankName = URL.encodePathSegment(bank.getCurrentName());
-					String uri = "/presets/banks/download-bank/" + bankName + ".xml?uuid=" + bank.getUUID();
-					Window.open(uri, "", "");
-					return super.click(eventPoint);
-				}
-			});
 
 			addChild(new ContextMenuItem(this, "Sort Bank Numbers") {
 				@Override

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/presets/PresetManagerContextMenu.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/presets/PresetManagerContextMenu.java
@@ -9,6 +9,7 @@ import com.google.gwt.user.client.Window.Navigator;
 import com.google.gwt.user.client.ui.FileUpload;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.nonlinearlabs.client.ClipboardManager.ClipboardContent;
+import com.nonlinearlabs.client.dataModel.presetManager.PresetManagerModel;
 import com.nonlinearlabs.client.NonMaps;
 import com.nonlinearlabs.client.Renameable;
 import com.nonlinearlabs.client.world.Control;
@@ -19,6 +20,8 @@ import com.nonlinearlabs.client.world.maps.presets.PresetManager;
 import com.nonlinearlabs.client.world.overlay.ContextMenu;
 import com.nonlinearlabs.client.world.overlay.ContextMenuItem;
 import com.nonlinearlabs.client.world.overlay.OverlayLayout;
+import com.nonlinearlabs.client.world.maps.presets.bank.Bank;
+import com.google.gwt.http.client.URL;
 
 public class PresetManagerContextMenu extends ContextMenu {
 
@@ -56,6 +59,22 @@ public class PresetManagerContextMenu extends ContextMenu {
 					NonMaps.theMaps.getServerProxy().importBank(fileName, text, pos);
 				}, ".xml");
 
+				return super.click(eventPoint);
+			}
+		});
+
+
+		PresetManager pm = NonMaps.get().getNonLinearWorld().getPresetManager();
+		Bank bank = pm.findBank(pm.getSelectedBank());
+
+		String name = "Export Bank (" + bank.getOrderNumber() + " - " + bank.getCurrentName() + ") to File ...";
+
+		addChild(new ContextMenuItem(this, name) {
+			@Override
+			public Control click(final Position eventPoint) {
+				String bankName = URL.encodePathSegment(bank.getCurrentName());
+				String uri = "/presets/banks/download-bank/" + bankName + ".xml?uuid=" + bank.getUUID();
+				Window.open(uri, "", "");
 				return super.click(eventPoint);
 			}
 		});
@@ -107,8 +126,6 @@ public class PresetManagerContextMenu extends ContextMenu {
 			}
 
 		});
-
-		PresetManager pm = getNonMaps().getNonLinearWorld().getPresetManager();
 
 		addChild(new ContextMenuItem(this, !pm.isInMoveAllBanks() ? "Move all Banks" : "Disable Move all Banks") {
 			@Override

--- a/projects/epc/web-ui/src/main/webapp/style.css
+++ b/projects/epc/web-ui/src/main/webapp/style.css
@@ -908,6 +908,7 @@ input[type="range"]::-moz-range-thumb {
 	background: #fff;
 	border-radius: 0px;
 	border: 1px solid #000;
+	cursor: not-allowed !important;
 }
 
 .slider-c::-moz-range-thumb {
@@ -937,6 +938,7 @@ input[type="range"]::-webkit-slider-thumb {
 	height: 8px;
 	background: #fff;
 	border-radius: 0px;
+	cursor: not-allowed !important;
 }
 
 .slider-c::-webkit-slider-thumb {


### PR DESCRIPTION
trying to solve #2206

I further simplified the problematic "Carbon Pad tst 5" (beware of short env times!) and attached another buggy brass sound (that clearly suffers from similar effects, although the mono feedback also is involved), see:

[Comb Issue (2206).zip](https://github.com/nonlinear-labs-dev/C15/files/5287998/Comb.Issue.2206.zip)

I transferred the Carbon Preset to the R5 Prototype (62) and tested both the old and eco AP for the DC offset.

The results so far:
- [x] Comb AP: in R5, both filters work and produce similar results (AP ECO seems to be fine)
- [x] Comb LP, AP: in the Linux Engine, disabling DSP of LP and AP still produces offset (the filters do not seem involved)
- [x] recent optimizations: reverting global DNC, re-introducing DNC-Offset, reverting parallel-data improvements in the Comb Filter still produce offset (as expected, not involved in offset)
- [x] observed final Decay factor (the "g" wire, multiplying on the "z" in R5) and Delay time (after clipping, before rounding) in R5 and Linux Engine: signals behave similarly and modulation depth by "PM" seems right (so, Delay Time clipping is not the issue) / deviation less than 0.1%
- [x] observe and compare saturated signal (before delay write) in R5 and Linux Engine: maximal observed signal ranges over several octaves [-2.1 ... 2.2], typical observed ranges [-1.5 ... 2.1] -> hinting at an offset (but, this effect occurs both in Prototype and Engine...)
- [x] confirmed similar Decay Times between R5 and LE (deviation less than 1%)
- [x] confirmed that higher resolution/precision for exponentiation tables (pitches, levels, times) does not affect dc offset