### PR TITLE
include acceptance tests again, 

### DIFF
--- a/projects/epc/CMakeLists.txt
+++ b/projects/epc/CMakeLists.txt
@@ -7,29 +7,28 @@ OPTION(BUILD_EPC_SCRIPTS "Install the shell scripts on the ePC" Off)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wdouble-promotion -march=native")
 
-IF(BUILD_ACCEPTANCE_TESTS)
-  message ("FIX THIS!")
-    #add_subdirectory(acceptance-tests)
-ENDIF()
+IF (BUILD_ACCEPTANCE_TESTS)
+    add_subdirectory(acceptance-tests)
+ENDIF ()
 
-IF(BUILD_AUDIOENGINE)
+IF (BUILD_AUDIOENGINE)
     add_subdirectory(audio-engine)
-ENDIF()
+ENDIF ()
 
-IF(BUILD_ONLINEHELP)
+IF (BUILD_ONLINEHELP)
     add_subdirectory(online-help)
-ENDIF()
+ENDIF ()
 
-IF(BUILD_PLAYGROUND)
+IF (BUILD_PLAYGROUND)
     add_subdirectory(playground)
-ENDIF()
+ENDIF ()
 
-IF(BUILD_WEBUI)
+IF (BUILD_WEBUI)
     add_subdirectory(web-ui)
-ENDIF()
+ENDIF ()
 
-IF(BUILD_EPC_SCRIPTS)
+IF (BUILD_EPC_SCRIPTS)
     add_subdirectory(scripts)
-ENDIF()
+ENDIF ()
 
 add_subdirectory(third-party)

--- a/projects/epc/acceptance-tests/src/Midi.cpp
+++ b/projects/epc/acceptance-tests/src/Midi.cpp
@@ -82,7 +82,7 @@ namespace Tests
     // no error for three seconds = success
     playgroundApp.getMainContext()->signal_timeout().connect_seconds(
         [&] {
-          REQUIRE(selectionCount == 1);
+          CHECK(selectionCount == 1);
           playgroundApp.quit();
           return false;
         },

--- a/projects/epc/playground/src/testing/unit-tests/EditBufferTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/EditBufferTests.cpp
@@ -28,16 +28,16 @@ template <SoundType tNewSoundType> void loadPreset(Preset *newPreset)
   editBuffer->undoableLoad(scope->getTransaction(), newPreset, true);
   editBuffer->TEST_doDeferredJobs();
 
-  REQUIRE(editBuffer->getType() == tNewSoundType);
-  REQUIRE_FALSE(editBuffer->isModified());
-  REQUIRE_FALSE(editBuffer->findAnyParameterChanged());
-  REQUIRE(editBuffer->getUUIDOfLastLoadedPreset() == newPreset->getUuid());
+  CHECK(editBuffer->getType() == tNewSoundType);
+  CHECK_FALSE(editBuffer->isModified());
+  CHECK_FALSE(editBuffer->findAnyParameterChanged());
+  CHECK(editBuffer->getUUIDOfLastLoadedPreset() == newPreset->getUuid());
 }
 
 TEST_CASE("EditBuffer Initialized")
 {
   auto eb = getEditBuffer();
-  REQUIRE(eb != nullptr);
+  CHECK(eb != nullptr);
 }
 
 TEST_CASE("Simple EditBuffer Conversion")
@@ -53,9 +53,9 @@ TEST_CASE("Simple EditBuffer Conversion")
     editBuffer->undoableConvertToDual(scope->getTransaction(), SoundType::Layer);
     editBuffer->TEST_doDeferredJobs();
 
-    REQUIRE(editBuffer->getType() == SoundType::Layer);
-    REQUIRE(editBuffer->isModified());
-    REQUIRE_FALSE(editBuffer->findAnyParameterChanged());
+    CHECK(editBuffer->getType() == SoundType::Layer);
+    CHECK(editBuffer->isModified());
+    CHECK_FALSE(editBuffer->findAnyParameterChanged());
   }
 
   SECTION("Convert Single to Split Sound")
@@ -64,12 +64,12 @@ TEST_CASE("Simple EditBuffer Conversion")
     editBuffer->undoableConvertToDual(scope->getTransaction(), SoundType::Split);
     editBuffer->TEST_doDeferredJobs();
 
-    REQUIRE(editBuffer->getType() == SoundType::Split);
-    REQUIRE(editBuffer->isModified());
-    REQUIRE_FALSE(editBuffer->findAnyParameterChanged());
+    CHECK(editBuffer->getType() == SoundType::Split);
+    CHECK(editBuffer->isModified());
+    CHECK_FALSE(editBuffer->findAnyParameterChanged());
 
