### PR TITLE
Issue 1962

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_out_mix.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_out_mix.cpp
@@ -16,15 +16,20 @@ Engine::PolyOutputMixer::PolyOutputMixer()
 void Engine::PolyOutputMixer::init(const float _samplerate, const uint32_t _numOfVoices)
 {
   m_out_l = m_out_r = 0.0f;
-  m_hp30hz_b0 = (6.28319f / _samplerate) * 30.0f;
-  m_hp30hz_b0 = std::min(m_hp30hz_b0, 0.8f);
+  const float norm_omega = NlToolbox::Constants::twopi / _samplerate;
+  m_hp30hz_b0 = norm_omega * 30.0f;  // 30 Hz - no clipping needed
   m_hp30hz_stateVar_L = m_hp30hz_stateVar_R = 0.0f;
-  float omega = NlToolbox::Math::tan(12.978f * NlToolbox::Constants::pi / static_cast<float>(_samplerate));
+#if OutMix_SimpleHP == 0
+  float omega = NlToolbox::Math::tan(12.978f * NlToolbox::Constants::pi / _samplerate);
   float denom = 1.0f / (1.0f + omega);
   m_hp_a1 = (1.0f - omega) * denom;
   m_hp_b0 = denom;
   m_hp_b1 = -denom;
   m_hp_stateVar_L1 = m_hp_stateVar_L2 = m_hp_stateVar_R1 = m_hp_stateVar_R2 = 0.0f;
+#elif OutMix_SimpleHP == 1
+  m_hp_b0 = norm_omega * 12.978f;  // 8 ST (12.978 Hz) - no clipping needed
+  m_hp_stateVar_L = m_hp_stateVar_R = 0.0f;
+#endif
 }
 
 void Engine::PolyOutputMixer::combine(PolySignals &_signals, const PolyValue &_voiceLevel, const PolyValue &_sampleA,
@@ -71,6 +76,7 @@ void Engine::PolyOutputMixer::combine(PolySignals &_signals, const PolyValue &_v
 
 void Engine::PolyOutputMixer::filter_level(PolySignals &_signals)
 {
+#if OutMix_SimpleHP == 0
   // HP L
   float tmpVar = m_hp_b0 * m_out_l;
   tmpVar += m_hp_b1 * m_hp_stateVar_L1;
@@ -82,6 +88,8 @@ void Engine::PolyOutputMixer::filter_level(PolySignals &_signals)
   m_hp_stateVar_L1 = m_out_l + NlToolbox::Constants::DNC_const;
   m_hp_stateVar_L2 = tmpVar + NlToolbox::Constants::DNC_const;
 #endif
+  // Out L
+  m_out_l = tmpVar * _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
   // HP R
   tmpVar = m_hp_b0 * m_out_r;
   tmpVar += m_hp_b1 * m_hp_stateVar_R1;
@@ -93,12 +101,37 @@ void Engine::PolyOutputMixer::filter_level(PolySignals &_signals)
   m_hp_stateVar_R1 = m_out_r + NlToolbox::Constants::DNC_const;
   m_hp_stateVar_R2 = tmpVar + NlToolbox::Constants::DNC_const;
 #endif
-  m_out_l *= _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
-  m_out_r *= _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
+  // Out R
+  m_out_r = tmpVar * _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
+#elif OutMix_SimpleHP == 1
+  // HP L
+  float tmpVar = m_out_l - m_hp_stateVar_L;
+#if POTENTIAL_IMPROVEMENT_DNC_OMIT_POLYPHONIC
+  m_hp_stateVar_L = tmpVar * m_hp_b0 + m_hp_stateVar_L;
+#else
+  m_hp_stateVar_L = tmpVar * m_hp_b0 + m_hp_stateVar_L + NlToolbox::Constants::DNC_const;
+#endif
+  // Out L
+  m_out_l = tmpVar * _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
+  // HP R
+  tmpVar = m_out_r - m_hp_stateVar_R;
+#if POTENTIAL_IMPROVEMENT_DNC_OMIT_POLYPHONIC
+  m_hp_stateVar_R = tmpVar * m_hp_b0 + m_hp_stateVar_R;
+#else
+  m_hp_stateVar_R = tmpVar * m_hp_b0 + m_hp_stateVar_R + NlToolbox::Constants::DNC_const;
+#endif
+  // Out R
+  m_out_r = tmpVar * _signals.get(C15::Signals::Quasipoly_Signals::Out_Mix_Lvl);
+#endif
 }
 
 void Engine::PolyOutputMixer::resetDSP()
 {
-  m_out_l = m_out_r = m_hp_stateVar_L1 = m_hp_stateVar_L2 = m_hp_stateVar_R1 = m_hp_stateVar_R2 = 0.0f;
+  m_out_l = m_out_r = 0.0f;
   m_hp30hz_stateVar_L = m_hp30hz_stateVar_R = 0.0f;
+#if OutMix_SimpleHP == 0
+  m_hp_stateVar_L1 = m_hp_stateVar_L2 = m_hp_stateVar_R1 = m_hp_stateVar_R2 = 0.0f;
+#elif OutMix_SimpleHP == 1
+  m_hp_stateVar_L = m_hp_stateVar_R = 0.0f;
+#endif
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_out_mix.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_out_mix.h
@@ -13,6 +13,8 @@
 #include <vector>
 #include "ae_info.h"
 
+#define OutMix_SimpleHP 0
+
 namespace Engine
 {
   class PolyOutputMixer
@@ -28,7 +30,12 @@ namespace Engine
 
    private:
     PolyValue m_hp30hz_stateVar_L = {}, m_hp30hz_stateVar_R = {};
-    float m_hp30hz_b0 = 0.0f, m_hp_b0 = 0.0f, m_hp_b1 = 0.0f, m_hp_a1 = 0.0f, m_hp_stateVar_L1 = 0.0f,
-          m_hp_stateVar_R1 = 0.0f, m_hp_stateVar_L2 = 0.0f, m_hp_stateVar_R2 = 0.0f;
+    float m_hp30hz_b0 = 0.0f;
+#if OutMix_SimpleHP == 0
+    float m_hp_b0 = 0.0f, m_hp_b1 = 0.0f, m_hp_a1 = 0.0f, m_hp_stateVar_L1 = 0.0f, m_hp_stateVar_R1 = 0.0f,
+          m_hp_stateVar_L2 = 0.0f, m_hp_stateVar_R2 = 0.0f;
+#elif OutMix_SimpleHP == 1
+    float m_hp_b0 = 0.0f, m_hp_stateVar_L = 0.0f, m_hp_stateVar_R = 0.0f;
+#endif
   };
 }  // namespace Engine

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -830,11 +830,11 @@ void PolySection::startEnvelopes(const uint32_t _voiceId, const float _pitch, co
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_1) * m_env_a.m_timeFactor[_voiceId][1];
   m_env_a.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_BP);
-  m_env_a.setSegmentDest(_voiceId, 2, true, peak);
+  m_env_a.setSegmentDest(_voiceId, 2, true, dest);
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_A_Dec_2) * m_env_a.m_timeFactor[_voiceId][2];
   m_env_a.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_A_Sus);
