### PR TITLE
Issue 2393

### DIFF
--- a/projects/epc/playground/src/presets/BankActions.cpp
+++ b/projects/epc/playground/src/presets/BankActions.cpp
@@ -347,27 +347,12 @@ BankActions::BankActions(PresetManager &presetManager)
         UNDO::Scope::tTransactionScopePtr scope = m_presetManager.getUndoScope().startContinuousTransaction(
             &presetManager, std::chrono::hours(1), preset->buildUndoTransactionTitle("Select Preset"));
 
-        auto transaction = scope->getTransaction();
-        m_presetManager.selectBank(transaction, bank->getUuid());
-        bank->selectPreset(transaction, presetUUID);
-      }
-    }
-  });
-
-  addAction("select-preset-with-direct-load", [&](std::shared_ptr<NetworkRequest> request) mutable {
-    Glib::ustring presetUUID = request->get("uuid");
-
-    if(auto bank = m_presetManager.findBankWithPreset(presetUUID))
-    {
-      if(auto preset = bank->findPreset(presetUUID))
-      {
-        UNDO::Scope::tTransactionScopePtr scope = m_presetManager.getUndoScope().startContinuousTransaction(
-            &presetManager, std::chrono::hours(1), preset->buildUndoTransactionTitle("Select Preset"));
+        if(Application::get().getSettings()->getSetting<DirectLoadSetting>()->get())
+          Application::get().getHWUI()->setLoadToPart(false);
 
         auto transaction = scope->getTransaction();
         m_presetManager.selectBank(transaction, bank->getUuid());
         bank->selectPreset(transaction, presetUUID);
-        m_presetManager.getEditBuffer()->undoableLoad(transaction, m_presetManager.findPreset(presetUUID), true);
       }
     }
   });

--- a/projects/epc/playground/src/presets/PresetManager.cpp
+++ b/projects/epc/playground/src/presets/PresetManager.cpp
@@ -964,6 +964,8 @@ void PresetManager::scheduleLoadToPart(const Preset *preset, VoiceGroup loadFrom
     }
   });
 }
+
+//How could this ever have worked?
 void PresetManager::autoLoadPresetAccordingToLoadType()
 {
   auto eb = getEditBuffer();

--- a/projects/epc/playground/src/proxies/hwui/HWUI.h
+++ b/projects/epc/playground/src/proxies/hwui/HWUI.h
@@ -53,6 +53,7 @@ class HWUI
   VoiceGroup getCurrentVoiceGroup() const;
   bool isInLoadToPart() const;
 
+  //TODO Remove all non HWUI Related things! -> VoiceGroup, LoadToPart etc
   void setLoadToPart(bool state);
   void setCurrentVoiceGroup(VoiceGroup v);
   void setCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction, VoiceGroup v);

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/ServerProxy.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/ServerProxy.java
@@ -257,6 +257,12 @@ public class ServerProxy {
 		queueJob(uri, true);
 	}
 