-    REQUIRE(editBuffer->findParameterByID({ 249, VoiceGroup::I })->getValue().getFineDenominator() == 11);
-    REQUIRE(editBuffer->findParameterByID({ 249, VoiceGroup::II })->getValue().getFineDenominator() == 11);
+    CHECK(editBuffer->findParameterByID({ 249, VoiceGroup::I })->getValue().getFineDenominator() == 11);
+    CHECK(editBuffer->findParameterByID({ 249, VoiceGroup::II })->getValue().getFineDenominator() == 11);
   }
 
   SECTION("Undo Convert Single to Split")
@@ -80,11 +80,11 @@ TEST_CASE("Simple EditBuffer Conversion")
       editBuffer->TEST_doDeferredJobs();
     }
 
-    REQUIRE(editBuffer->isModified());
-    REQUIRE_FALSE(editBuffer->findAnyParameterChanged());
-    REQUIRE(editBuffer->getType() == SoundType::Split);
-    REQUIRE(editBuffer->findParameterByID({ 249, VoiceGroup::I })->getValue().getFineDenominator() == 11);
-    REQUIRE(editBuffer->findParameterByID({ 249, VoiceGroup::II })->getValue().getFineDenominator() == 11);
+    CHECK(editBuffer->isModified());
+    CHECK_FALSE(editBuffer->findAnyParameterChanged());
+    CHECK(editBuffer->getType() == SoundType::Split);
+    CHECK(editBuffer->findParameterByID({ 249, VoiceGroup::I })->getValue().getFineDenominator() == 11);
+    CHECK(editBuffer->findParameterByID({ 249, VoiceGroup::II })->getValue().getFineDenominator() == 11);
 
     editBuffer->getParent()->getUndoScope().undo();
     editBuffer->TEST_doDeferredJobs();

--- a/projects/epc/playground/src/testing/unit-tests/HWUI/RibbonTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/HWUI/RibbonTests.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
 
     THEN("ALL LEDs Off")
     {
-      r.forEachLED([](auto, const auto& led) { REQUIRE(led.getState() == 0); });
+      r.forEachLED([](auto, const auto& led) { CHECK(led.getState() == 0); });
     }
   }
 
@@ -58,7 +58,7 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
     r.setLEDsForValueUniPolar(1.0);
     THEN("ALL LEDs On")
     {
-      r.forEachLED([](auto, const auto& led) { REQUIRE(led.getState() == 3); });
+      r.forEachLED([](auto, const auto& led) { CHECK(led.getState() == 3); });
     }
   }
 
@@ -70,9 +70,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
       r.forEachLED([](auto index, const auto& led) {
         auto isLast = index != NUM_LEDS_PER_RIBBON - 1;
         if(isLast)
-          REQUIRE(led.getState() == 3);
+          CHECK(led.getState() == 3);
         else
-          REQUIRE(led.getState() < 3);
+          CHECK(led.getState() < 3);
       });
     }
   }
@@ -85,9 +85,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
       r.forEachLED([](auto index, const auto& led) {
         auto isFirst = index == 0;
         if(isFirst)
-          REQUIRE(led.getState() > 0);
+          CHECK(led.getState() > 0);
         else
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
       });
     }
   }
@@ -103,15 +103,15 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
 
         if(leftHalf)
         {
-          REQUIRE(led.getState() == 3);
+          CHECK(led.getState() == 3);
         }
         else if(rightHalf)
         {
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
         }
         else
         {
-          REQUIRE(led.getState() == 1);
+          CHECK(led.getState() == 1);
         }
       });
     }
@@ -124,9 +124,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
     {
       r.forEachLED([centerLED](auto index, const auto& led) {
         if(index == centerLED)
-          REQUIRE(led.getState() == 3);
+          CHECK(led.getState() == 3);
         else
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
       });
     }
   }
@@ -141,9 +141,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
         auto right = index > centerLED;
 
         if(left)
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
         else if(right || index == centerLED)
-          REQUIRE(led.getState() == 3);
+          CHECK(led.getState() == 3);
       });
     }
   }
@@ -158,9 +158,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
         auto right = index > centerLED;
 
         if(right)
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
         else if(left || index == centerLED)
-          REQUIRE(led.getState() == 3);
+          CHECK(led.getState() == 3);
       });
     }
   }
