### PR TITLE
The IRQs have to be put onto dedicated cores ...

### DIFF
--- a/projects/epc/audio-engine/system/audio-engine.service.in
+++ b/projects/epc/audio-engine/system/audio-engine.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nonlinear-Labs C15 Audio Engine
-After=systemd-modules-load.service sound.target fixCpuBindings.service alsa-restore.service
+After=systemd-modules-load.service sound.target alsa-restore.service
 StartLimitIntervalSec=0
 StartLimitInterval=0
 

--- a/projects/epc/audio-engine/system/fixCpuBindings.service.in
+++ b/projects/epc/audio-engine/system/fixCpuBindings.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Fix CPU bindings
-After=syslog.target persistent.mount
+After=syslog.target persistent.mount audio-engine.service
 
 [Service]
 ExecStart=@C15_INSTALL_PATH@/scripts/fixCpuBindings.sh


### PR DESCRIPTION
... once we can be sure that the intel sound driver is actually loaded.
This will be the case if the audio-engine could be
started successfully.