### PR TITLE
fix overrun from large SysEx data

### DIFF
--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -48,7 +48,7 @@ void Input::readMidi()
 
   // Raw bytes buffer for snd_raw_midi_read().
   // For large SysEx data coming in fast a fair amount of background buffer is really required
-  constexpr unsigned RAWMIDI_BUF_SIZE = 32768;  // empirical value + safety margin
+  constexpr unsigned RAWMIDI_BUF_SIZE = 131072;  // empirical value + safety margin
 
   // Maximum granularity of the main receive loop.
   // Typically, incoming data between polls will be in much smaller sized blocks.

--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -2,21 +2,22 @@
 #include <nltools/threading/Threading.h>
 #include <nltools/messaging/Message.h>
 #include <nltools/logging/Log.h>
+#include <nltools/ExceptionTools.h>
 
 IO::IO(snd_rawmidi_t *handle)
-    : handle(handle)
+    : m_handle(handle)
 {
 }
 
 IO::IO(IO &&i)
-    : handle(std::exchange(i.handle, nullptr))
+    : m_handle(std::exchange(i.m_handle, nullptr))
 {
 }
 
 IO::~IO()
 {
-  if(handle)
-    snd_rawmidi_close(handle);
+  if(m_handle)
+    snd_rawmidi_close(m_handle);
 }
 
 Input::Input(Input &&i)
@@ -40,6 +41,32 @@ Input::~Input()
   m_bg.wait();
 }
 
