### PR TITLE
playground will send program changes to audio-engine, which will

### DIFF
--- a/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
+++ b/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
@@ -202,14 +202,18 @@ int main(int args, char *argv[])
     sender = std::thread([&] { readMidi(cancelPipe[0], inputHandle); });
   }
 
-  runMainLoop();
+  if(inputHandle || outputHandle)
+  {
+    runMainLoop();
 
-  if(sender.joinable())
-    sender.join();
+    if(sender.joinable())
+      sender.join();
 
-  snd_rawmidi_close(outputHandle);
-  snd_rawmidi_close(inputHandle);
+    snd_rawmidi_close(outputHandle);
+    snd_rawmidi_close(inputHandle);
 
-  nltools::Log::warning("MidiOverIP, round trip time:", minRTT.count(), " ... ", maxRTT.count(), "us");
+    nltools::Log::warning("MidiOverIP, round trip time:", minRTT.count(), " ... ", maxRTT.count(), "us");
+  }
+
   return EXIT_SUCCESS;
 }

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -48,14 +48,30 @@ C15Synth::C15Synth(const AudioEngineOptions* options)
     m_dsp->onMidiMessage(100, static_cast<uint32_t>(noteDown.m_keyPos), 0);
   });
 
+  // receive program changes from playground and dispatch it to midi-over-ip
+  receive<nltools::msg::Midi::ProgramChangeMessage>(EndPoint::AudioEngine, [this](const auto& pc) {
+    m_externalMidiOutBuffer.push(nltools::msg::Midi::SimpleMessage { 0xC0, pc.program, 0 });
+    m_externalMidiOutThreadWaiter.notifyUnlocked();
+  });
+
   receive<nltools::msg::Midi::SimpleMessage>(EndPoint::ExternalMidiOverIPClient, [&](const auto& msg) {
     MidiEvent e;
     std::copy(msg.rawBytes, msg.rawBytes + 3, e.raw);
-    pushMidiEvent(e);
 
-    nltools::msg::Midi::MessageAcknowledge ack;
-    ack.id = msg.id;
-    send(nltools::msg::EndPoint::ExternalMidiOverIPBridge, ack);
+    if((e.raw[0] & 0xC0) == 0xC0)
+    {
+      // receive program changes midi-over-ip and dispatch it to playground
+      send(nltools::msg::EndPoint::Playground, nltools::msg::Midi::ProgramChangeMessage { e.raw[1] });
+    }
+    else
+    {
+      pushMidiEvent(e);
+
+      // TODO: after successfull evaluation of round trip times, remove this messages
+      nltools::msg::Midi::MessageAcknowledge ack;
+      ack.id = msg.id;
+      send(nltools::msg::EndPoint::ExternalMidiOverIPBridge, ack);
+    }
   });
 
   Glib::MainContext::get_default()->signal_idle().connect(sigc::mem_fun(this, &C15Synth::doIdle));

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -58,7 +58,7 @@ C15Synth::C15Synth(const AudioEngineOptions* options)
     MidiEvent e;
     std::copy(msg.rawBytes, msg.rawBytes + 3, e.raw);
 
-    if((e.raw[0] & 0xC0) == 0xC0)
+    if((e.raw[0] & 0xF0) == 0xC0)
     {
       // receive program changes midi-over-ip and dispatch it to playground
       send(nltools::msg::EndPoint::Playground, nltools::msg::Midi::ProgramChangeMessage { e.raw[1] });

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
@@ -11,8 +11,9 @@ namespace UNDO
 }
 
 class EditBuffer;
+class Uuid;
 
-class AudioEngineProxy
+class AudioEngineProxy : public sigc::trackable
 {
  public:
   AudioEngineProxy();
@@ -49,8 +50,12 @@ class AudioEngineProxy
   static nltools::msg::SinglePresetMessage createSingleEditBufferMessage(const EditBuffer& eb);
 
  private:
-  uint m_suppressParamChanges = 0;
-
   static void fillMonoPart(nltools::msg::ParameterGroups::MonoGroup& monoGroup, ParameterGroup* const& g);
   static void fillUnisonPart(nltools::msg::ParameterGroups::UnisonGroup& unisonGroup, ParameterGroup* const& g);
+
+  void onBankSelectionChanged(const Uuid& uuid);
+  void onBankChanged();
+
+  uint m_suppressParamChanges = 0;
+  sigc::connection m_presetSelectionConnection;
 };

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -31,6 +31,16 @@ namespace nltools
 
         uint64_t id = 0;
       };
+
+      struct ProgramChangeMessage
+      {
+        constexpr static MessageType getType()
+        {
+          return MessageType::MidiProgramChange;
+        }
+
+        uint8_t program;
+      };
     }
 
     using tID = int;

--- a/projects/shared/nltools/include/nltools/messaging/Messaging.h
+++ b/projects/shared/nltools/include/nltools/messaging/Messaging.h
@@ -41,7 +41,7 @@ namespace nltools
 
          NotifyHardwareSourceChanged,
 
-         MidiSimpleMessage, MidiAck,
+         MidiSimpleMessage, MidiAck, MidiProgramChange,
 
          SyncFS);
 


### PR DESCRIPTION
dispatch it to midi-over-ip and the other way around

Sorry, I can't test the feature as my Roland FP-30 does not send or receive program changes.