### PR TITLE
Issue 2472 Fix

### DIFF
--- a/build-tools/create-c15-update/update_scripts/bbb_update.sh
+++ b/build-tools/create-c15-update/update_scripts/bbb_update.sh
@@ -18,7 +18,7 @@ report_and_quit(){
 }
 
 executeAsRoot() {
-    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP \
+    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ServerAliveInterval=1 -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP \
         "sudo -S /bin/bash -c '$1' 1>&2 > /dev/null"
     return $?
 }

--- a/build-tools/create-c15-update/update_scripts/epc_pull_update.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_pull_update.sh
@@ -18,7 +18,7 @@ report_and_quit(){
 }
 
 executeAsRoot() {
-    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1' "
+    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ServerAliveInterval=1 -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1' "
     return $?
 }
 

--- a/build-tools/create-c15-update/update_scripts/epc_push_update.sh
+++ b/build-tools/create-c15-update/update_scripts/epc_push_update.sh
@@ -17,7 +17,7 @@ report_and_quit(){
 }
 
 executeAsRoot() {
-    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1' "
+    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ServerAliveInterval=1 -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1' "
     return $?
 }
 

--- a/build-tools/create-c15-update/update_scripts/run.sh
+++ b/build-tools/create-c15-update/update_scripts/run.sh
@@ -83,12 +83,12 @@ report() {
 }
 
 executeAsRoot() {
-    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1'"
+    echo "sscl" | /update/utilities/sshpass -p 'sscl' ssh -o ServerAliveInterval=1 -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no sscl@$EPC_IP "sudo -S /bin/bash -c '$1'"
     return $?
 }
 
 executeOnWin() {
-    /update/utilities/sshpass -p 'TEST' ssh -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no TEST@$EPC_IP "$1" 1>&2 > /dev/null
+    /update/utilities/sshpass -p 'TEST' ssh -o ServerAliveInterval=1 -o ConnectionAttempts=1 -o ConnectTimeout=1 -o StrictHostKeyChecking=no TEST@$EPC_IP "$1" 1>&2 > /dev/null
     return $?
 }
 


### PR DESCRIPTION
The option `ServerAliveInterval=1` will cause the client to tear down the connection if the Server does not reply after 1 second.
This should not cause any other problems.