### PR TITLE
closes #2299

### DIFF
--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
@@ -48,6 +48,7 @@ import com.nonlinearlabs.client.world.overlay.PresetInfoDialog;
 import com.nonlinearlabs.client.world.overlay.belt.EditBufferDraggingButton;
 import com.nonlinearlabs.client.world.overlay.belt.presets.PresetContextMenu;
 import com.nonlinearlabs.client.world.overlay.html.presetSearch.PresetSearchDialog;
+import com.nonlinearlabs.client.world.pointer.PointerState;
 
 public class PresetManager extends MapsLayout {
 
@@ -557,7 +558,6 @@ public class PresetManager extends MapsLayout {
 
 			return this;
 		} else if (dragProxy.getOrigin() instanceof IPreset) {
-
 			IPreset p = (IPreset) dragProxy.getOrigin();
 
 			if (p instanceof Preset) {
@@ -690,6 +690,8 @@ public class PresetManager extends MapsLayout {
 		} else if (keyCode == com.google.gwt.event.dom.client.KeyCodes.KEY_ESCAPE) {
 			NonMaps.get().getNonLinearWorld().getViewport().getOverlay().removeExistingContextMenus();
 			NonMaps.get().getNonLinearWorld().getViewport().getOverlay().collapseGlobalMenu();
+			getNonMaps().getNonLinearWorld().getViewport().getOverlay().cancelDragging();
+			PointerState.get().removeReceiver();
 			closeMultiSelection();
 		} else if (keyCode == com.google.gwt.event.dom.client.KeyCodes.KEY_M
 				&& NonMaps.get().getNonLinearWorld().isCtrlDown()) {

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/pointer/PointerState.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/pointer/PointerState.java
@@ -140,6 +140,10 @@ public class PointerState {
 		setGesture(new Identity());
 	}
 
+	public void removeReceiver() {
+		resetReceiver();
+	}
+
 	private void resetReceiver() {
 		if (currentReceiver != null)
 			currentReceiver.gestureFocusLost();


### PR DESCRIPTION
Had to remove a dangling reference from the Pointerstate. EG: If the (left drag) gesture is canceled, logically, using ESC, and then the left mouse button is released the drop action of the, gone from the overlay, dragproxy was still fired as the dragproxy lived inside the PointerState.