### PR TITLE
In contrast to the docu, snd_midi_event_decode(decoder, buf, 3, &even…

### DIFF
--- a/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
+++ b/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
@@ -74,12 +74,12 @@ void readMidi(int cancelHandle, snd_rawmidi_t *inputHandle)
         {
           if(snd_midi_event_encode_byte(encoder, byte, &event) == 1)
           {
-            if(event.type != SND_SEQ_EVENT_NONE)
+            if(event.type < SND_SEQ_EVENT_SONGPOS)
             {
               if(enableMidi)
               {
                 Midi::SimpleMessage msg;
-                msg.numBytesUsed = snd_midi_event_decode(decoder, msg.rawBytes.data(), 3, &event);
+                msg.numBytesUsed = std::min(3l, snd_midi_event_decode(decoder, msg.rawBytes.data(), 3, &event));
                 send(EndPoint::ExternalMidiOverIPClient, msg);
               }
               break;


### PR DESCRIPTION
…t) returns

the number of bytes that could have been written to buf, instead of the number
of bytes actually written. This corrupts the message and makes AudioEngine crash.

Also, filter some messages that are not relevant for our purposes.
Relevant whitelisted messages are:

SND_SEQ_EVENT_NOTE, SND_SEQ_EVENT_NOTEON, SND_SEQ_EVENT_NOTEOFF,
SND_SEQ_EVENT_KEYPRESS, SND_SEQ_EVENT_CONTROLLER, SND_SEQ_EVENT_PGMCHANGE,
SND_SEQ_EVENT_CHANPRESS, SND_SEQ_EVENT_PITCHBEND, SND_SEQ_EVENT_CONTROL14,