-  m_env_a.setSegmentDest(_voiceId, 3, true, peak);
+  m_env_a.setSegmentDest(_voiceId, 3, true, dest);
   // env b
   timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Time_KT) * _pitch;
   levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_B_Lvl_Vel);
@@ -863,11 +863,11 @@ void PolySection::startEnvelopes(const uint32_t _voiceId, const float _pitch, co
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_1) * m_env_b.m_timeFactor[_voiceId][1];
   m_env_b.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_BP);
-  m_env_b.setSegmentDest(_voiceId, 2, true, peak);
+  m_env_b.setSegmentDest(_voiceId, 2, true, dest);
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_B_Dec_2) * m_env_b.m_timeFactor[_voiceId][2];
   m_env_b.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_B_Sus);
-  m_env_b.setSegmentDest(_voiceId, 3, true, peak);
+  m_env_b.setSegmentDest(_voiceId, 3, true, dest);
   // env c
   timeKT = -0.5f * m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Time_KT) * _pitch;
   levelVel = m_smoothers.get(C15::Smoothers::Poly_Sync::Env_C_Lvl_Vel);
@@ -895,11 +895,11 @@ void PolySection::startEnvelopes(const uint32_t _voiceId, const float _pitch, co
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_1) * m_env_c.m_timeFactor[_voiceId][1];
   m_env_c.setSegmentDx(_voiceId, 2, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_BP);
-  m_env_c.setSegmentDest(_voiceId, 2, peak);
+  m_env_c.setSegmentDest(_voiceId, 2, dest);
   time = m_smoothers.get(C15::Smoothers::Poly_Slow::Env_C_Dec_2) * m_env_c.m_timeFactor[_voiceId][2];
   m_env_c.setSegmentDx(_voiceId, 3, 1.0f / (time + 1.0f));
   dest = peak * m_smoothers.get(C15::Smoothers::Poly_Fast::Env_C_Sus);
