### PR TITLE
fix midi over IP CPU load on sysex and unsupported incoming messages

### DIFF
--- a/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
+++ b/projects/bbb/midi-over-ip/src/MidiOverIP.cpp
@@ -78,8 +78,8 @@ void readMidi(int cancelHandle, snd_rawmidi_t *inputHandle)
               Midi::SimpleMessage msg;
               msg.numBytesUsed = std::min(3l, snd_midi_event_decode(decoder, msg.rawBytes.data(), 3, &event));
               send(EndPoint::ExternalMidiOverIPClient, msg);
-              break;
             }
+            break;
           }
         }
         else if(readResult == -19)


### PR DESCRIPTION
move break to outer scope, so that ignored messages also break the read loop and return to polling