### PR TITLE
Remove existing link in order to not fail following "ln -s".

### DIFF
--- a/build-tools/create-c15-update/update_scripts/run.sh
+++ b/build-tools/create-c15-update/update_scripts/run.sh
@@ -117,6 +117,8 @@ check_preconditions() {
         fi
         report "" "Something went wrong!" "Please retry update!" && return 1
     fi
+    
+    rm /update/EPC/update.tar
 
     if [[ "$(executeAsRoot "uname -r")" == "4.9.9-rt6-1-rt" ]]; then
         if ! ln -s /update/EPC/update_5-7i3.tar /update/EPC/update.tar; then
@@ -130,9 +132,8 @@ check_preconditions() {
         FIX_EPC=false
     fi
 
-    [ -f "$/update/BBB/rootfs.tar.gz" ] || report "E87: BBB update missing" "Please retry download!" && return 1
-
-    [ -f "$/update/playcontroller/main.bin" ] || report "E88: playcontroller update missing" "Please retry download!" && return 1
+    [ -f "/update/BBB/rootfs.tar.gz" ] || (report "E87: BBB update missing" "Please retry download!" && return 1)
+    [ -f "/update/playcontroller/main.bin" ] || (report "E88: playcontroller update missing" "Please retry download!" && return 1)
 
     return 0
 }


### PR DESCRIPTION
Respect operator precedence in error handling.