### PR TITLE
fixup recall voice alloc reset

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -526,6 +526,8 @@ class VoiceAllocation
         break;
       case LayerMode::Split:
         clear_keyState(m_layerId[_layer]);
+        if(newMode != oldMode)
+          clear_keyState(m_layerId[1 - _layer]);
         break;
       case LayerMode::Layer:
         clear_keyState(AllocatorId::Dual);


### PR DESCRIPTION
fixes #2565 

The Bug fixed here has some specific circumstances that have to be met in order to observe it:
- Key Event Input needs to be "Singular" _(meaning the C15 Keybed or MIDI Receive with Secondary = "Common")_
- loaded Preset needs to be a Split Sound with monophonic Part II (bug not observable otherwise)
- before loading next Preset, press and hold a few keys in Part II
- while holding Keys, load polyphonic Layer or Single preset (bug observed with both), notes will disapper
- after loading, release held Keys and then play again (sometimes, just one voice will work, sometimes just two voices work - giving an overall monophonic impression)

The Voice Allocation did not correctly clear Keys associated with Part II (in the former Split Sound), so they still were considered "pressed" after loading another Preset), leading to confusion in the Key Association process.