+struct MidiEventCodecs
+{
+  MidiEventCodecs(unsigned encoderSize, unsigned decoderSize)
+  {
+    snd_midi_event_new(encoderSize, &encoder);
+    snd_midi_event_new(decoderSize, &decoder);
+
+    if(encoder == nullptr || decoder == nullptr)
+      nltools::Log::throwException("Could not set up midi parser buffers");
+
+    snd_midi_event_no_status(decoder, 1);  // force full-qualified midi events (no "running status")
+  }
+
+  ~MidiEventCodecs()
+  {
+    if(encoder)
+      snd_midi_event_free(encoder);
+
+    if(decoder)
+      snd_midi_event_free(decoder);
+  }
+
+  snd_midi_event_t *encoder = nullptr;
+  snd_midi_event_t *decoder = nullptr;
+};
+
 void Input::readMidi()
 {
   using namespace nltools::msg;
@@ -54,124 +81,114 @@ void Input::readMidi()
   // Typically, incoming data between polls will be in much smaller sized blocks.
   constexpr unsigned LOCAL_BUF_SIZE = 1024;  // non-critical value
 
-  // Parser sizes
-  constexpr unsigned ENCODER_SIZE = LOCAL_BUF_SIZE;  // byte stream --> midi events
-  constexpr unsigned DECODER_SIZE = 128;             // midi event --> bytes
-
-  uint8_t *buffer = new uint8_t[LOCAL_BUF_SIZE];
-  snd_midi_event_t *encoder = nullptr;
-  snd_midi_event_t *decoder = nullptr;
+  uint8_t buffer[LOCAL_BUF_SIZE];
   size_t bufferReserve = RAWMIDI_BUF_SIZE;
 
-  int numPollFDs = snd_rawmidi_poll_descriptors_count(handle);
+  int numPollFDs = snd_rawmidi_poll_descriptors_count(m_handle);
   pollfd pollFileDescriptors[numPollFDs + 1];
-  numPollFDs = snd_rawmidi_poll_descriptors(handle, pollFileDescriptors, numPollFDs);
+  numPollFDs = snd_rawmidi_poll_descriptors(m_handle, pollFileDescriptors, numPollFDs);
   pollFileDescriptors[numPollFDs].fd = m_cancelPipe[0];
   pollFileDescriptors[numPollFDs].events = POLLIN;
 
-  snd_rawmidi_nonblock(handle, 1);  // make reads non-blocking
+  if(!setupDevice(RAWMIDI_BUF_SIZE))
+    nltools::Log::throwException("Could not set up midi receive buffer");
 
-  snd_rawmidi_params_t *pParams;
-  snd_rawmidi_params_alloca(&pParams);
-  snd_rawmidi_params_current(handle, pParams);
-  snd_rawmidi_params_set_buffer_size(handle, pParams, RAWMIDI_BUF_SIZE);
-  snd_rawmidi_params(handle, pParams);
-  snd_rawmidi_params_current(handle, pParams);
-  if(snd_rawmidi_params_get_buffer_size(pParams) != RAWMIDI_BUF_SIZE)
-  {
-    nltools::Log::error("Could not set up midi receive buffer");
-    goto _Exit;
-  }
-
-  // Parsers to encode/decode byte stream <--> midi event
-  // These parsers run asynchronous to the main buffer data chunks --> must be global
-  snd_midi_event_new(ENCODER_SIZE, &encoder);
-  snd_midi_event_new(DECODER_SIZE, &decoder);
-  if(encoder == nullptr || decoder == nullptr)
-  {
-    nltools::Log::error("Could not set up midi parser buffers");
-    goto _Exit;
-  }
-
-  snd_midi_event_no_status(decoder, 1);  // force full-qualified midi events (no "running status")
-
-  snd_seq_event_t event;
   snd_rawmidi_status_t *pStatus;
   snd_rawmidi_status_alloca(&pStatus);
 
+  MidiEventCodecs codecs(LOCAL_BUF_SIZE, 128);
+
   while(!m_quit)
   {
-    auto result = snd_rawmidi_status(handle, pStatus);
-    if(result != 0)
-    {  // unplugging event, typically
-    _StreamError:
-      nltools::Log::error("Could read data/status from midi input file descriptor =>", snd_strerror(result));
-      goto _Exit;
-    }
+    if(auto result = snd_rawmidi_status(m_handle, pStatus))
+      nltools::Log::throwException("Could read data/status from midi input file descriptor =>", snd_strerror(result));
 
     if(snd_rawmidi_status_get_xruns(pStatus) > 0)
     {
-      nltools::Log::error("raw_midi receive buffer overrun");
-      snd_midi_event_reset_decode(decoder);  // purge any half-decoded events
+      nltools::Log::warning("raw_midi receive buffer overrun");
+      snd_midi_event_reset_decode(codecs.decoder);  // purge any half-decoded events
     }
 
-    auto currentBufferReserve = RAWMIDI_BUF_SIZE - snd_rawmidi_status_get_avail(pStatus);
-    if(currentBufferReserve < bufferReserve)
+    bufferReserve = logReserve(pStatus, RAWMIDI_BUF_SIZE, bufferReserve);
+
+    if(auto result = fetchChunk(buffer, LOCAL_BUF_SIZE, numPollFDs, pollFileDescriptors))
+      processChunk(buffer, result, codecs.encoder, codecs.decoder);
+  }
+}
+
+size_t Input::logReserve(snd_rawmidi_status_t *pStatus, size_t bufferSize, size_t oldReserve) const
+{
+  auto currentBufferReserve = bufferSize - snd_rawmidi_status_get_avail(pStatus);
+  if(currentBufferReserve < oldReserve)
+  {
+    nltools::Log::info("raw_midi receive buffer headroom : ", currentBufferReserve);
+    return currentBufferReserve;
+  }
+  return oldReserve;
+}
+
+size_t Input::fetchChunk(uint8_t *buffer, size_t length, int numPollFDs, pollfd *pollFileDescriptors)
+{
+  auto result = snd_rawmidi_read(m_handle, buffer, length);
+  if(result == -EAGAIN)  // nothing remaining or no data
+  {
+    // now sleep until data is coming in ...
+    if(poll(pollFileDescriptors, numPollFDs + 1, -1) > 0)
+      return 0;
+
+    nltools::Log::throwException("Polling the midi input file descriptor failed.");
+  }
+
+  if(result < 0)  // catch errors
+    nltools::Log::throwException("Error reading midi: ", snd_strerror(result));
+
+  return result;
+}
+
+void Input::processChunk(uint8_t *buffer, size_t length, snd_midi_event_t *encoder, snd_midi_event_t *decoder)
+{
+  using namespace nltools::msg;
+
+  snd_seq_event_t event;
+
+  while(length > 0)
+  {
+    auto consumed = snd_midi_event_encode(encoder, buffer, length, &event);
+
+    if(consumed <= 0)
     {
-      bufferReserve = currentBufferReserve;
-      nltools::Log::info("raw_midi receive buffer headroom : ", bufferReserve);
+      nltools::Log::error("Could not encode stream into midi event =>", snd_strerror(consumed));
+      snd_midi_event_reset_encode(encoder);
+      return;
     }
 
-    // try fetch a block of bytes, non-blocking
-    result = snd_rawmidi_read(handle, buffer, LOCAL_BUF_SIZE);
-    if(result == -EAGAIN)  // nothing remaining or no data
+    length -= consumed;
+    buffer += consumed;
+
+    // TODO : Bundle available messages into one packet for less IP overhead ?
+    if(event.type < SND_SEQ_EVENT_SONGPOS)
     {
-      // now sleep until data is coming in ...
-      if(poll(pollFileDescriptors, numPollFDs + 1, -1) > 0)
-        continue;  // ... have new data, go read it
-
-      nltools::Log::error("Polling the midi input file descriptor failed.");
-      goto _Exit;
+      // event is complete *and* is relevant for us --> reconvert event to 1..3 bytes raw data
+      snd_midi_event_reset_decode(decoder);
+      Midi::SimpleMessage msg;
+      msg.numBytesUsed = std::min(3l, snd_midi_event_decode(decoder, msg.rawBytes.data(), 3, &event));
+      send(EndPoint::ExternalMidiOverIPClient, msg);
     }
+  }
+}
 
