### PR TITLE
Fix XML to not crash on older versions

### DIFF
--- a/projects/epc/playground/src/presets/recall/RecallParameterGroups.cpp
+++ b/projects/epc/playground/src/presets/recall/RecallParameterGroups.cpp
@@ -43,7 +43,6 @@ RecallParameter *RecallParameterGroups::findParameterByID(const ParameterId &id)
   if(it != m_parameters.end())
     return it->second.get();
 
-  nltools::throwException("Could not find Recall Parameter with id ", id.toString());
   return nullptr;
 }
 


### PR DESCRIPTION
change recall parameter set xml tag to recall-param-v2 to prevent reading invalid IDS in old versions