-  m_env_c.setSegmentDest(_voiceId, 3, peak);
+  m_env_c.setSegmentDest(_voiceId, 3, dest);
   // start envelopes
   m_env_a.start(_voiceId);
   m_env_b.start(_voiceId);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -534,6 +534,9 @@ void PolySection::postProcess_poly_audio(const uint32_t _voiceId, const float _m
 void PolySection::postProcess_poly_fast(const uint32_t _voiceId)
 {
   updateEnvLevels(_voiceId);
+#if Process_Pitch_Fast == 1
+  postProcess_poly_pitch(_voiceId);
+#endif
   // temporary variables
   const uint32_t uIndex = m_unison_index[_voiceId];
   const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
@@ -585,42 +588,45 @@ void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
 {
   // envelopes
   updateEnvTimes(_voiceId);
+#if Process_Pitch_Fast == 0
+  postProcess_poly_pitch(_voiceId);
+#endif
   // temporary variables
   const float notePitch = m_note_pitch[_voiceId];
   float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue;
   // osc a
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
+  //  m_signals.set(
+  //      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
+  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
   envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // osc b
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
-  m_signals.set(
-      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
-      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
+  //  m_signals.set(
+  //      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
+  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+  //  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // comb filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
-  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
-                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
-  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
-                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
+  //                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
+  //                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
   unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
   envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
@@ -647,20 +653,20 @@ void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
       C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
       evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
   // state variable filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
+  //  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
+  //  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
+  //  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
+  //  unitValue
+  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
+  //  unitValue
+  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
       * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
@@ -684,12 +690,10 @@ void PolySection::postProcess_mono_slow()
                 evalNyquist(m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Chirp) * 440.0f));
 }
 
-void PolySection::postProcess_poly_key(const uint32_t _voiceId)
+void PolySection::postProcess_poly_pitch(const uint32_t _voiceId)
 {
-  // pitch, unison, temporary variables
-  const uint32_t uIndex = m_unison_index[_voiceId];
-  const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
-  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue, tmp_lvl, tmp_pan;
+  const float notePitch = m_note_pitch[_voiceId];
+  float keyTracking, unitPitch, envMod, unitValue, unitSpread, unitMod;
   // osc a
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
   unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
@@ -698,11 +702,6 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
   m_signals.set(
       C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
       evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                          1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // osc b
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
   unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
@@ -711,11 +710,6 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
   m_signals.set(
       C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
       evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
-  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
-                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
-                    * NlToolbox::Crossfades::unipolarCrossFade(
-                          1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // comb filter
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
   unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
@@ -723,6 +717,63 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
                 evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
   m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
                 unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
+  // state variable filter
+  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
+  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
+  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
+  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
+  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
+  unitValue
+      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
+  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
+  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
+  unitValue
+      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
+  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
+  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
+}
+
+void PolySection::postProcess_poly_key(const uint32_t _voiceId)
+{
+  postProcess_poly_pitch(_voiceId);
+  // pitch, unison, temporary variables
+  const uint32_t uIndex = m_unison_index[_voiceId];
+  const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
+  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue, tmp_lvl, tmp_pan;
+  // osc a
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
+  //  m_signals.set(
+  //      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
+  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
+  m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
+                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
+                    * NlToolbox::Crossfades::unipolarCrossFade(
+                          1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+  // osc b
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
+  //  m_signals.set(
+  //      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
+  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
+  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
+  m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
+                m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
+                    * NlToolbox::Crossfades::unipolarCrossFade(
+                          1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
+  // comb filter
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
+  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
+  //                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
+  //                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
   unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
   envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
@@ -749,20 +800,20 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
       C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
       evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
   // state variable filter
-  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  unitValue
-      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
+  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
+  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
+  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
+  //  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
+  //  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
+  //  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
+  //  unitValue
+  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
+  //  unitValue
+  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
+  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
       * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -593,40 +593,19 @@ void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
 #endif
   // temporary variables
   const float notePitch = m_note_pitch[_voiceId];
-  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue;
+  float keyTracking, unitPitch, envMod, unitSign, unitMod, unitValue;
   // osc a
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
-  //  m_signals.set(
-  //      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
-  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
   envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // osc b
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
-  //  m_signals.set(
-  //      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
-  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
-  //  envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // comb filter
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
-  //                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
-  //                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
   unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
   envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
@@ -653,20 +632,6 @@ void PolySection::postProcess_poly_slow(const uint32_t _voiceId)
       C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
       evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
   // state variable filter
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  //  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  //  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  //  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  //  unitValue
-  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  //  unitValue
-  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
       * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);
@@ -754,40 +719,20 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
   // pitch, unison, temporary variables
   const uint32_t uIndex = m_unison_index[_voiceId];
   const float basePitch = m_base_pitch[_voiceId], notePitch = m_note_pitch[_voiceId];
-  float keyTracking, unitPitch, envMod, unitSign, unitSpread, unitMod, unitValue, tmp_lvl, tmp_pan;
+  float keyTracking, unitPitch, envMod, unitSign, unitMod, unitValue, tmp_lvl, tmp_pan;
   // osc a
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Pitch_Env_C);
-  //  m_signals.set(
-  //      C15::Signals::Truepoly_Signals::Osc_A_Freq, _voiceId,
-  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
   envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_A_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_A_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // osc b
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Pitch_Env_C);
-  //  m_signals.set(
-  //      C15::Signals::Truepoly_Signals::Osc_B_Freq, _voiceId,
-  //      evalNyquist((*m_reference) * m_convert->eval_osc_pitch(unitPitch + (notePitch * keyTracking) + envMod)));
   envMod = m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct_Env_C);
   m_signals.set(C15::Signals::Truepoly_Signals::Osc_B_Fluct_Env_C, _voiceId,
                 m_smoothers.get(C15::Smoothers::Poly_Slow::Osc_B_Fluct)
                     * NlToolbox::Crossfades::unipolarCrossFade(
                           1.0f, m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId), envMod));
   // comb filter
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch_KT);
-  //  unitPitch = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Pitch);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Freq, _voiceId,
-  //                evalNyquist((*m_reference) * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking))));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::Comb_Flt_Bypass, _voiceId,
-  //                unitPitch > dsp_comb_max_freqFactor ? 1.0f : 0.0f);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_KT);
   unitSign = m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay) < 0 ? -0.001f : 0.001f;
   envMod = 1.0f - m_comb_decayCurve.applyCurve(m_smoothers.get(C15::Smoothers::Poly_Slow::Comb_Flt_Decay_Gate));
