### PR TITLE
Epc2 update intergration

### DIFF
--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc_10i3 bbb"
+        "playcontroller epc_5-7i3 bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -10,6 +10,8 @@ add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar
     DEPENDS epc-create-update
     DEPENDS ${CMAKE_BINARY_DIR}/build-tools/epc/update.tar
+    DEPENDS epc2-create-update
+    DEPENDS ${CMAKE_BINARY_DIR}/build-tools/epc2/create-update/update.tar
     DEPENDS bbb-rootfs
     DEPENDS ${CMAKE_BINARY_DIR}/build-tools/bbb/rootfs.tar.gz
     DEPENDS playcontroller-blobs
@@ -17,12 +19,13 @@ add_custom_command(
     DEPENDS ${SOURCE_FILES}
     COMMAND ${CMAKE_SOURCE_DIR}/build-tools/create-c15-update/create-c15-update.sh
         ${CMAKE_BINARY_DIR}/build-tools/epc/update.tar
+        ${CMAKE_BINARY_DIR}/build-tools/epc2/create-update/update.tar
         ${CMAKE_BINARY_DIR}/build-tools/bbb/rootfs.tar.gz
         ${CMAKE_BINARY_DIR}/build-tools/playcontroller/projects/playcontroller/firmware/src/main/main.bin
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc bbb"
+        "playcontroller epc2 bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc2 bbb"
+        "playcontroller epc epc2 bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc epc2 bbb"
+        "playcontroller epc_5-7i3 epc_10i3 bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc_5-7i3 epc_10i3 bbb"
+        "playcontroller epc_10i3 bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/CMakeLists.txt
+++ b/build-tools/CMakeLists.txt
@@ -25,7 +25,7 @@ add_custom_command(
         ${CMAKE_BINARY_DIR}
         ${CMAKE_SOURCE_DIR}
         nonlinear-c15-update
-        "playcontroller epc_5-7i3 bbb"
+        "playcontroller epc bbb"
 )
 
 add_custom_target(c15-update DEPENDS ${CMAKE_BINARY_DIR}/nonlinear-c15-update.tar)

--- a/build-tools/create-c15-update/Installer_Error_Codes.txt
+++ b/build-tools/create-c15-update/Installer_Error_Codes.txt
@@ -34,6 +34,9 @@ List of current Error Messages
 - 83 :: "E83: Can't logon to ePC OS ..."
 - 84 :: "E84: Upgrade OS first!"
 - 85 :: "E85: OS too old for update!"
+- 86 :: "E86: ePC update missing" "Please retry download!"
+- 87 :: "E87: BBB update missing" "Please retry download!"
+- 88 :: "E88: playcontroller update missing" "Please retry download!"
 
 ------------------------------------------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------------------------------------------

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -19,22 +19,22 @@ UPDATE_PLAYCONTROLLER=0
 UPDATE_EPC=0
 UPDATE_EPC_2=0
 
-if [[ $ASPECTS = epc_5-7i3 ]]
+if [[ "$ASPECTS" == "epc_5-7i3" ]]
 then
     UPDATE_EPC=1
 fi
 
-if [[ $ASPECTS = epc_10i3 ]]
+if [[ "$ASPECTS" == "epc_10i3" ]]
 then
     UPDATE_EPC_2=1
 fi
 
-if [[ $ASPECTS = *playcontroller* ]]
+if [[ "$ASPECTS" == "playcontroller" ]]
 then
     UPDATE_PLAYCONTROLLER=1
 fi
 
-if [[ $ASPECTS = *bbb* ]]
+if [[ "$ASPECTS" == "bbb" ]]
 then
     UPDATE_BBB=1
 fi
@@ -74,7 +74,7 @@ deploy_updates() {
 
     if [ $UPDATE_EPC == 1 ]; then
         echo "Will deploy ePC_1 update."
-        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_5-7i3.tar || fail_and_exit;
+        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_5-7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_5-7i3.tar || fail_and_exit;
     fi
 
     if [ $UPDATE_EPC_2 == 1 ]; then

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -1,26 +1,32 @@
 #!/bin/bash
 #
-# Author:       Anton Schmied
 # Date:         12.02.2020
 # vom Cmake übergebene Pfade zu den .tarS
 
 EPC_UPDATE=$1
-BBB_UPDATE=$2
-PLAYCONTROLLER_UPDATE=$3
-BINARY_DIR=$4
-SOURCE_DIR=$5/build-tools/create-c15-update
-OUTNAME=$6
-ASPECTS=$7
+EPC_2_UPDATE=$2
+BBB_UPDATE=$3
+PLAYCONTROLLER_UPDATE=$4
+BINARY_DIR=$5
+SOURCE_DIR=$6/build-tools/create-c15-update
+OUTNAME=$7
+ASPECTS=$8
 OUT_DIRECTORY=$BINARY_DIR/$OUTNAME
 OUT_TAR=$BINARY_DIR/$OUTNAME.tar
 
 UPDATE_BBB=0
 UPDATE_PLAYCONTROLLER=0
 UPDATE_EPC=0
+UPDATE_EPC_2=0
 
 if [[ $ASPECTS = *epc* ]]
 then
     UPDATE_EPC=1
+fi
+
+if [[ $ASPECTS = *epc2* ]]
+then
+    UPDATE_EPC_2=1
 fi
 
 if [[ $ASPECTS = *playcontroller* ]]
@@ -40,6 +46,7 @@ fail_and_exit() {
 
 check_preconditions () {
     if [ -z "$EPC_UPDATE" -a $UPDATE_EPC == 1 ]; then echo "ePC update missing..." && return 1; fi
+    if [ -z "$EPC_2_UPDATE" -a $UPDATE_EPC_2 == 1 ]; then echo "ePC 2 update missing..." && return 1; fi
     if [ -z "$BBB_UPDATE" -a $UPDATE_BBB == 1 ]; then echo "BBB update missing..." && return 1; fi
     if [ -z "$PLAYCONTROLLER_UPDATE" -a $UPDATE_PLAYCONTROLLER == 1 ]; then echo "playcontroller update missing..." && return 1; fi
     return 0
@@ -50,7 +57,7 @@ create_update_file_structure() {
     rm -rf $OUT_DIRECTORY
     mkdir $OUT_DIRECTORY || fail_and_exit
     if [ $UPDATE_BBB == 1 ]; then mkdir $OUT_DIRECTORY/BBB || fail_and_exit; fi
-    if [ $UPDATE_EPC == 1 ]; then mkdir $OUT_DIRECTORY/EPC || fail_and_exit; fi
+    if [ $UPDATE_EPC == 1 ] || [ $UPDATE_EPC_2 == 1 ]; then mkdir $OUT_DIRECTORY/EPC || fail_and_exit; fi
     if [ $UPDATE_PLAYCONTROLLER == 1 ]; then mkdir $OUT_DIRECTORY/playcontroller || fail_and_exit; fi
     mkdir $OUT_DIRECTORY/utilities || fail_and_exit
     echo "Creating Update Structure done."
@@ -66,6 +73,10 @@ deploy_updates() {
 
     if [ $UPDATE_EPC == 1 ]; then
         cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update.tar && chmod 666 $OUT_DIRECTORY/EPC/update.tar || fail_and_exit;
+    fi
+
+    if [ $UPDATE_EPC_2 == 1 ]; then
+        cp $EPC_2_UPDATE $OUT_DIRECTORY/EPC/update.tar && chmod 666 $OUT_DIRECTORY/EPC/update.tar || fail_and_exit;
     fi
 
     if [ $UPDATE_PLAYCONTROLLER == 1 ]; then

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -17,16 +17,10 @@ OUT_TAR=$BINARY_DIR/$OUTNAME.tar
 UPDATE_BBB=0
 UPDATE_PLAYCONTROLLER=0
 UPDATE_EPC=0
-UPDATE_EPC_2=0
 
-if [[ $ASPECTS = *epc_5-7i3* ]]
+if [[ $ASPECTS = *epc* ]]
 then
     UPDATE_EPC=1
-fi
-
-if [[ $ASPECTS = *epc_10i3* ]]
-then
-    UPDATE_EPC_2=1
 fi
 
 if [[ $ASPECTS = *playcontroller* ]]
@@ -46,7 +40,6 @@ fail_and_exit() {
 
 check_preconditions () {
     if [ -z "$EPC_UPDATE" -a $UPDATE_EPC == 1 ]; then echo "ePC update missing..." && return 1; fi
-    if [ -z "$EPC_2_UPDATE" -a $UPDATE_EPC_2 == 1 ]; then echo "ePC 2 update missing..." && return 1; fi
     if [ -z "$BBB_UPDATE" -a $UPDATE_BBB == 1 ]; then echo "BBB update missing..." && return 1; fi
     if [ -z "$PLAYCONTROLLER_UPDATE" -a $UPDATE_PLAYCONTROLLER == 1 ]; then echo "playcontroller update missing..." && return 1; fi
     return 0
@@ -57,7 +50,7 @@ create_update_file_structure() {
     rm -rf $OUT_DIRECTORY
     mkdir $OUT_DIRECTORY || fail_and_exit
     if [ $UPDATE_BBB == 1 ]; then mkdir $OUT_DIRECTORY/BBB || fail_and_exit; fi
-    if [ $UPDATE_EPC == 1 ] || [ $UPDATE_EPC_2 == 1 ]; then mkdir $OUT_DIRECTORY/EPC || fail_and_exit; fi
+    if [ $UPDATE_EPC == 1 ]; then mkdir $OUT_DIRECTORY/EPC || fail_and_exit; fi
     if [ $UPDATE_PLAYCONTROLLER == 1 ]; then mkdir $OUT_DIRECTORY/playcontroller || fail_and_exit; fi
     mkdir $OUT_DIRECTORY/utilities || fail_and_exit
     echo "Creating Update Structure done."
@@ -73,12 +66,8 @@ deploy_updates() {
     fi
 
     if [ $UPDATE_EPC == 1 ]; then
-        echo "Will deploy ePC_1 update."
+        echo "Will deploy ePC updates."
         cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_5-7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_5-7i3.tar || fail_and_exit;
-    fi
-
-    if [ $UPDATE_EPC_2 == 1 ]; then
-        echo "Will deploy ePC_2 update."
         cp $EPC_2_UPDATE $OUT_DIRECTORY/EPC/update_10i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_10i3.tar || fail_and_exit;
     fi
 
@@ -103,7 +92,7 @@ deploy_scripts() {
             fail_and_exit;
     fi
 
-    if [ $UPDATE_EPC == 1 ] || [ $UPDATE_EPC_2 == 1 ]; then
+    if [ $UPDATE_EPC == 1 ]; then
         cp $SOURCE_DIR/update_scripts/epc_pull_update.sh $OUT_DIRECTORY/EPC/ && \
             chmod 777 $OUT_DIRECTORY/EPC/epc_pull_update.sh && \
             cp $SOURCE_DIR/update_scripts/epc_push_update.sh $OUT_DIRECTORY/EPC/ && \

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -68,18 +68,22 @@ deploy_updates() {
     echo "Deploying updates..."
 
     if [ $UPDATE_BBB == 1 ]; then
+        echo "Will deploy BBB update."
         cp $BBB_UPDATE $OUT_DIRECTORY/BBB/ && chmod 666 $OUT_DIRECTORY/BBB/rootfs.tar.gz || fail_and_exit;
     fi
 
     if [ $UPDATE_EPC == 1 ]; then
-        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update.tar && chmod 666 $OUT_DIRECTORY/EPC/update.tar || fail_and_exit;
+        echo "Will deploy ePC_1 update."
+        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_7i3.tar || fail_and_exit;
     fi
 
     if [ $UPDATE_EPC_2 == 1 ]; then
-        cp $EPC_2_UPDATE $OUT_DIRECTORY/EPC/update.tar && chmod 666 $OUT_DIRECTORY/EPC/update.tar || fail_and_exit;
+        echo "Will deploy ePC_2 update."
+        cp $EPC_2_UPDATE $OUT_DIRECTORY/EPC/update_10i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_10i3.tar || fail_and_exit;
     fi
 
     if [ $UPDATE_PLAYCONTROLLER == 1 ]; then
+        echo "Will deploy playcontroller update."
         cp $PLAYCONTROLLER_UPDATE $OUT_DIRECTORY/playcontroller/main.bin && chmod 666 $OUT_DIRECTORY/playcontroller/main.bin || fail_and_exit;
     fi
 
@@ -99,7 +103,7 @@ deploy_scripts() {
             fail_and_exit;
     fi
 
-    if [ $UPDATE_EPC == 1 ]; then
+    if [ $UPDATE_EPC == 1 ] || [ $UPDATE_EPC_2 == 1 ]; then
         cp $SOURCE_DIR/update_scripts/epc_pull_update.sh $OUT_DIRECTORY/EPC/ && \
             chmod 777 $OUT_DIRECTORY/EPC/epc_pull_update.sh && \
             cp $SOURCE_DIR/update_scripts/epc_push_update.sh $OUT_DIRECTORY/EPC/ && \

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -19,12 +19,12 @@ UPDATE_PLAYCONTROLLER=0
 UPDATE_EPC=0
 UPDATE_EPC_2=0
 
-if [[ $ASPECTS = *epc* ]]
+if [[ $ASPECTS = epc_5-7i3 ]]
 then
     UPDATE_EPC=1
 fi
 
-if [[ $ASPECTS = *epc2* ]]
+if [[ $ASPECTS = epc_10i3 ]]
 then
     UPDATE_EPC_2=1
 fi
@@ -74,7 +74,7 @@ deploy_updates() {
 
     if [ $UPDATE_EPC == 1 ]; then
         echo "Will deploy ePC_1 update."
-        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_7i3.tar || fail_and_exit;
+        cp $EPC_UPDATE $OUT_DIRECTORY/EPC/update_7i3.tar && chmod 666 $OUT_DIRECTORY/EPC/update_5-7i3.tar || fail_and_exit;
     fi
 
     if [ $UPDATE_EPC_2 == 1 ]; then

--- a/build-tools/create-c15-update/create-c15-update.sh
+++ b/build-tools/create-c15-update/create-c15-update.sh
@@ -19,22 +19,22 @@ UPDATE_PLAYCONTROLLER=0
 UPDATE_EPC=0
 UPDATE_EPC_2=0
 
-if [[ "$ASPECTS" == "epc_5-7i3" ]]
+if [[ $ASPECTS = *epc_5-7i3* ]]
 then
     UPDATE_EPC=1
 fi
 
-if [[ "$ASPECTS" == "epc_10i3" ]]
+if [[ $ASPECTS = *epc_10i3* ]]
 then
     UPDATE_EPC_2=1
 fi
 
-if [[ "$ASPECTS" == "playcontroller" ]]
+if [[ $ASPECTS = *playcontroller* ]]
 then
     UPDATE_PLAYCONTROLLER=1
 fi
 
-if [[ "$ASPECTS" == "bbb" ]]
+if [[ $ASPECTS = *bbb* ]]
 then
     UPDATE_BBB=1
 fi

--- a/build-tools/create-c15-update/update_scripts/run.sh
+++ b/build-tools/create-c15-update/update_scripts/run.sh
@@ -119,7 +119,7 @@ check_preconditions() {
     fi
 
     if [ "$(executeAsRoot "uname -r")" = "4.9.9-rt6-1-rt" ]; then
-        ln -s /update/EPC/update_7i3.tar /update/EPC/update.tar
+        ln -s /update/EPC/update_5-7i3.tar /update/EPC/update.tar
         FIX_EPC=true
     else
         ln -s /update/EPC/update_10i3.tar /update/EPC/update.tar
@@ -144,8 +144,6 @@ epc_pull_update() {
 epc_fix() {
     /update/utilities/sshpass -p "sscl" scp -r /update/EPC/epc_fix.sh sscl@192.168.10.10:/tmp
     executeAsRoot "cd /tmp && chmod +x epc_fix.sh && ./epc_fix.sh"
-    executeAsRoot "reboot"
-    wait4epc 60
     return $?
 }
 
@@ -171,6 +169,8 @@ epc_update() {
             sleep 2
             return 1
         fi
+        executeAsRoot "reboot"
+        wait4epc 60
     fi
 
     pretty "" "$MSG_UPDATING_EPC" "$MSG_DONE" "$MSG_UPDATING_EPC" "$MSG_DONE"

--- a/build-tools/create-c15-update/update_scripts/run.sh
+++ b/build-tools/create-c15-update/update_scripts/run.sh
@@ -118,13 +118,21 @@ check_preconditions() {
         report "" "Something went wrong!" "Please retry update!" && return 1
     fi
 
-    if [ "$(executeAsRoot "uname -r")" = "4.9.9-rt6-1-rt" ]; then
-        ln -s /update/EPC/update_5-7i3.tar /update/EPC/update.tar
+    if [[ "$(executeAsRoot "uname -r")" == "4.9.9-rt6-1-rt" ]]; then
+        if ! ln -s /update/EPC/update_5-7i3.tar /update/EPC/update.tar; then
+            report "E86: ePC update missing" "Please retry download!" && return 1
+        fi
         FIX_EPC=true
     else
-        ln -s /update/EPC/update_10i3.tar /update/EPC/update.tar
+        if ! ln -s /update/EPC/update_10i3.tar /update/EPC/update.tar; then
+            report "E86: ePC update missing" "Please retry download!" && return 1
+        fi
         FIX_EPC=false
     fi
+
+    [ -f "$/update/BBB/rootfs.tar.gz" ] || report "E87: BBB update missing" "Please retry download!" && return 1
+
+    [ -f "$/update/playcontroller/main.bin" ] || report "E88: playcontroller update missing" "Please retry download!" && return 1
 
     return 0
 }
@@ -160,7 +168,7 @@ epc_update() {
         fi
     fi
 
-    if [ "$FIX_EPC" = "true" ]; then
+    if [[ "$FIX_EPC" == "true" ]]; then
         epc_fix
         return_code=$?
         if [ $return_code -ne 0 ]; then

--- a/build-tools/epc2/host-os/Dockerfile
+++ b/build-tools/epc2/host-os/Dockerfile
@@ -1,5 +1,4 @@
-ARG arch_version
-FROM archlinux:${arch_version}
+FROM archlinux:20200908
 ARG packages
 RUN echo "[dvzrv]" >> /etc/pacman.d/mirrorlist
 RUN echo "Server = https://pkgbuild.com/~dvzrv/repo/\$arch" >> /etc/pacman.d/mirrorlist


### PR DESCRIPTION
So, both ePC updates are deployed into the C15-update.tar
Then we check the kernel version and link to the corresponding ePC update within the run.sh.
tested both, seems to work fine for both ePCs

!!!***************************************!!!
https://github.com/nonlinear-labs-dev/C15/blob/epc2/build-tools/epc2/host-os/Dockerfile
is adjusted to personal needs, since my Docker Version is out of date