@@ -175,9 +175,9 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
         auto rightHalfOn = right && index <= (centerLED + (centerLED / 2));
 
         if(rightHalfOn || index == centerLED)
-          REQUIRE(led.getState() != 0);
+          CHECK(led.getState() != 0);
         else
-          REQUIRE(led.getState() == 0);
+          CHECK(led.getState() == 0);
       });
     }
   }
@@ -192,7 +192,7 @@ TEST_CASE("Upper Ribbon", "[HWUI][Ribbon]")
         auto leftHalfOn = left && index >= (centerLED / 2);
 
         if(leftHalfOn || index == centerLED)
-          REQUIRE(led.getState() != 0);
+          CHECK(led.getState() != 0);
         else
           REQUIRE(led.getState() == 0);
       });

--- a/projects/epc/playground/src/testing/unit-tests/HWUI/TextSplitterTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/HWUI/TextSplitterTests.cpp
@@ -6,17 +6,17 @@
 TEST_CASE("Text Splitter concat utf8", "[HWUI][Text]")
 {
   Glib::ustring in("\u24b6\u24b7\u24b8\u24b9");
-  REQUIRE(in.length() == 4);
+  CHECK(in.length() == 4);
   std::stringstream str;
   str << in;
   Glib::ustring out = str.str();
-  REQUIRE(out.length() == 4);
+  CHECK(out.length() == 4);
 }
 
 TEST_CASE("Text Splitter iterate utf8", "[HWUI][Text]")
 {
   Glib::ustring in("\u24b6\u24b7\u24b8\u24b9");
-  REQUIRE(in.length() == 4);
+  CHECK(in.length() == 4);
   std::stringstream str;
 
   for(auto it = in.begin(); it != in.end(); it++)
@@ -27,5 +27,5 @@ TEST_CASE("Text Splitter iterate utf8", "[HWUI][Text]")
   }
 
   Glib::ustring out = str.str();
-  REQUIRE(out.length() == 4);
+  CHECK(out.length() == 4);
 }

--- a/projects/epc/playground/src/testing/unit-tests/LPC/MessageParserTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/LPC/MessageParserTests.cpp
@@ -25,10 +25,10 @@ TEST_CASE("Message Parser")
         if(needed == 0)
         {
           const MessageParser::NLMessage &msg = foo.getMessage();
-          REQUIRE(msg.type == MessageParser::PRESET_DIRECT);
-          REQUIRE(msg.length == 2);
-          REQUIRE(msg.params[0] == 99);
-          REQUIRE(msg.params[1] == 77);
+          CHECK(msg.type == MessageParser::PRESET_DIRECT);
+          CHECK(msg.length == 2);
+          CHECK(msg.params[0] == 99);
+          CHECK(msg.params[1] == 77);
           break;
         }
 

--- a/projects/epc/playground/src/testing/unit-tests/async/SpawnAsyncCommandLineTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/async/SpawnAsyncCommandLineTests.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Async Command Line does not block")
   bool done = false;
   AsyncCommandLine cmd({ "sleep", "1" },
                        [&](auto o) {
-                         REQUIRE_FALSE(blocked);
+                         CHECK_FALSE(blocked);
                          done = true;
                        },
                        [](auto e) {});
@@ -24,7 +24,7 @@ TEST_CASE("Async Completion will mark job as done")
   auto done = false;
   SpawnAsyncCommandLine::spawn({ "sleep", "1" }, [&](auto) { done = true; }, [](auto) {});
   TestHelper::doMainLoop(std::chrono::milliseconds { 10 }, std::chrono::milliseconds { 2000 }, [&] { return done; });
-  REQUIRE(SpawnAsyncCommandLine::removeDone() > 0);
+  CHECK(SpawnAsyncCommandLine::removeDone() > 0);
 }
 
 TEST_CASE("Async Spawn increments job count")
@@ -37,7 +37,7 @@ TEST_CASE("Async Spawn increments job count")
   SpawnAsyncCommandLine::spawn({ "sleep", "1" }, [&](auto) { done = true; }, [](auto) {});
 
   auto newCount = SpawnAsyncCommandLine::getNumCommands();
-  REQUIRE(newCount > old);
+  CHECK(newCount > old);
 
   TestHelper::doMainLoop(std::chrono::milliseconds { 10 }, std::chrono::milliseconds { 2000 }, [&] { return done; });
 }

--- a/projects/epc/playground/src/testing/unit-tests/data/IntrusiveListTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/data/IntrusiveListTests.cpp
@@ -29,11 +29,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 4);
+    CHECK(expected == 4);
 
     expected = 0;
 
