### PR TITLE
Enable Wifi on ePC2

### DIFF
--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -24,42 +24,42 @@ install_packages() {
 }
 
 setup_wifi() {
-    (
-    cat <<-'ENDOFHERE'
-[connection]
-id=C15
-uuid=61679179-6804-4197-b476-eacad1d492e4
-type=wifi
-interface-name=wlp0s20f3
-permissions=
 
-[wifi]
-band=bg
-channel=7
-mac-address-blacklist=
-mode=ap
-ssid=NL-C15-Unit-EPC-00001
+    cat <<- ENDOFHERE > /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
+    [connection]
+    id=C15
+    uuid=61679179-6804-4197-b476-eacad1d492e4
+    type=wifi
+    interface-name=wlp0s20f3
+    permissions=
 
-[wifi-security]
-key-mgmt=wpa-psk
-pairwise=ccmp;
-proto=rsn;
-psk=88888888
+    [wifi]
+    band=bg
+    channel=7
+    mac-address-blacklist=
+    mode=ap
+    ssid=NL-C15-Unit-EPC-00001
 
-[ipv4]
-address1=192.168.100.101/24,192.168.100.1
-dns-search=
-method=shared
+    [wifi-security]
+    key-mgmt=wpa-psk
+    pairwise=ccmp;
+    proto=rsn;
+    psk=88888888
 
-[ipv6]
-addr-gen-mode=stable-privacy
-dns-search=
-method=auto
+    [ipv4]
+    address1=192.168.100.101/24,192.168.100.1
+    dns-search=
+    method=shared
 
-[proxy]
+    [ipv6]
+    addr-gen-mode=stable-privacy
+    dns-search=
+    method=auto
+
+    [proxy]
 ENDOFHERE
-    ) > /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
 
+    bash
     /bin/arch-chroot /overlay-fs chmod 600 /etc/NetworkManager/system-connections/C15.nmconnection
     /bin/arch-chroot /overlay-fs systemctl enable NetworkManager
 }

--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -20,6 +20,47 @@ install_packages() {
     pacstrap -c /overlay-fs $UPDATE_PACKAGES
 }
 