+	public void selectPresetWithDirectLoad(String uuid) {
+		StaticURI.Path path = new StaticURI.Path("presets", "banks", "select-preset-with-direct-load");
+		StaticURI uri = new StaticURI(path, new StaticURI.KeyValue("uuid", uuid));
+		queueJob(uri, true);
+	}
+
 	public void newBank(String initialName, NonPosition pos) {
 		StaticURI.Path path = new StaticURI.Path("presets", "new-bank");
 		StaticURI.KeyValue x = new StaticURI.KeyValue("x", pos.getX());

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/ServerProxy.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/ServerProxy.java
@@ -257,12 +257,6 @@ public class ServerProxy {
 		queueJob(uri, true);
 	}
 
-	public void selectPresetWithDirectLoad(String uuid) {
-		StaticURI.Path path = new StaticURI.Path("presets", "banks", "select-preset-with-direct-load");
-		StaticURI uri = new StaticURI(path, new StaticURI.KeyValue("uuid", uuid));
-		queueJob(uri, true);
-	}
-
 	public void newBank(String initialName, NonPosition pos) {
 		StaticURI.Path path = new StaticURI.Path("presets", "new-bank");
 		StaticURI.KeyValue x = new StaticURI.KeyValue("x", pos.getX());

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/dataModel/editBuffer/EditBufferModelUpdater.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/dataModel/editBuffer/EditBufferModelUpdater.java
@@ -5,7 +5,6 @@ import com.nonlinearlabs.client.dataModel.Updater;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.SoundType;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.VoiceGroup;
 import com.nonlinearlabs.client.dataModel.editBuffer.ModulateableParameterModel.ModSource;
-import com.nonlinearlabs.client.dataModel.setup.SetupModel;
 
 public class EditBufferModelUpdater extends Updater {
 

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/presenters/FadeEditorPresenterProvider.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/presenters/FadeEditorPresenterProvider.java
@@ -57,11 +57,6 @@ public class FadeEditorPresenterProvider extends Notifier<FadeEditorPresenter> {
         presenter.splitII.to = 60;
         presenter.splitII.indicator = presenter.splitII.from;
 
-        Tracer.log("splitI.from" + presenter.splitI.from);
-        Tracer.log("splitI.to" + presenter.splitI.to);
-        Tracer.log("splitII.from" + presenter.splitII.from);
-        Tracer.log("splitII.to" + presenter.splitII.to);
-
         BasicParameterModel fadeI = model.getParameter(new ParameterId(396, VoiceGroup.I));
         BasicParameterModel fadeII = model.getParameter(new ParameterId(396, VoiceGroup.II));
         double fadeIVal = fadeI.value.getQuantizedAndClipped(true);

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/PresetManager.java
@@ -144,6 +144,11 @@ public class PresetManager extends MapsLayout {
 			return true;
 		});
 
+		EditBufferModel.get().loadedPreset.onChange(loadedPreset -> {
+			endLoadToPartMode();
+			return true;
+		});
+
 		loadToPartNotifier = new LoadToPartModeNotifier();
 	}
 

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/bank/PresetList.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/bank/PresetList.java
@@ -119,10 +119,7 @@ public class PresetList extends LayoutResizingVertical {
 		selectedPreset = uuid;
 
 		if (sendToServer) {
-			if (SetupModel.get().systemSettings.directLoad.getBool())
-				getNonMaps().getServerProxy().selectPresetWithDirectLoad(uuid);
-			else
-				getNonMaps().getServerProxy().selectPreset(uuid);
+			getNonMaps().getServerProxy().selectPreset(uuid);
 		}
 
 		requestLayout();

--- a/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/bank/PresetList.java
+++ b/projects/epc/web-ui/src/main/java/com/nonlinearlabs/client/world/maps/presets/bank/PresetList.java
@@ -1,6 +1,7 @@
 package com.nonlinearlabs.client.world.maps.presets.bank;
 
 import com.nonlinearlabs.client.NonMaps;
+import com.nonlinearlabs.client.dataModel.setup.SetupModel;
 import com.nonlinearlabs.client.world.Control;
 import com.nonlinearlabs.client.world.maps.LayoutResizingVertical;
 import com.nonlinearlabs.client.world.maps.presets.bank.preset.Preset;
@@ -117,8 +118,11 @@ public class PresetList extends LayoutResizingVertical {
 	public void selectPreset(String uuid, boolean sendToServer) {
 		selectedPreset = uuid;
 
-		if(sendToServer) {
-			getNonMaps().getServerProxy().selectPreset(uuid);
+		if (sendToServer) {
+			if (SetupModel.get().systemSettings.directLoad.getBool())
+				getNonMaps().getServerProxy().selectPresetWithDirectLoad(uuid);
+			else
+				getNonMaps().getServerProxy().selectPreset(uuid);
 		}
 
 		requestLayout();


### PR DESCRIPTION
HOTFIX! When Direct Load was active the select action from the WebUI was being processed deferred and then HWUI aspects have been taken into account: Load to Part Active? Yes -> load preset part to part, even if load to part in the WebUI was off. Now if direct load is on the select action will directly trigger an load. This will in turn close the Load To Part overlay that is being used in the async callback that is scheduled from selectPreset.

@hhoegelo lets talk about this