@@ -41,11 +41,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 4);
+    CHECK(expected == 4);
   }
 
   SECTION("Remove Middle")
@@ -61,11 +61,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 4);
+    CHECK(expected == 4);
 
     l.remove(one);
 
@@ -73,14 +73,14 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
 
       if(expected == 1)
         expected = 2;
     }
 
-    REQUIRE(expected == 4);
+    CHECK(expected == 4);
   }
 
   SECTION("Remove First")
@@ -98,11 +98,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 4);
+    CHECK(expected == 4);
   }
 
   SECTION("Remove Last")
@@ -119,11 +119,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 3);
+    CHECK(expected == 3);
   }
 
   SECTION("Clear") {
@@ -139,11 +139,11 @@ TEST_CASE("Simple IntrusiveList Operations")
 
     for(auto i : l)
     {
-      REQUIRE(i->data == expected);
+      CHECK(i->data == expected);
       expected++;
     }
 
-    REQUIRE(expected == 3);
+    CHECK(expected == 3);
     l.clear();
   }
 }

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
@@ -19,9 +19,9 @@ TEST_CASE("Load Part I of Split into Layer Part I")
   MockPresetStorage presets;
   auto preset = presets.getSplitPreset();
 
-  REQUIRE(preset->getType() == SoundType::Split);
+  CHECK(preset->getType() == SoundType::Split);
 
-  REQUIRE_NOTHROW(preset->findParameterByID({ C15::PID::Split_Split_Point, VoiceGroup::I }, true));
+  CHECK_NOTHROW(preset->findParameterByID({ C15::PID::Split_Split_Point, VoiceGroup::I }, true));
 
   {
     auto scope = TestHelper::createTestScope();
@@ -168,7 +168,7 @@ TEST_CASE("Load Part I of Split into Layer Part II")
   MockPresetStorage presets;
   auto preset = presets.getSplitPreset();
 
-  REQUIRE(preset->getType() == SoundType::Split);
+  CHECK(preset->getType() == SoundType::Split);
 
   {
     auto scope = TestHelper::createTestScope();

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Load Part I of Split into Split Part I")
   MockPresetStorage presets;
   auto preset = presets.getSplitPreset();
 
-  REQUIRE(preset->getType() == SoundType::Split);
+  CHECK(preset->getType() == SoundType::Split);
 
   {
     auto scope = TestHelper::createTestScope();
@@ -57,7 +57,7 @@ TEST_CASE("Load Part I of Split into Split Part I")
       }
       else
       {
-        REQUIRE(false);
+        CHECK(false);
       }
     }
 
@@ -181,7 +181,7 @@ TEST_CASE("Load Part I of Split into Split Part II")
   MockPresetStorage presets;
   auto preset = presets.getSplitPreset();
 
-  REQUIRE(preset->getType() == SoundType::Split);
+  CHECK(preset->getType() == SoundType::Split);
 
   {
     auto scope = TestHelper::createTestScope();
@@ -219,7 +219,7 @@ TEST_CASE("Load Part I of Split into Split Part II")
       }
       else
       {
-        REQUIRE(false);
+        CHECK(false);
       }
     }
 

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Load Single into Split Part I")
   MockPresetStorage presets;
   auto preset = presets.getSinglePreset();
 
-  REQUIRE(preset->getType() == SoundType::Single);
+  CHECK(preset->getType() == SoundType::Single);
 
   {
     auto scope = TestHelper::createTestScope();
@@ -170,7 +170,7 @@ TEST_CASE("Load Single into Split Part II")
   MockPresetStorage presets;
   auto preset = presets.getSinglePreset();
 
-  REQUIRE(preset->getType() == SoundType::Single);
+  CHECK(preset->getType() == SoundType::Single);
 
   {
     auto scope = TestHelper::createTestScope();

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/OverwritePreset.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/OverwritePreset.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Override Single Preset With new!", "[Preset][Store]")
     TestHelper::initSingleEditBuffer(scope->getTransaction());
     eb->setName(scope->getTransaction(), "Name");
     toOverwrite->copyFrom(scope->getTransaction(), eb);
-    REQUIRE(toOverwrite->getName() == "Name");
+    CHECK(toOverwrite->getName() == "Name");
   }
 }
 
@@ -33,8 +33,8 @@ TEST_CASE("Override Dual Preset With new!", "[Preset][Store]")
 
     toOverwrite->copyFrom(scope->getTransaction(), eb);
 
