### PR TITLE
- Fix build problems by bumping to ubuntu 20.04 (LTS)

### DIFF
--- a/build-tools/bbb/CMakeLists.txt
+++ b/build-tools/bbb/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(USER $ENV{USER})
 SET(DOCKERNAME nl-cross-build-environment)
-SET(NONLINUX nonlinear_2020.43)
+SET(NONLINUX nonlinear_2021.01)
 
 file(GLOB_RECURSE ALL_FILES_IN_PROJECT ${CMAKE_SOURCE_DIR}/projects/*)
 

--- a/build-tools/bbb/Dockerfile
+++ b/build-tools/bbb/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 ENV LANG en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y git locales && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && dpkg-reconfigure --frontend=noninteractive locales && update-locale LANG=en_US.UTF-8
-RUN apt-get update -y && apt-get install -y git cmake build-essential wget cpio python unzip bc doxygen curl libcurl4-openssl-dev bash ncurses-dev nano
+RUN apt-get update -y && apt-get install -y git cmake build-essential wget cpio python unzip bc doxygen curl libcurl4-openssl-dev bash ncurses-dev nano zlib1g-dev

--- a/build-tools/epc/Dockerfile
+++ b/build-tools/epc/Dockerfile
@@ -1,3 +1,6 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
+
+ENV LANG en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get remove -y gstreamer1.0 libwayland-server0 x11-common && apt-get install -y --fix-missing mtools qemu-system-x86 sshpass bash fuseiso squashfs-tools sudo genisoimage xorriso syslinux-utils fuse-overlayfs fuse3 squashfuse wget

--- a/build-tools/playcontroller/Dockerfile
+++ b/build-tools/playcontroller/Dockerfile
@@ -1,3 +1,6 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
+
+ENV LANG en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y git gcc-arm-none-eabi cmake build-essential crossbuild-essential-armhf crossbuild-essential-armel pkg-config


### PR DESCRIPTION
- switch to new nonlinux version which has nlimagemaker for rescue usb sticks

@All: I had to remove the build-tools/bbb folder in my build directory after applying that fix.
@schlenkibus I will add another PR for staging, without the nonlinux update