### PR TITLE
midi-over-ip ammendments

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -37,6 +37,7 @@ inline constexpr bool LOG_INIT = false;
 inline constexpr bool LOG_MIDI_TCD = false;
 inline constexpr bool LOG_MIDI_RAW = false;
 inline constexpr bool LOG_MIDI_DETAIL = false;
+inline constexpr bool LOG_MIDI_OUT = false;
 inline constexpr bool LOG_DISPATCH = false;
 inline constexpr bool LOG_EDITS = false;
 inline constexpr bool LOG_TIMES = false;

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
@@ -25,9 +25,6 @@
 #include <groups/SplitParameterGroups.h>
 #include <proxies/playcontroller/PlaycontrollerProxy.h>
 
-constexpr auto cUnisonVoicesParameterNumber = 249;
-constexpr auto cMonoEnableParameterNumber = 364;
-
 AudioEngineProxy::AudioEngineProxy()
 {
   using namespace nltools::msg;
@@ -64,16 +61,16 @@ template <typename tMsg> void fillMessageWithGlobalParams(tMsg &msg, const EditB
   size_t mcT = 0;
   size_t modR = 0;
 
-  auto masterParameter
-      = dynamic_cast<const ModulateableParameter *>(editBuffer.findParameterByID({ 247, VoiceGroup::Global }));
+  auto masterParameter = dynamic_cast<const ModulateableParameter *>(
+      editBuffer.findParameterByID({ C15::PID::Master_Volume, VoiceGroup::Global }));
   auto &master = msg.master.volume;
   master.id = masterParameter->getID().getNumber();
   master.controlPosition = masterParameter->getControlPositionValue();
   master.modulationAmount = masterParameter->getModulationAmount();
   master.mc = masterParameter->getModulationSource();
 
-  auto tuneParameter
-      = dynamic_cast<const ModulateableParameter *>(editBuffer.findParameterByID({ 248, VoiceGroup::Global }));
+  auto tuneParameter = dynamic_cast<const ModulateableParameter *>(
+      editBuffer.findParameterByID({ C15::PID::Master_Tune, VoiceGroup::Global }));
   auto &tune = msg.master.tune;
   tune.id = tuneParameter->getID().getNumber();
   tune.controlPosition = tuneParameter->getControlPositionValue();
@@ -143,7 +140,7 @@ void forEachParameterInGroup(const EditBuffer *eb, const GroupId &group, tParame
 
 nltools::msg::SinglePresetMessage AudioEngineProxy::createSingleEditBufferMessage(const EditBuffer &eb)
 {
-  nltools::msg::SinglePresetMessage msg {};
+  nltools::msg::SinglePresetMessage msg{};
   fillMessageWithGlobalParams(msg, eb);
 
   size_t mc = 0;
@@ -201,31 +198,31 @@ void AudioEngineProxy::fillMonoPart(nltools::msg::ParameterGroups::MonoGroup &mo
 {
   auto from = g->getVoiceGroup();
 
-  if(auto enable = g->findParameterByID({ cMonoEnableParameterNumber, from }))
+  if(auto enable = g->findParameterByID({ C15::PID::Mono_Grp_Enable, from }))
   {
     auto &monoEnable = monoGroup.monoEnable;
-    monoEnable.id = cMonoEnableParameterNumber;
+    monoEnable.id = C15::PID::Mono_Grp_Enable;
     monoEnable.controlPosition = enable->getControlPositionValue();
   }
 
-  if(auto prio = g->findParameterByID({ 365, from }))
+  if(auto prio = g->findParameterByID({ C15::PID::Mono_Grp_Prio, from }))
   {
     auto &item = monoGroup.priority;
-    item.id = 365;
+    item.id = C15::PID::Mono_Grp_Prio;
     item.controlPosition = prio->getControlPositionValue();
   }
 
-  if(auto legato = g->findParameterByID({ 366, from }))
+  if(auto legato = g->findParameterByID({ C15::PID::Mono_Grp_Legato, from }))
   {
     auto &item = monoGroup.legato;
-    item.id = 366;
+    item.id = C15::PID::Mono_Grp_Legato;
     item.controlPosition = legato->getControlPositionValue();
   }
 
-  if(auto glide = dynamic_cast<ModulateableParameter *>(g->findParameterByID({ 367, from })))
+  if(auto glide = dynamic_cast<ModulateableParameter *>(g->findParameterByID({ C15::PID::Mono_Grp_Glide, from })))
   {
     auto &item = monoGroup.glide;
-    item.id = 367;
+    item.id = C15::PID::Mono_Grp_Glide;
     item.controlPosition = glide->getControlPositionValue();
     item.mc = glide->getModulationSource();
     item.modulationAmount = glide->getModulationAmount();
@@ -236,14 +233,14 @@ void AudioEngineProxy::fillUnisonPart(nltools::msg::ParameterGroups::UnisonGroup
 {
   auto from = g->getVoiceGroup();
 
-  if(auto unisonParam = g->getParameterByID({ cUnisonVoicesParameterNumber, from }))
+  if(auto unisonParam = g->getParameterByID({ C15::PID::Unison_Voices, from }))
   {
     auto &unisonVoices = unisonGroup.unisonVoices;
-    unisonVoices.id = cUnisonVoicesParameterNumber;
+    unisonVoices.id = C15::PID::Unison_Voices;
     unisonVoices.controlPosition = unisonParam->getControlPositionValue();
   }
 
-  if(auto unisonDetune = dynamic_cast<ModulateableParameter *>(g->getParameterByID({ 250, from })))
+  if(auto unisonDetune = dynamic_cast<ModulateableParameter *>(g->getParameterByID({ C15::PID::Unison_Detune, from })))
   {
     auto &detune = unisonGroup.detune;
     detune.id = unisonDetune->getID().getNumber();
@@ -252,14 +249,16 @@ void AudioEngineProxy::fillUnisonPart(nltools::msg::ParameterGroups::UnisonGroup
     detune.modulationAmount = unisonDetune->getModulationAmount();
   }
 
-  if(auto unisonPan = g->getParameterByID({ 252, from }))
+  if(auto unisonPan = g->getParameterByID(
+         { C15::PID::Unison_Pan, from }))  // previously was 252: Unison Phase (seems like a bugfix..?)
   {
     auto &pan = unisonGroup.pan;
     pan.id = unisonPan->getID().getNumber();
     pan.controlPosition = unisonPan->getControlPositionValue();
   }
 
-  if(auto unisonPhase = g->getParameterByID({ 253, from }))
+  if(auto unisonPhase = g->getParameterByID(
+         { C15::PID::Unison_Phase, from }))  // previously was 253: Unison Pan (seems like a bugfix..?)
   {
     auto &phase = unisonGroup.phase;
     phase.id = unisonPhase->getID().getNumber();
@@ -295,8 +294,7 @@ template <typename tMsg> void fillDualMessage(tMsg &msg, const EditBuffer &editB
         }
         else
         {
-          if(p->getID().getNumber() != cUnisonVoicesParameterNumber
-             && p->getID().getNumber() != cMonoEnableParameterNumber)
+          if(p->getID().getNumber() != C15::PID::Unison_Voices && p->getID().getNumber() != C15::PID::Mono_Grp_Enable)
           {
             auto &unModulateable = msg.unmodulateables[arrayIndex][unMod++];
             unModulateable.id = p->getID().getNumber();
@@ -313,7 +311,7 @@ template <typename tMsg> void fillDualMessage(tMsg &msg, const EditBuffer &editB
 
 nltools::msg::SplitPresetMessage AudioEngineProxy::createSplitEditBufferMessage(const EditBuffer &eb)
 {
-  nltools::msg::SplitPresetMessage msg {};
+  nltools::msg::SplitPresetMessage msg{};
   fillMessageWithGlobalParams(msg, eb);
   fillDualMessage(msg, eb);
 
@@ -349,7 +347,7 @@ nltools::msg::SplitPresetMessage AudioEngineProxy::createSplitEditBufferMessage(
 
 nltools::msg::LayerPresetMessage AudioEngineProxy::createLayerEditBufferMessage(const EditBuffer &eb)
 {
-  nltools::msg::LayerPresetMessage msg {};
+  nltools::msg::LayerPresetMessage msg{};
   fillMessageWithGlobalParams(msg, eb);
   fillDualMessage(msg, eb);
 
@@ -417,7 +415,7 @@ void AudioEngineProxy::onBankChanged()
       uint8_t pos = bank->getPresetPosition(preset);
 
       if(pos < 128)
-        nltools::msg::send(nltools::msg::EndPoint::AudioEngine, nltools::msg::Midi::ProgramChangeMessage { pos });
+        nltools::msg::send(nltools::msg::EndPoint::AudioEngine, nltools::msg::Midi::ProgramChangeMessage{ pos });
     }
   }
 }


### PR DESCRIPTION
- [x] added optional logging of MIDI Out messages (disabled by default)
- [x] fixed MIDI Out Program Change message
- [x] code simplification: introduced `C15::PID` to `AudioEngineProxy.cpp`
- [ ] found a bug in `AudioEngineProxy.cpp` and fixed it - verification needed