### PR TITLE
If there is no utf-8 enabled locale installed to

### DIFF
--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -18,6 +18,10 @@ setup_overlay() {
 install_packages() {
     pacman --noconfirm -S $UPDATE_PACKAGES
     pacstrap -c /overlay-fs $UPDATE_PACKAGES
+    
+    echo "en_US.UTF-8 UTF-8" > /overlay-fs/etc/locale.gen
+    /bin/arch-chroot /overlay-fs locale-gen
+
 }
 
 build_binaries() {


### PR DESCRIPTION
the system, conversions from Glib::ustrings containing
multi-byte utf-8 characters (like our MacroControl names)
to std::strings will throw.