+setup_wifi() {
+    (
+    cat <<-ENDOFHERE
+        [connection]
+        id=C15
+        uuid=61679179-6804-4197-b476-eacad1d492e4
+        type=wifi
+        interface-name=wlp0s20f3
+        permissions=
+    
+        [wifi]
+        band=bg
+        channel=7
+        mac-address-blacklist=
+        mode=ap
+        ssid=Unit-C15-99999
+
+        [wifi-security]
+        key-mgmt=wpa-psk
+        pairwise=ccmp;
+        proto=rsn;  
+        psk=88888888
+
+        [ipv4]
+        address1=192.168.100.101/24,192.168.100.1
+        dns-search=
+        method=shared
+
+        [ipv6]
+        addr-gen-mode=stable-privacy
+        dns-search=
+        method=auto
+
+        [proxy]
+    ENDOFHERE
+    ) > /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
+    
+    arch-chroot /mnt /bin/bash -c "systemctl enable NetworkManager"    
+    arch-chroot /mnt /bin/bash -c "systemctl start NetworkManager"
+}
+
 build_binaries() {
     DESTDIR=/overlay-fs cmake -DCMAKE_BUILD_TYPE=Release ${BUILD_SWITCHES} -S /source -B /build
     make -j8 -C /build
@@ -35,5 +76,6 @@ create_update() {
 
 setup_overlay
 install_packages
+setup_wifi
 build_binaries
 create_update

--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -24,7 +24,6 @@ install_packages() {
 }
 
 setup_wifi() {
-    touch /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
     (
     cat <<-'ENDOFHERE'
 [connection]
@@ -39,7 +38,7 @@ band=bg
 channel=7
 mac-address-blacklist=
 mode=ap
-ssid=Unit-C15-99999
+ssid=NL-C15-Unit-EPC-00001
 
 [wifi-security]
 key-mgmt=wpa-psk
@@ -60,9 +59,9 @@ method=auto
 [proxy]
 ENDOFHERE
     ) > /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
-    
-    /bin/arch-chroot /overlay-fs sudo systemctl enable NetworkManager
-#    /bin/arch-chroot /overlay-fs systemctl start NetworkManager
+
+    /bin/arch-chroot /overlay-fs chmod 600 /etc/NetworkManager/system-connections/C15.nmconnection
+    /bin/arch-chroot /overlay-fs systemctl enable NetworkManager
 }
 
 build_binaries() {

--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -59,7 +59,6 @@ setup_wifi() {
     [proxy]
 ENDOFHERE
 
-    bash
     /bin/arch-chroot /overlay-fs chmod 600 /etc/NetworkManager/system-connections/C15.nmconnection
     /bin/arch-chroot /overlay-fs systemctl enable NetworkManager
 }

--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -21,48 +21,48 @@ install_packages() {
     
     echo "en_US.UTF-8 UTF-8" > /overlay-fs/etc/locale.gen
     /bin/arch-chroot /overlay-fs locale-gen
-
 }
 
 setup_wifi() {
+    touch /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
     (
-    cat <<'ENDOFHERE'
-        [connection]
-        id=C15
-        uuid=61679179-6804-4197-b476-eacad1d492e4
-        type=wifi
-        interface-name=wlp0s20f3
-        permissions=
-    
-        [wifi]
-        band=bg
-        channel=7
-        mac-address-blacklist=
-        mode=ap
-        ssid=Unit-C15-99999
+    cat <<-'ENDOFHERE'
+[connection]
+id=C15
+uuid=61679179-6804-4197-b476-eacad1d492e4
+type=wifi
+interface-name=wlp0s20f3
+permissions=
 
-        [wifi-security]
-        key-mgmt=wpa-psk
-        pairwise=ccmp;
-        proto=rsn;  
-        psk=88888888
+[wifi]
+band=bg
+channel=7
+mac-address-blacklist=
+mode=ap
+ssid=Unit-C15-99999
 
-        [ipv4]
-        address1=192.168.100.101/24,192.168.100.1
-        dns-search=
-        method=shared
+[wifi-security]
+key-mgmt=wpa-psk
+pairwise=ccmp;
+proto=rsn;
+psk=88888888
 
-        [ipv6]
-        addr-gen-mode=stable-privacy
-        dns-search=
-        method=auto
+[ipv4]
+address1=192.168.100.101/24,192.168.100.1
+dns-search=
+method=shared
 
-        [proxy]
-    ENDOFHERE
+[ipv6]
+addr-gen-mode=stable-privacy
+dns-search=
+method=auto
+
+[proxy]
+ENDOFHERE
     ) > /overlay-fs/etc/NetworkManager/system-connections/C15.nmconnection
     
-    arch-chroot /mnt /bin/bash -c "systemctl enable NetworkManager"    
-    arch-chroot /mnt /bin/bash -c "systemctl start NetworkManager"
+    /bin/arch-chroot /overlay-fs sudo systemctl enable NetworkManager
+#    /bin/arch-chroot /overlay-fs systemctl start NetworkManager
 }
 
 build_binaries() {

--- a/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
+++ b/build-tools/epc2/create-update/createEPC2UpdateDockerCommands.sh
@@ -22,7 +22,7 @@ install_packages() {
 
 setup_wifi() {
     (
-    cat <<-ENDOFHERE
+    cat <<'ENDOFHERE'
         [connection]
         id=C15
         uuid=61679179-6804-4197-b476-eacad1d492e4


### PR DESCRIPTION
This deploys a config file for the Networkmanager to read from and enables the latter. For now the SSID is fixed and cannot be changed. It is enough to start testing the functionality though.