@@ -814,20 +759,6 @@ void PolySection::postProcess_poly_key(const uint32_t _voiceId)
       C15::Signals::Truepoly_Signals::Comb_Flt_LP_Freq, _voiceId,
       evalNyquist(440.0f * unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod)));
   // state variable filter
-  //  keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_KT);
-  //  envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Uncl, _voiceId)
-  //      * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut_Env_C);
-  //  unitPitch = (*m_reference) * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Cut);
-  //  unitSpread = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Spread);
-  //  unitMod = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_FM);
-  //  unitValue
-  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod + unitSpread));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_Cut, _voiceId, unitValue);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F1_FM, _voiceId, unitValue * unitMod);
-  //  unitValue
-  //      = evalNyquist(unitPitch * m_convert->eval_lin_pitch(69.0f + (notePitch * keyTracking) + envMod - unitSpread));
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_Cut, _voiceId, unitValue);
-  //  m_signals.set(C15::Signals::Truepoly_Signals::SV_Flt_F2_FM, _voiceId, unitValue * unitMod);
   keyTracking = m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_KT) * m_svf_resFactor;
   envMod = m_signals.get(C15::Signals::Truepoly_Signals::Env_C_Clip, _voiceId)
       * m_smoothers.get(C15::Smoothers::Poly_Slow::SV_Flt_Res_Env_C);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.h
@@ -22,6 +22,8 @@
 #include "ae_poly_out_mix.h"
 #include "nltoolbox.h"
 
+#define Process_Pitch_Fast 0
+
 class PolySection
 {
  public:
@@ -92,6 +94,7 @@ class PolySection
   void postProcess_mono_fast();
   void postProcess_poly_slow(const uint32_t _voiceId);
   void postProcess_mono_slow();
+  void postProcess_poly_pitch(const uint32_t _voiceId);
   void postProcess_poly_key(const uint32_t _voiceId);
   void startEnvelopes(const uint32_t _voiceId, const float _pitch, const float _vel);
   void stopEnvelopes(const uint32_t _voiceId, const float _pitch, const float _vel);


### PR DESCRIPTION
see #1962 
- [x] fixes "Pitch Bug" of the Envelopes A,B,C (missing the Breakpoint occasionally when using 0 times for Attack, Decay1)
- [ ] consider fast clock or variable (?) clock for updating Pitches (Osc A/B, Comb, SVF)