### PR TITLE
The jobs are scheduled to a MainContext of 'unknown' lifetime,

### DIFF
--- a/projects/shared/nltools/include/nltools/threading/ContextBoundMessageQueue.h
+++ b/projects/shared/nltools/include/nltools/threading/ContextBoundMessageQueue.h
@@ -5,6 +5,8 @@
 #include <sigc++/trackable.h>
 #include <glibmm/refptr.h>
 #include <atomic>
+#include <memory>
+#include <list>
 
 namespace nltools
 {
@@ -23,6 +25,10 @@ namespace nltools
      private:
       Glib::RefPtr<Glib::MainContext> m_context;
       std::atomic<uint32_t> m_pendingCalls {};
+
+      using Job = std::function<void()>;
+      using tJob = std::shared_ptr<Job>;
+      std::list<tJob> m_jobs;
     };
   }
 }


### PR DESCRIPTION
so it can happen, that the callback finally uses dangeling objects.
To fix this, we want to be sure that there are at least 2 owners of
the job when it is going to be executed: The closure and the queue.