-    if(result < 0)  // catch errors
-      goto _StreamError;
+bool Input::setupDevice(size_t bufferSize)
+{
+  snd_rawmidi_nonblock(m_handle, 1);  // make reads non-blocking
 
-    auto remaining = result;      // # of bytes
-    auto currentBuffer = buffer;  // position in buffer
+  snd_rawmidi_params_t *pParams;
+  snd_rawmidi_params_alloca(&pParams);
+  snd_rawmidi_params_current(m_handle, pParams);
+  snd_rawmidi_params_set_buffer_size(m_handle, pParams, bufferSize);
+  snd_rawmidi_params(m_handle, pParams);
+  snd_rawmidi_params_current(m_handle, pParams);
 
-    // process fetched chunk of bytes
-    while(remaining > 0)
-    {
-      auto consumed = snd_midi_event_encode(encoder, currentBuffer, remaining, &event);
-      if(consumed <= 0)
-      {
-        nltools::Log::error("Could not encode stream into midi event =>", snd_strerror(consumed));
-        snd_midi_event_reset_encode(encoder);
-        break;  // discard and continue reading
-      }
-
-      remaining -= consumed;
-      currentBuffer += consumed;
-
-      // TODO : Bundle available messages into one packet for less IP overhead ?
-      if(event.type < SND_SEQ_EVENT_SONGPOS)
-      {  // event is complete *and* is relevant for us --> reconvert event to 1..3 bytes raw data
-        snd_midi_event_reset_decode(decoder);
-        Midi::SimpleMessage msg;
-        msg.numBytesUsed = std::min(3l, snd_midi_event_decode(decoder, msg.rawBytes.data(), 3, &event));
-        send(EndPoint::ExternalMidiOverIPClient, msg);
-      }
-    }
-  }  // while(!m_quit)
-
-_Exit:
-  if(encoder)
-    snd_midi_event_free(encoder);
-  if(decoder)
-    snd_midi_event_free(decoder);
-  delete[] buffer;
-  m_quit = true;
+  return snd_rawmidi_params_get_buffer_size(pParams) == bufferSize;
 }
 
 snd_rawmidi_t *Input::open(const std::string &name)
@@ -193,12 +210,12 @@ Output::Output(const std::string &name)
 
 void Output::send(const nltools::msg::Midi::SimpleMessage &msg)
 {
-  if(auto res = snd_rawmidi_write(handle, msg.rawBytes.data(), msg.numBytesUsed))
+  if(auto res = snd_rawmidi_write(m_handle, msg.rawBytes.data(), msg.numBytesUsed))
   {
     if(size_t(res) != msg.numBytesUsed)
       nltools::Log::error("Could not write message into midi output device");
     else
-      snd_rawmidi_drain(handle);
+      snd_rawmidi_drain(m_handle);
   }
 }
 

--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -89,7 +89,7 @@ void Input::readMidi()
     if(readResult < 0)
     {
       nltools::Log::error("Could not read from midi input file descriptor =>", snd_strerror(readResult));
-      break;
+      break;  // quit (unplugging event, typically)
     }
 
     auto remaining = readResult;  // # of bytes

--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -101,7 +101,8 @@ void Input::readMidi()
       if(consumed <= 0)
       {
         nltools::Log::error("Could not encode stream into midi event =>", snd_strerror(consumed));
-        break;
+        snd_midi_event_reset_encode(encoder);
+        break;  // discard and continue reading
       }
 
       remaining -= consumed;

