### PR TITLE
Issue 2031 revisited

### DIFF
--- a/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
+++ b/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
@@ -1,5 +1,4 @@
 #include <Application.h>
-
 #include <presets/PresetManager.h>
 #include <presets/EditBuffer.h>
 #include <proxies/hwui/HWUI.h>
@@ -83,10 +82,7 @@ void ScreenSaverTimeoutSetting::init()
 
   Application::get().getPresetManager()->getEditBuffer()->onChange([this]() { endAndReschedule(); }, false);
 
-  Application::get().getPlaycontrollerProxy()->onLastKeyChanged([this](int key) {
-    nltools::Log::info(__LINE__, __FILE__, __PRETTY_FUNCTION__, "Received last Key from Playcontroller:", key);
-    endAndReschedule();
-  });
+  Application::get().getPlaycontrollerProxy()->onLastKeyChanged([this](int key) { endAndReschedule(); });
 
   Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled().onLayoutInstalled([this](Layout* l) {
     if(dynamic_cast<BOLEDScreenSaver*>(l) == nullptr)

--- a/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
+++ b/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
@@ -3,6 +3,7 @@
 #include <presets/PresetManager.h>
 #include <presets/EditBuffer.h>
 #include <proxies/hwui/HWUI.h>
+#include <proxies/playcontroller/PlaycontrollerProxy.h>
 #include <proxies/hwui/panel-unit/PanelUnit.h>
 #include <proxies/hwui/panel-unit/EditPanel.h>
 #include <proxies/hwui/panel-unit/boled/BOLED.h>
@@ -81,6 +82,11 @@ void ScreenSaverTimeoutSetting::init()
       [this](auto* n, auto* old) { endAndReschedule(); }, std::nullopt);
 
   Application::get().getPresetManager()->getEditBuffer()->onChange([this]() { endAndReschedule(); }, false);
+
+  Application::get().getPlaycontrollerProxy()->onLastKeyChanged([this](int key) {
+    nltools::Log::info(__LINE__, __FILE__, __PRETTY_FUNCTION__, "Received last Key from Playcontroller:", key);
+    endAndReschedule();
+  });
 
   Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled().onLayoutInstalled([this](Layout* l) {
     if(dynamic_cast<BOLEDScreenSaver*>(l) == nullptr)

--- a/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
+++ b/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.cpp
@@ -32,6 +32,11 @@ Glib::ustring ScreenSaverTimeoutSetting::getDisplayString() const
     return "Disabled";
   if(m_timeout.count() == 1)
     return "1 Minute";
+  if(m_timeout.count() == 60)
+    return "1 Hour";
+  if(m_timeout.count() > 60)
+    return std::to_string(m_timeout.count() / 60) + " Hours";
+
   return std::to_string(m_timeout.count()) + " Minutes";
 }
 
@@ -47,9 +52,9 @@ void ScreenSaverTimeoutSetting::init()
     m_expiration = std::make_unique<Expiration>([&] { m_screenSaverSignal.send(true); }, m_timeout);
   }
 
-  Application::get().getHWUI()->onHWUIChanged([&]() {
-    m_screenSaverSignal.send(false);
+  //TODO subscribe to real events...
 
+  Application::get().getHWUI()->onHWUIChanged([&]() {
     if(m_expiration)
     {
       m_expiration->refresh(m_timeout);
@@ -57,8 +62,20 @@ void ScreenSaverTimeoutSetting::init()
   });
 }
 
+void ScreenSaverTimeoutSetting::sendState(bool state)
+{
+  m_screenSaverSignal.send(state);
+}
+
 void ScreenSaverTimeoutSetting::incDec(int inc)
 {
+
+  //  auto currentIndex = std::find(s_logTimeOuts.begin(), s_logTimeOuts.end(), m_timeout.count());
+  //  if(currentIndex != s_logTimeOuts.end())
+  //  {
+  //    currentIndex = std::max(0, std::min<int>(currentIndex + inc, s_logTimeOuts.size() - 1));
+  //  }
+
   auto n = m_timeout.count() + inc;
   n = std::min<int>(std::max<int>(n, 0), 30);
   m_timeout = std::chrono::minutes(n);

--- a/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.h
+++ b/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.h
@@ -18,9 +18,11 @@ class ScreenSaverTimeoutSetting : public Setting, public sigc::trackable
   void sendState(bool state);
 
  private:
+  void endAndReschedule();
   std::unique_ptr<Expiration> m_expiration = nullptr;
   Signal<void, bool> m_screenSaverSignal;
 
+  size_t selectedIndex;
   std::chrono::minutes m_timeout;
   const std::array<int, 6> s_logTimeOuts = { 0, 1, 5, 20, 60, 180 };
 };

--- a/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.h
+++ b/projects/epc/playground/src/device-settings/ScreenSaverTimeoutSetting.h
@@ -15,10 +15,12 @@ class ScreenSaverTimeoutSetting : public Setting, public sigc::trackable
   bool persistent() const override;
 
   void incDec(int inc);
+  void sendState(bool state);
 
  private:
   std::unique_ptr<Expiration> m_expiration = nullptr;
   Signal<void, bool> m_screenSaverSignal;
 
   std::chrono::minutes m_timeout;
+  const std::array<int, 6> s_logTimeOuts = { 0, 1, 5, 20, 60, 180 };
 };

--- a/projects/epc/playground/src/proxies/hwui/base-unit/soled/SOLEDScreenSaver.cpp
+++ b/projects/epc/playground/src/proxies/hwui/base-unit/soled/SOLEDScreenSaver.cpp
@@ -20,12 +20,21 @@ bool SOLEDScreenSaver::animate()
 {
   auto old = m_scrollingLabel->getPosition();
 
-  old.setLeft(old.getLeft() + velocity);
+  auto& velX = velocity.first;
+  auto& velY = velocity.second;
 
-  if(old.getLeft() <= 1)
-    velocity = 1;
+  old.setLeft(old.getLeft() + velX);
+  old.setTop(old.getTop() + velY);
+
+  if(old.getLeft() <= 0)
+    velX = 1;
   else if(old.getRight() >= 127)
-    velocity = -1;
+    velX = -1;
+
+  if(old.getTop() <= 0)
+    velY = 1;
+  else if(old.getBottom() >= 32)
+    velY = -1;
 
   m_scrollingLabel->setPosition(old);
   return true;
@@ -40,7 +49,7 @@ bool SOLEDScreenSaver::redraw(FrameBuffer& fb)
 
 void SOLEDScreenSaver::init()
 {
-  m_scrollingLabel = addControl(new Label({ "Nonlinear Labs - C15", 0 }, { 1, 0, 93, 32 }));
+  m_scrollingLabel = addControl(new Label({ "Nonlinear Labs - C15", 0 }, { 1, 0, 93, 9 }));
 }
 
 void SOLEDScreenSaver::destroy()

--- a/projects/epc/playground/src/proxies/hwui/base-unit/soled/SOLEDScreenSaver.h
+++ b/projects/epc/playground/src/proxies/hwui/base-unit/soled/SOLEDScreenSaver.h
@@ -11,7 +11,7 @@ class SOLEDScreenSaver : public Layout
   void init() override;
 
  private:
-  int velocity = 1;
+  std::pair<int, int> velocity = { 1, 1 };
   Label* m_scrollingLabel = nullptr;
   sigc::connection m_animationConnection;
   sigc::connection m_editbufferConnection;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.h
@@ -34,6 +34,7 @@ class PanelUnit : public HardwareUserInterfaceUnit, public sigc::trackable
   MacroControlAssignmentStateMachine &getMacroControlAssignmentStateMachine();
 
  private:
+  void onScreenSaverStateChanged(bool state);
   void installUsageMode(FocusAndMode focusAndMode);
   ParameterId choseHWBestSourceForMC(const ParameterId &mcParamId) const;
   void onBBBBConnected();
@@ -41,4 +42,6 @@ class PanelUnit : public HardwareUserInterfaceUnit, public sigc::trackable
   EditPanel m_editPanel;
   std::vector<tLed> m_leds;
   MacroControlAssignmentStateMachine m_macroControlAssignmentStateMachine;
+
+  std::shared_ptr<UsageMode> m_stashedUsageMode = nullptr;
 };

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/ScreenSaverUsageMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/ScreenSaverUsageMode.cpp
@@ -1,0 +1,27 @@
+#include "ScreenSaverUsageMode.h"
+#include <Application.h>
+#include <device-settings/Settings.h>
+#include <device-settings/ScreenSaverTimeoutSetting.h>
+
+ScreenSaverUsageMode::ScreenSaverUsageMode()
+    : UsageMode()
+{
+}
+
+void ScreenSaverUsageMode::setup()
+{
+}
+
+bool ScreenSaverUsageMode::onButtonPressed(Buttons buttonID, ButtonModifiers modifiers, bool state)
+{
+  if(state)
+  {
+    m_downReceived = true;
+  }
+  else if(m_downReceived)
+  {
+    Application::get().getSettings()->getSetting<ScreenSaverTimeoutSetting>()->sendState(false);
+  }
+
+  return true;
+}

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/ScreenSaverUsageMode.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/ScreenSaverUsageMode.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <proxies/hwui/UsageMode.h>
+
+class ScreenSaverUsageMode : public UsageMode
+{
+ public:
+  ScreenSaverUsageMode();
+  bool onButtonPressed(Buttons buttonID, ButtonModifiers modifiers, bool state) override;
+  void setup() override;
+
+ private:
+  bool m_downReceived = false;
+};

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLEDScreenSaver.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/BOLEDScreenSaver.cpp
@@ -33,22 +33,22 @@ bool BOLEDScreenSaver::animate()
 {
   auto old = m_label->getPosition();
 
-  if(old.getRight() > 256)
+  if(old.getRight() >= 256)
   {
     m_vel.first = -1;
   }
 
-  if(old.getLeft() < 0)
+  if(old.getLeft() <= 0)
   {
     m_vel.first = 1;
   }
 
-  if(old.getBottom() > 64)
+  if(old.getBottom() >= 64)
   {
     m_vel.second = -1;
   }
 
-  if(old.getTop() < 0)
+  if(old.getTop() <= 0)
   {
     m_vel.second = 1;
   }

--- a/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.cpp
+++ b/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.cpp
@@ -212,6 +212,10 @@ void PlaycontrollerProxy::onHardwareSourceReceived(const MessageParser::NLMessag
     DebugLevel::info("physical control parameter:", param->getMiniParameterEditorName(), ": ", value);
     applyParamMessageAbsolutely(param, value);
   }
+  else if(id == HW_SOURCE_ID_LAST_KEY)
+  {
+    notifyLastKey(value);
+  }
   else
   {
     DebugLevel::info("could not parse hw id", id, " to physical control parameter");
@@ -391,6 +395,11 @@ sigc::connection PlaycontrollerProxy::onPlaycontrollerSoftwareVersionChanged(con
   return m_signalPlaycontrollerSoftwareVersionChanged.connectAndInit(s, m_playcontrollerSoftwareVersion);
 }
 
+sigc::connection PlaycontrollerProxy::onLastKeyChanged(sigc::slot<void, int> s)
+{
+  return m_lastKeyChanged.connect(s);
+}
+
 void PlaycontrollerProxy::requestPlaycontrollerSoftwareVersion()
 {
   tMessageComposerPtr cmp(new MessageComposer(MessageParser::REQUEST));
@@ -404,4 +413,9 @@ void PlaycontrollerProxy::requestPlaycontrollerSoftwareVersion()
 std::string PlaycontrollerProxy::getPlaycontrollerSoftwareVersion() const
 {
   return (m_playcontrollerSoftwareVersion == -1) ? "-" : std::to_string(m_playcontrollerSoftwareVersion);
+}
+
+void PlaycontrollerProxy::notifyLastKey(gint16 key)
+{
+  m_lastKeyChanged.send(key);
 }

--- a/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.h
+++ b/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.h
@@ -66,6 +66,7 @@ class PlaycontrollerProxy
 
   sigc::connection onRibbonTouched(sigc::slot<void, int> s);
   sigc::connection onPlaycontrollerSoftwareVersionChanged(const sigc::slot<void, int> &s);
+  sigc::connection onLastKeyChanged(sigc::slot<void, int> s);
   int getLastTouchedRibbonParameterID() const;
   std::string getPlaycontrollerSoftwareVersion() const;
 
@@ -98,6 +99,7 @@ class PlaycontrollerProxy
   int m_lastTouchedRibbon;
   Signal<void, int> m_signalRibbonTouched;
   Signal<void, int> m_signalPlaycontrollerSoftwareVersionChanged;
+  Signal<void, int> m_lastKeyChanged;
 
   std::unique_ptr<QuantizedValue::IncrementalChanger> m_relativeEditControlMessageChanger;
 
@@ -113,4 +115,5 @@ class PlaycontrollerProxy
 
   void onHeartbeatStumbled();
   void requestPlaycontrollerSoftwareVersion();
+  void notifyLastKey(gint16 key);
 };


### PR DESCRIPTION
Fixup following ticket: #2210
and address some of the issues from #2031, but not ignoring WebUI actions which affect the Editbuffer or PresetManager.
- last pressed Key is also now consumed and ends screensaver

