### PR TITLE
Fix 'Undo restores wrong sound'

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/smoother_handle.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/smoother_handle.h
@@ -32,12 +32,9 @@ template <size_t Size> class ProtoSmoother
   // starting a segment (_dx: converted time, _dest: destination)
   inline void start(int idx, const float _dx, const float _dest)
   {
-    if(_dest != m_value[idx])
-    {
-      m_start[idx] = m_value[idx];
-      m_diff[idx] = _dest - m_start[idx];
-      m_x[idx] = m_dx[idx] = _dx;
-    }
+    m_start[idx] = m_value[idx];
+    m_diff[idx] = _dest - m_start[idx];
+    m_x[idx] = m_dx[idx] = _dx;
   }
   // syncing
   inline void sync(int idx, const float _dest)


### PR DESCRIPTION
Example:
+-----------+-------------------+---------------------------------+
| Timepoint | User Interaction  |        AE param changes         |
+-----------+-------------------+---------------------------------+
| (I)       | Param A (0...1)   | Param A (0...1)                 |
| (II)      | Param A (1...0)   | Param A (1...0)                 |
| (III)     | UndoJump to (I)   | Param A (0...1),Param A (1...0) |
| (IV)      | UndoJump to (III) | Param A (0...1),Param A (1...0) |
+-----------+-------------------+---------------------------------+

On parameter changes, the AE used to compare the new target value with
the *current value* instead of the *old target value*.
If, as in (III) and (IV), two contradicting requests drop in quickly
enough, the AE did not trigger a new ramp to the new target, but keeps
ramping towards the old target value.
This patch fixes the problem by not comparing at all, but simply update
the always-running ramp parameters accordingly.