### PR TITLE
Fix combining preset loads into one undo transaction

### DIFF
--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
@@ -44,7 +44,7 @@ namespace UNDO
     m_continuing = false;
   }
 
-  bool ContinuousTransaction::isContinueing() const
+  bool ContinuousTransaction::isContinuing() const
   {
     return m_continuing;
   }

--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
@@ -41,12 +41,12 @@ namespace UNDO
 
   void ContinuousTransaction::stopContinuation()
   {
-    m_continueing = false;
+    m_continuing = false;
   }
 
   bool ContinuousTransaction::isContinueing() const
   {
-    return m_continueing;
+    return m_continuing;
   }
 
   void ContinuousTransaction::implUndoAction() const

--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.cpp
@@ -39,6 +39,16 @@ namespace UNDO
     return m_closingCommand.get();
   }
 
+  void ContinuousTransaction::stopContinuation()
+  {
+    m_continueing = false;
+  }
+
+  bool ContinuousTransaction::isContinueing() const
+  {
+    return m_continueing;
+  }
+
   void ContinuousTransaction::implUndoAction() const
   {
     if(m_closingCommand)

--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
@@ -23,6 +23,9 @@ namespace UNDO
     void setClosingCommand(std::unique_ptr<ContinuousTransaction> command);
     UNDO::ContinuousTransaction *getClosingCommand() const;
 
+    void stopContinuation();
+    bool isContinueing() const;
+
    protected:
     void implUndoAction() const override;
     void implRedoAction() const override;
@@ -32,6 +35,7 @@ namespace UNDO
 
    private:
     void *m_id = nullptr;
+    bool m_continueing = true;
     steady_clock::time_point m_creationTimestamp;
     std::unique_ptr<ContinuousTransaction> m_closingCommand = nullptr;
     bool m_isNested = false;

--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
@@ -24,7 +24,7 @@ namespace UNDO
     UNDO::ContinuousTransaction *getClosingCommand() const;
 
     void stopContinuation();
-    bool isContinueing() const;
+    bool isContinuing() const;
 
    protected:
     void implUndoAction() const override;

--- a/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
+++ b/projects/epc/playground/src/libundo/undo/ContinuousTransaction.h
@@ -35,7 +35,7 @@ namespace UNDO
 
    private:
     void *m_id = nullptr;
-    bool m_continueing = true;
+    bool m_continuing = true;
     steady_clock::time_point m_creationTimestamp;
     std::unique_ptr<ContinuousTransaction> m_closingCommand = nullptr;
     bool m_isNested = false;

--- a/projects/epc/playground/src/libundo/undo/Scope.cpp
+++ b/projects/epc/playground/src/libundo/undo/Scope.cpp
@@ -117,7 +117,7 @@ namespace UNDO
     {
       if(auto last = dynamic_cast<ContinuousTransaction *>(getUndoTransaction()))
       {
-        if(last->getID() == id && last->getAge() <= timeout)
+        if(last->isContinueing() && last->getID() == id && last->getAge() <= timeout)
         {
           auto ret = std::make_unique<TransactionCreationScope>(transaction.get());
           last->setClosingCommand(std::move(transaction));

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -43,6 +43,7 @@
 #include <presets/Preset.h>
 #include <device-settings/SplitPointSyncParameters.h>
 #include <device-settings/SyncSplitSettingUseCases.h>
+#include <libundo/undo/ContinuousTransaction.h>
 
 EditBuffer::EditBuffer(PresetManager *parent)
     : ParameterGroupSet(parent)
@@ -445,6 +446,9 @@ void EditBuffer::undoableLoadSelectedPreset(UNDO::Transaction *transaction, Voic
 
 void EditBuffer::undoableLoad(UNDO::Transaction *transaction, const Preset *preset, bool sendToAudioEngine)
 {
+  if(auto p = dynamic_cast<UNDO::ContinuousTransaction *>(transaction))
+    p->stopContinuation();  // if transaction was created for a select operation, direct-load has to stop replacing the transaction
+
   auto hwui = Application::get().getHWUI();
   auto parameterFocusLock = hwui->getParameterFocusLockGuard();
 


### PR DESCRIPTION
Subsequent preset selections should be combined into a ContinuousTransaction.
With direct load enabled, those transactions should loose their 'continueing'
state and create new undo entries each.