### PR TITLE
AudioEngine - integration of Overlapping Split Points

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -63,7 +63,7 @@ struct KeyAssignment
 
 struct VoiceAssignment
 {
-  uint32_t m_keyId = 0;
+  uint32_t m_keyNumber = 0;
   bool m_active = false, m_stolen = false;
 };
 
@@ -452,7 +452,7 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
       //clear stolen key first(all associated voices will be lost)
       if(m_voiceState[firstVoice].m_active)
       {
-        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyId]);
+        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyNumber]);
       }
     }
     return firstVoice;
@@ -494,7 +494,7 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
       // clear stolen key first (all associated voices of the corresp. part will be lost)
       if(m_voiceState[firstVoice].m_active)
       {
-        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyId], _layerIndex);
+        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyNumber], _layerIndex);
       }
     }
     return firstVoice;
@@ -519,7 +519,7 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
       // clear stolen key first (all associated voices will be lost)
       if(m_voiceState[firstVoice].m_active)
       {
-        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyId]);
+        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyNumber]);
       }
     }
     return firstVoice;
@@ -711,7 +711,7 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
       // glide is allowed for: first unison voice and: first unison voice of second voice group (important for single-sound cases)
       const bool allow_glide = unisonIndex == 0 ? true : m_glideAllowance[voiceId];
       VoiceAssignment* voiceState = &m_voiceState[voiceId];
-      voiceState->m_keyId = _keyId;
+      voiceState->m_keyNumber = _keyId;
       voiceState->m_stolen = voiceState->m_active;
       voiceState->m_active = true;
       m_traversal.add(m_localIndex[voiceId], m_localVoice[voiceId], unisonIndex, voiceState->m_active,

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -253,7 +253,6 @@ template <uint32_t Voices> class PolyVoiceAllocator
   uint32_t m_previous_assigned[Voices] = {}, m_next_assigned[Voices] = {}, m_next_released[Voices] = {},
            m_assignable = {}, m_num_assigned = {}, m_oldest_assigned = {}, m_youngest_assigned = {},
            m_oldest_released = {}, m_youngest_released = {}, m_unison = {};
-  // m_mono_keys[Voices] = {}, m_mono_latest = {}
 };
 
 // Main Voice Allocation Structure

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -491,10 +491,10 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
       {
         m_traversal.addEvent(_keyState->m_keyNumber, _keyState->m_velocity, true, false);
       }
-      // clear stolen key first (all associated voices will be lost)
+      // clear stolen key first (all associated voices of the corresp. part will be lost)
       if(m_voiceState[firstVoice].m_active)
       {
-        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyId]);
+        keyUp_confirm(&m_keyState[m_voiceState[firstVoice].m_keyId], _layerIndex);
       }
     }
     return firstVoice;
@@ -696,6 +696,12 @@ template <uint32_t GlobalVoices, uint32_t LocalVoices, uint32_t Keys> class Voic
   {
     _keyState->m_origin = AllocatorId::None;
     _keyState->m_active = false;
+  }
+  // for overlapping split points, we have to be a little more careful
+  inline void keyUp_confirm(KeyAssignment* _keyState, const uint32_t _layerIndex)
+  {
+    _keyState->m_origin = m_layerId[1 - _layerIndex];
+    // the key is still pressed in the other part and has been exclusively allocated to it
   }
   inline void keyDown_unisonLoop(const uint32_t _keyId, const uint32_t _firstVoice, const uint32_t _unisonVoices)
   {


### PR DESCRIPTION
When using overlapping Split Points, the VoiceAllocation had some issues associating different Mono und Unison settings in the different Parts ("Notenhänger"). Now, it should be possible to:
- play overlapping keys without issues, regardless of different Mono/Unison settings per part
- play overlapping keys, even if all voices in a part are exhausted (note steal) without issues
- play overlapping and non-overlapping keys simultaneously, even if all voices in a part are exhausted (note steal) without issue

A thorough Test of overlapping Split Points is necessary, of course.