### PR TITLE
WebUI: Value Edit Bug Fix

### DIFF
--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/ValueEdit.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/ValueEdit.java
@@ -84,7 +84,7 @@ public class ValueEdit extends OverlayLayout {
 
 		@Override
 		public Control doubleClick(Position pos) {
-			return click(null);
+			return this;
 		}
 
 		@Override


### PR DESCRIPTION
changed doubleClick handler to be ignored, previously continously clicking on the change arrow lead to random jumps over values, as click was called from double click, this is now fixed and you can spam-click the changed arrows as much as you like without missing value steps