### PR TITLE
AudioEngine - Comb DelaySmoother Fixes

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -249,12 +249,17 @@ bool PolySection::keyDown(PolyKeyEvent* _event)
     m_voice_level[_event->m_voiceId] = m_key_levels[_event->m_position];
     m_gain_curve_index[_event->m_voiceId] = 0;
 #endif
-    m_combfilter.setDelaySmoother(_event->m_voiceId);
     startEnvelopes(_event->m_voiceId, m_note_pitch[_event->m_voiceId], _event->m_velocity);
   }
   // process signals after starting envelopes
   postProcess_poly_key(_event->m_voiceId);
   setSlowFilterCoefs(_event->m_voiceId);
+  // set comb delay smoother after pitch processing (unfortunately separate if statement)
+  // is this legato-dependant?
+  if(_event->m_trigger_env)
+  {
+    m_combfilter.setDelaySmoother(_event->m_voiceId);
+  }
   m_key_active++;
   return retrigger_mono;
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/ae_poly_section.cpp
@@ -226,6 +226,7 @@ bool PolySection::keyDown(PolyKeyEvent* _event)
     {
       m_mono_glide.sync(0, 0.0f);
       m_mono_glide.start(0, m_time->eval_ms(3, m_smoothers.get(C15::Smoothers::Poly_Slow::Mono_Grp_Glide)), 1.0f);
+      m_mono_glide.render();
     }
     else
     {


### PR DESCRIPTION
Refers to: https://github.com/nonlinear-labs-dev/C15/issues/2250#issuecomment-723461077

Fixes testable with attached Bank:

- [x] fixed KeyDown processing order in Comb Filter: DelaySmoother is now again set after pitch processing (Preset 1 now sounds correct without pitch-sweep glitch)
- [x] Preset 2 ( = Preset 1 in Mono): the glitchy sweeping effect can arise when playing legato (because then there will be no delay smoothing - is this intended/a good idea?)
solved: glide now immediately effective (similar to envelopes)

[Comb Delay Smoother Tests.zip](https://github.com/nonlinear-labs-dev/C15/files/5523605/Comb.Delay.Smoother.Tests.zip)