--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -42,7 +42,7 @@ Input::~Input()
 
 void Input::readMidi()
 {
-// for unknown reason not checking xruns works better (less artifacts, less crashes/stalls)
+// check raw_midi buffer overruns
 #define CHECK_XRUNS (1)
 
 // TODO : test throttling until bbb_lpc_driver stops to moan

--- a/projects/bbb/midi-over-ip/src/IO.h
+++ b/projects/bbb/midi-over-ip/src/IO.h
@@ -22,7 +22,7 @@ class IO
   IO(IO &&i);
   ~IO();
 
-  snd_rawmidi_t *handle = nullptr;
+  snd_rawmidi_t *m_handle = nullptr;
 };
 
 class Input : public IO
@@ -32,9 +32,16 @@ class Input : public IO
   Input(const std::string &name);
   ~Input();
 
+  void fetchChunk();
+
  private:
   static snd_rawmidi_t *open(const std::string &name);
+
   void readMidi();
+  bool setupDevice(size_t bufferSize);
+  size_t fetchChunk(uint8_t *buffer, size_t length, int numPollFDs, pollfd *pollFileDescriptors);
+  void processChunk(uint8_t *buffer, size_t length, snd_midi_event_t *encoder, snd_midi_event_t *decoder);
+  size_t logReserve(snd_rawmidi_status_t *pStatus, size_t bufferSize, size_t oldReserve) const;
 
   std::future<void> m_bg;
   bool m_quit = false;

--- a/projects/bbb/midi-over-ip/systemd/midi-over-ip.service.in
+++ b/projects/bbb/midi-over-ip/systemd/midi-over-ip.service.in
@@ -1,8 +1,11 @@
 [Unit]
 Description=Nonlinear-Labs Midi Bridge
+After=syslog.target network.target systemd-modules-load.service chkphy.service install-update-from-usb.service
 
 [Service]
 ExecStart=@C15_INSTALL_PATH@/midi-over-ip/midi-over-ip -a 192.168.10.10
+Restart=on-failure
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/projects/shared/nltools/include/nltools/logging/Log.h
+++ b/projects/shared/nltools/include/nltools/logging/Log.h
@@ -92,6 +92,7 @@ namespace nltools
     template <typename... tArgs> static void throwException(const tArgs &... args)
     {
       auto str = nltools::string::concat(args...);
+      error(str);
       throw std::runtime_error(str);
     }
 


### PR DESCRIPTION
fixes #2462

- Increased size of raw_midi receive buffer, buffer overflows are handled and reported, as is buffer headroom.
- Restructured receive loop. Input is now processed in blocks, not single bytes at a time. This applies both to primary (byte stream) and secondary (midi event) buffers, the latter being asynchronous with the main buffer filling loop.
- fixed memory leaks from allocating new parsers all the time, it seems ;-)

---

The reason why the previous code broke with large sysex is that it did not always consume *all* bytes in raw_midi's "I/O-ringbuffer" before the next poll() was issued. By this, raw_midi's buffer had to overflow.

---

Seems to work pretty OK by now.
Even when continuously blasted with lots of data (256kB of SysEx at a fast repeat rate while sending 20 noteon/noteoff every 50ms) very low rates of buffer xruns (very few) and crashes (none) are seen so far.

#### remaining issue:
Occasionally the bbb_lpc_driver detects going about to loose connection to the LPC (but recovers) during heavy MIDI traffic. This even happens when received data is directly thrown away, no event encoding etc. 
It happens way more often when the BBB is on the HS side.
**==> connecting the  C15 on the FS side of the bridge is probably the better choice in general.**
Symptom: Under extremely heavy MIDI traffic conditions the BBB might might occasionally miss hardware source changes sent by the playcontroller, for display. It remains to be seen if this would ever be a problem in the real world.

`top` says CPU goes up significantly (80%++) but recovers instantly when the burst is over. No effect on normal MIDI transfer was noticed but that sure needs thorough testing. UI (Ribbon LED display tracking, etc) naturally slows down, of course.

----

Note: This fix should also be implemented in the future for the MIDI receive code in the AE (collecting playcontroller data, this time), where I had similar problems in test trials for larger SysEx data exchange...

ToDo :
- [ ] TESTING: fully validate performance for "normal" traffic with the various use scenarios (hot-plugging, multiple devices, etc)