-    REQUIRE(toOverwrite->getVoiceGroupName(VoiceGroup::I) == "1");
-    REQUIRE(toOverwrite->getVoiceGroupName(VoiceGroup::II) == "2");
-    REQUIRE(toOverwrite->getName() == "Name");
+    CHECK(toOverwrite->getVoiceGroupName(VoiceGroup::I) == "1");
+    CHECK(toOverwrite->getVoiceGroupName(VoiceGroup::II) == "2");
+    CHECK(toOverwrite->getName() == "Name");
   }
 }

--- a/projects/epc/playground/src/testing/unit-tests/parameters/LoadSinglePresetWithoutMcEandFResetsMcEAndFTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/parameters/LoadSinglePresetWithoutMcEandFResetsMcEAndFTests.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Load Single Preset Without MacroControl E and F defaults MC E and F")
   THEN("Loading old Preset resets non existing parameters")
   {
     eb->undoableLoad(scope->getTransaction(), mockPreset.get(), true);
-    REQUIRE(mcE->getGivenName() == "");
+    CHECK(mcE->getGivenName() == "");
     REQUIRE(mcF->getGivenName() == "");
     REQUIRE(partTune->getModulationSource() == MacroControls::NONE);
     REQUIRE(partVolume->getModulationSource() == MacroControls::NONE);

--- a/projects/epc/playground/src/testing/unit-tests/parameters/MonoParameterTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/parameters/MonoParameterTests.cpp
@@ -12,12 +12,12 @@ TEST_CASE("Mono Parameter Helper")
     {
       for(auto& p : g->getParameters())
       {
-        REQUIRE(MonoGroup::isMonoParameter(p));
+        CHECK(MonoGroup::isMonoParameter(p));
       }
     }
     else
     {
-      REQUIRE(false);
+      CHECK(false);
     }
   }
 }

--- a/projects/epc/playground/src/testing/unit-tests/parameters/ParameterInvariantTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/parameters/ParameterInvariantTests.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Parameter Dual/Global affiliation - Single-Sound")
 {
   TestHelper::forEachParameter(
       [](const Parameter* parameter) {
-        REQUIRE_FALSE(EditBuffer::isDualParameterForSoundType(parameter, SoundType::Single));
+        CHECK_FALSE(EditBuffer::isDualParameterForSoundType(parameter, SoundType::Single));
       },
       TestHelper::getEditBuffer());
 }
@@ -36,9 +36,9 @@ TEST_CASE("Parameter Dual/Global affiliation - Split Sound")
         auto ret = EditBuffer::isDualParameterForSoundType(parameter, SoundType::Split);
 
         if(GroupAffiliation::isRealGlobal(parameter))
-          REQUIRE_FALSE(ret);
+          CHECK_FALSE(ret);
         else
-          REQUIRE(ret);
+          CHECK(ret);
       },
       TestHelper::getEditBuffer());
 }
@@ -51,21 +51,21 @@ TEST_CASE("Parameter Dual/Global affiliation - Layer Sound")
 
         if(GroupAffiliation::isRealGlobal(parameter))
         {
-          REQUIRE_FALSE(isDual);
+          CHECK_FALSE(isDual);
         }
         else
         {
           if(MonoGroup::isMonoParameter(parameter))
           {
-            REQUIRE_FALSE(isDual);
+            CHECK_FALSE(isDual);
           }
           else if(UnisonGroup::isUnisonParameter(parameter))
           {
-            REQUIRE_FALSE(isDual);
+            CHECK_FALSE(isDual);
           }
           else
           {
-            REQUIRE(isDual);
+            CHECK(isDual);
           }
         }
       },

--- a/projects/epc/playground/src/testing/unit-tests/parameters/ParameterNameSaneTest.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/parameters/ParameterNameSaneTest.cpp
@@ -9,7 +9,7 @@ TEST_CASE("No Parameter Name Contains '@VG' placeholder")
     for(auto& g : TestHelper::getEditBuffer()->getParameterGroups(vg))
       for(auto& p : g->getParameters())
       {
-        REQUIRE(p->getLongName().find("@VG") == std::string::npos);
-        REQUIRE(p->getShortName().find("@VG") == std::string::npos);
+        CHECK(p->getLongName().find("@VG") == std::string::npos);
+        CHECK(p->getShortName().find("@VG") == std::string::npos);
       }
 }


### PR DESCRIPTION
and replace all REQUIRE occurrences with CHECK inside test cases.
As a failing REQUIRE assertion quits the whole test-application, CHECK will log the failure and continue