### PR TITLE
Use event driven callback for syncing hw sources to playground

### DIFF
--- a/projects/bbb/bridge/src/FileSystemSync.cpp
+++ b/projects/bbb/bridge/src/FileSystemSync.cpp
@@ -30,6 +30,8 @@ FileSystemSync::~FileSystemSync()
 
 void FileSystemSync::doBackgroundSyncing()
 {
+  pthread_setname_np(pthread_self(), "FSSync");
+
   std::unique_lock<std::mutex> l(m_mutex);
 
   while(!m_cancel)

--- a/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
+++ b/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
@@ -96,6 +96,7 @@ void AlsaAudioOutput::stop()
 
 void AlsaAudioOutput::doBackgroundWork()
 {
+  pthread_setname_np(pthread_self(), "AudioOut");
   const auto framesPerCallback = m_numFramesPerPeriod;
 
   snd_pcm_prepare(m_handle);

--- a/projects/epc/audio-engine/src/io/midi/AlsaMidiInput.cpp
+++ b/projects/epc/audio-engine/src/io/midi/AlsaMidiInput.cpp
@@ -43,6 +43,8 @@ void AlsaMidiInput::close()
 
 void AlsaMidiInput::doBackgroundWork()
 {
+  pthread_setname_np(pthread_self(), "MidiIn");
+
   uint8_t byte;
 
   snd_midi_event_t *encoder = nullptr;

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -9,7 +9,7 @@ C15Synth::C15Synth(const AudioEngineOptions* options)
     : Synth(options)
     , m_dsp(std::make_unique<dsp_host_dual>())
     , m_options(options)
-    , m_externalMidiOutThread(std::async(std::launch::async, [this] { sendExternalMidiOut(); }))
+    , m_syncExternalsTask(std::async(std::launch::async, [this] { syncExternals(); }))
 {
   m_hwSourceValues.fill(0);
 
@@ -42,16 +42,18 @@ C15Synth::C15Synth(const AudioEngineOptions* options)
 
   receive<Keyboard::NoteUp>(EndPoint::AudioEngine, [this](const Keyboard::NoteUp& noteUp) {
     m_dsp->onMidiMessage(0, static_cast<uint32_t>(noteUp.m_keyPos), 0);
+    m_syncExternalsWaiter.notify_all();
   });
 
   receive<Keyboard::NoteDown>(EndPoint::AudioEngine, [this](const Keyboard::NoteDown& noteDown) {
     m_dsp->onMidiMessage(100, static_cast<uint32_t>(noteDown.m_keyPos), 0);
+    m_syncExternalsWaiter.notify_all();
   });
 
   // receive program changes from playground and dispatch it to midi-over-ip
   receive<nltools::msg::Midi::ProgramChangeMessage>(EndPoint::AudioEngine, [this](const auto& pc) {
     m_externalMidiOutBuffer.push(nltools::msg::Midi::SimpleMessage { 0xC0, pc.program });
-    m_externalMidiOutThreadWaiter.notify_all();
+    m_syncExternalsWaiter.notify_all();
   });
 
   receive<nltools::msg::Midi::SimpleMessage>(EndPoint::ExternalMidiOverIPClient, [&](const auto& msg) {
@@ -68,38 +70,57 @@ C15Synth::C15Synth(const AudioEngineOptions* options)
       pushMidiEvent(e);
     }
   });
-
-  Glib::MainContext::get_default()->signal_idle().connect(sigc::mem_fun(this, &C15Synth::doIdle));
 }
 
 C15Synth::~C15Synth()
 {
   {
-    std::unique_lock<std::mutex> lock(m_externalMidiOutMutex);
+    std::unique_lock<std::mutex> lock(m_syncExternalsMutex);
     m_quit = true;
-    m_externalMidiOutThreadWaiter.notify_all();
+    m_syncExternalsWaiter.notify_all();
   }
-  m_externalMidiOutThread.wait();
+  m_syncExternalsTask.wait();
 }
 
-void C15Synth::sendExternalMidiOut()
+void C15Synth::syncExternals()
 {
-  std::unique_lock<std::mutex> lock(m_externalMidiOutMutex);
+  static_assert(std::tuple_size_v<dsp_host_dual::HWSourceValues> == std::tuple_size_v<decltype(m_hwSourceValues)>,
+                "Types do not match!");
+
+  std::unique_lock<std::mutex> lock(m_syncExternalsMutex);
 
   while(!m_quit)
   {
-    m_externalMidiOutThreadWaiter.wait(lock);
+    m_syncExternalsWaiter.wait(lock);
+    syncExternalMidiBridge();
+    syncPlayground();
+  }
+}
 
-    while(!m_quit && !m_externalMidiOutBuffer.empty())
+void C15Synth::syncExternalMidiBridge()
+{
+  while(!m_externalMidiOutBuffer.empty())
+  {
+    auto msg = m_externalMidiOutBuffer.pop();
+    send(nltools::msg::EndPoint::ExternalMidiOverIPBridge, msg);
+    if(LOG_MIDI_OUT)
     {
-      auto msg = m_externalMidiOutBuffer.pop();
-      send(nltools::msg::EndPoint::ExternalMidiOverIPBridge, msg);
-      if(LOG_MIDI_OUT)
-      {
-        nltools::Log::info("midiOut(status: ", static_cast<uint16_t>(msg.rawBytes[0]),
-                           ", data0: ", static_cast<uint16_t>(msg.rawBytes[1]),
-                           ", data1: ", static_cast<uint16_t>(msg.rawBytes[2]), ")");
-      }
+      nltools::Log::info("midiOut(status: ", static_cast<uint16_t>(msg.rawBytes[0]),
+                         ", data0: ", static_cast<uint16_t>(msg.rawBytes[1]),
+                         ", data1: ", static_cast<uint16_t>(msg.rawBytes[2]), ")");
+    }
+  }
+}
+
+void C15Synth::syncPlayground()
+{
+  auto engineHWSourceValues = m_dsp->getHWSourceValues();
+  for(size_t i = 0; i < std::tuple_size_v<dsp_host_dual::HWSourceValues>; i++)
+  {
+    using namespace nltools::msg;
+    if(std::exchange(m_hwSourceValues[i], engineHWSourceValues[i]) != engineHWSourceValues[i])
+    {
+      send(EndPoint::Playground, HardwareSourceChangedNotification { i, static_cast<double>(engineHWSourceValues[i]) });
     }
   }
 }
@@ -107,12 +128,14 @@ void C15Synth::sendExternalMidiOut()
 void C15Synth::doMidi(const MidiEvent& event)
 {
   m_dsp->onMidiMessage(event.raw[0], event.raw[1], event.raw[2]);
+  m_syncExternalsWaiter.notify_all();
 }
 
 void C15Synth::doTcd(const MidiEvent& event)
 {
   m_dsp->onTcdMessage(event.raw[0], event.raw[1], event.raw[2],
                       [=](auto outgoingMidiMessage) { queueExternalMidiOut(outgoingMidiMessage); });
+  m_syncExternalsWaiter.notify_all();
 }
 
 void C15Synth::simulateKeyDown(int key)
@@ -135,25 +158,6 @@ unsigned int C15Synth::getRenderedSamples()
 dsp_host_dual* C15Synth::getDsp()
 {
   return m_dsp.get();
-}
-
-bool C15Synth::doIdle()
-{
-  static_assert(std::tuple_size_v<dsp_host_dual::HWSourceValues> == std::tuple_size_v<decltype(m_hwSourceValues)>,
-                "Types do not match!");
-
-  auto engineHWSourceValues = m_dsp->getHWSourceValues();
-  for(size_t i = 0; i < std::tuple_size_v<dsp_host_dual::HWSourceValues>; i++)
-  {
-    if(std::exchange(m_hwSourceValues[i], engineHWSourceValues[i]) != engineHWSourceValues[i])
-    {
-      nltools::msg::send(
-          nltools::msg::EndPoint::Playground,
-          nltools::msg::HardwareSourceChangedNotification { i, static_cast<double>(engineHWSourceValues[i]) });
-    }
-  }
-
-  return true;
 }
 
 void C15Synth::doAudio(SampleFrame* target, size_t numFrames)
@@ -330,7 +334,7 @@ void C15Synth::onHWSourceMessage(const nltools::msg::HWSourceChangedMessage& msg
 void C15Synth::queueExternalMidiOut(const dsp_host_dual::SimpleRawMidiMessage& m)
 {
   m_externalMidiOutBuffer.push(m);
-  m_externalMidiOutThreadWaiter.notify_all();
+  m_syncExternalsWaiter.notify_all();
 }
 
 void C15Synth::onSplitPresetMessage(const nltools::msg::SplitPresetMessage& msg)

--- a/projects/epc/audio-engine/src/synth/C15Synth.h
+++ b/projects/epc/audio-engine/src/synth/C15Synth.h
@@ -64,9 +64,11 @@ class C15Synth : public Synth, public sigc::trackable
   dsp_host_dual* getDsp();
 
  private:
-  bool doIdle();
   void queueExternalMidiOut(const dsp_host_dual::SimpleRawMidiMessage& m);
-  void sendExternalMidiOut();
+
+  void syncExternals();
+  void syncExternalMidiBridge();
+  void syncPlayground();
 
   std::unique_ptr<dsp_host_dual> m_dsp;
   std::array<float, 8> m_hwSourceValues;
@@ -74,8 +76,8 @@ class C15Synth : public Synth, public sigc::trackable
 
   RingBuffer<nltools::msg::Midi::SimpleMessage, 2048> m_externalMidiOutBuffer;
 
-  std::mutex m_externalMidiOutMutex;
-  std::condition_variable m_externalMidiOutThreadWaiter;
+  std::mutex m_syncExternalsMutex;
+  std::condition_variable m_syncExternalsWaiter;
   std::atomic<bool> m_quit { false };
-  std::future<void> m_externalMidiOutThread;
+  std::future<void> m_syncExternalsTask;
 };


### PR DESCRIPTION
Using idle callback to send updated hw sources to playground
was a bad idea: a whole core is eaten up for this job now.
So I reused the dedicated background thread for syncing
external midi to do the playground syncing, too.