### PR TITLE
AudioEngine - final assertion fix

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -62,7 +62,6 @@ dsp_host_dual::dsp_host_dual()
   assert(CC_Range_7_Bit::decodeUnipolarMidiValue(0x00) == 0.0f);
   assert(CC_Range_7_Bit::decodeUnipolarMidiValue(0x40) == 0.5f);
   assert(CC_Range_7_Bit::decodeUnipolarMidiValue(0x7F) == 1.0f);
-  assert(CC_Range_7_Bit::decodeUnipolarMidiValue(0xFF) == 1.0f);
 }
 
 void dsp_host_dual::init(const uint32_t _samplerate, const uint32_t _polyphony)


### PR DESCRIPTION
Had to remove an assertion for 7-Bit decoding: an out-of-range MIDI message shouldn't be possible anyway.
Now, this _really_ is tested numerically and runs in debug mode.