### PR TITLE
issue 2698

### DIFF
--- a/projects/epc/acceptance-tests/src/MIDIInputSpecialMappingsTests.cpp
+++ b/projects/epc/acceptance-tests/src/MIDIInputSpecialMappingsTests.cpp
@@ -46,7 +46,15 @@ namespace SecTests
       return SoundType::Split;
     }
 
-    VoiceGroup getSplitPartForKey(int key) override
+    VoiceGroup getSplitPartForKeyDown(int key) override
+    {
+      if(key == 64)
+        return VoiceGroup::Global;
+
+      return key > 64 ? VoiceGroup::II : VoiceGroup::I;
+    }
+
+    VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override
     {
       if(key == 64)
         return VoiceGroup::Global;
@@ -74,7 +82,7 @@ TEST_CASE("Secondary Channel", "[MIDI][TCD]")
   //Construct Objects
   SecTests::SplitDSPMock host;
   std::vector<nltools::msg::Midi::SimpleMessage> midiOut;
-  InputEventStage eventStage { &host, &settings, [] {}, [&](auto m) { midiOut.emplace_back(m); } };
+  InputEventStage eventStage{ &host, &settings, [] {}, [&](auto m) { midiOut.emplace_back(m); } };
 
   WHEN("TCD key is pressed on Part I")
   {
@@ -145,7 +153,13 @@ TEST_CASE("Receive MIDI from Channel I and Channel II leads to correct Split", "
   {
    public:
     using PassOnKeyDownHost::PassOnKeyDownHost;
-    VoiceGroup getSplitPartForKey(int key) override
+    VoiceGroup getSplitPartForKeyDown(int key) override
+    {
+      if(key == 64)
+        return VoiceGroup::Global;
+      return key > 64 ? VoiceGroup::II : VoiceGroup::I;
+    }
+    VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override
     {
       if(key == 64)
         return VoiceGroup::Global;
@@ -168,8 +182,7 @@ TEST_CASE("Receive MIDI from Channel I and Channel II leads to correct Split", "
   settings.setReceiveChannel(MidiReceiveChannel::CH_1);
   settings.setSplitReceiveChannel(MidiReceiveChannelSplit::CH_2);
   std::vector<nltools::msg::Midi::SimpleMessage> sendMIDI;
-  InputEventStage eventStage(
-      &hostPartI, &settings, [] {}, [&](auto m) { sendMIDI.emplace_back(m); });
+  InputEventStage eventStage(&hostPartI, &settings, [] {}, [&](auto m) { sendMIDI.emplace_back(m); });
 
   WHEN("MIDI In on Prim. Channel 1, receive")
   {
@@ -213,8 +226,7 @@ TEST_CASE("Receive MIDI Special Receive Channel Settings leads to Note Down", "[
 
   PassOnKeyDownHostSingle host(77, 1.0, VoiceGroup::I);
   auto settings = createSpecialSettings();
-  InputEventStage eventStage(
-      &host, &settings, [] {}, [&](auto m) { CHECK(false); });
+  InputEventStage eventStage(&host, &settings, [] {}, [&](auto m) { CHECK(false); });
 
   WHEN("MIDI In with CH1 & CH1")
   {

--- a/projects/epc/acceptance-tests/src/mock/InputEventStageTester.cpp
+++ b/projects/epc/acceptance-tests/src/mock/InputEventStageTester.cpp
@@ -4,7 +4,7 @@
 #include <synth/input/TCDDecoder.h>
 
 InputEventStageTester::InputEventStageTester(InputEventStage* stage)
-    : m_inputStage { stage }
+    : m_inputStage{ stage }
 {
 }
 
@@ -83,9 +83,14 @@ void InputEventStageTester::doSendCCOut(uint16_t value, int msbCC, int lsbCC, in
   m_inputStage->doSendCCOut(value, msbCC, lsbCC, hwID);
 }
 
-VoiceGroup InputEventStageTester::calculateSplitPartForEvent(DSPInterface::InputEventSource inputEvent, int keyNumber)
+VoiceGroup InputEventStageTester::calculateSplitPartForKeyDown(DSPInterface::InputEventSource inputEvent, int keyNumber)
 {
-  return m_inputStage->calculateSplitPartForEvent(inputEvent, keyNumber);
+  return m_inputStage->calculateSplitPartForKeyDown(inputEvent, keyNumber);
+}
+
+VoiceGroup InputEventStageTester::calculateSplitPartForKeyUp(DSPInterface::InputEventSource inputEvent, int keyNumber)
+{
+  return m_inputStage->calculateSplitPartForKeyUp(inputEvent, keyNumber);
 }
 
 DSPInterface::InputEventSource InputEventStageTester::getInputSourceFromParsedChannel(MidiReceiveChannel channel)

--- a/projects/epc/acceptance-tests/src/mock/InputEventStageTester.h
+++ b/projects/epc/acceptance-tests/src/mock/InputEventStageTester.h
@@ -30,7 +30,8 @@ class InputEventStageTester
   void sendHardwareChangeAsMidi(TCDDecoder* pDecoder);
   void sendCCOut(int hwID, float value, int msbCC, int lsbCC);
   void doSendCCOut(uint16_t value, int msbCC, int lsbCC, int hwID);
-  VoiceGroup calculateSplitPartForEvent(DSPInterface::InputEventSource inputEvent, int keyNumber);
+  VoiceGroup calculateSplitPartForKeyDown(DSPInterface::InputEventSource inputEvent, int keyNumber);
+  VoiceGroup calculateSplitPartForKeyUp(DSPInterface::InputEventSource inputEvent, int keyNumber);
   DSPInterface::InputEventSource getInputSourceFromParsedChannel(MidiReceiveChannel channel);
 
  private:

--- a/projects/epc/acceptance-tests/src/mock/MockDSPHosts.cpp
+++ b/projects/epc/acceptance-tests/src/mock/MockDSPHosts.cpp
@@ -27,7 +27,12 @@ SoundType MockDSPHost::getType()
   return m_type;
 }
 
-VoiceGroup MockDSPHost::getSplitPartForKey(int key)
+VoiceGroup MockDSPHost::getSplitPartForKeyDown(int key)
+{
+  return VoiceGroup::I;
+}
+
+VoiceGroup MockDSPHost::getSplitPartForKeyUp(int key, InputEventSource from)
 {
   return VoiceGroup::I;
 }
@@ -46,9 +51,9 @@ void MockDSPHost::setType(SoundType type)
 }
 
 PassOnKeyDownHost::PassOnKeyDownHost(const int expectedNote, float expectedVelo, VoiceGroup expectedPart)
-    : m_note { expectedNote }
-    , m_vel { expectedVelo }
-    , m_part { expectedPart }
+    : m_note{ expectedNote }
+    , m_vel{ expectedVelo }
+    , m_part{ expectedPart }
 {
 }
 
@@ -72,19 +77,29 @@ bool PassOnKeyDownHost::didReceiveKeyDown() const
   return m_receivedKeyDown;
 }
 
-VoiceGroup PassOnKeyDownHost::getSplitPartForKey(int key)
+VoiceGroup PassOnKeyDownHost::getSplitPartForKeyDown(int key)
+{
+  return VoiceGroup::Global;
+}
+
+VoiceGroup PassOnKeyDownHost::getSplitPartForKeyUp(int key, InputEventSource from)
 {
   return VoiceGroup::Global;
 }
 
 PassOnKeyUpHost::PassOnKeyUpHost(const int expectedNote, float expectedVelo, VoiceGroup expectedPart)
-    : m_note { expectedNote }
-    , m_vel { expectedVelo }
-    , m_part { expectedPart }
+    : m_note{ expectedNote }
+    , m_vel{ expectedVelo }
+    , m_part{ expectedPart }
 {
 }
 
-VoiceGroup PassOnKeyUpHost::getSplitPartForKey(int key)
+VoiceGroup PassOnKeyUpHost::getSplitPartForKeyDown(int key)
+{
+  return VoiceGroup::Global;
+}
+
+VoiceGroup PassOnKeyUpHost::getSplitPartForKeyUp(int key, InputEventSource from)
 {
   return VoiceGroup::Global;
 }
@@ -109,8 +124,8 @@ bool PassOnKeyUpHost::didReceiveKeyUp() const
 }
 
 PassOnHWReceived::PassOnHWReceived(int expectedId, float expectedValue)
-    : m_id { expectedId }
-    , m_value { expectedValue }
+    : m_id{ expectedId }
+    , m_value{ expectedValue }
 {
 }
 
@@ -156,8 +171,17 @@ C15::Properties::HW_Return_Behavior ConfigureableDSPHost::getBehaviour(int id)
   return C15::Properties::HW_Return_Behavior::Stay;
 }
 
-VoiceGroup ConfigureableDSPHost::getSplitPartForKey(int key)
+VoiceGroup ConfigureableDSPHost::getSplitPartForKeyDown(int key)
 {
+  if(m_getSplitPartForKey)
+    return m_getSplitPartForKey(key);
+
+  return VoiceGroup::I;
+}
+
+VoiceGroup ConfigureableDSPHost::getSplitPartForKeyUp(int key, InputEventSource from)
+{
+  // not sure here...
   if(m_getSplitPartForKey)
     return m_getSplitPartForKey(key);
 

--- a/projects/epc/acceptance-tests/src/mock/MockDSPHosts.h
+++ b/projects/epc/acceptance-tests/src/mock/MockDSPHosts.h
@@ -10,7 +10,8 @@ class MockDSPHost : public DSPInterface
   void onKeyUp(const int note, float velocity, InputEventSource from) override;
   C15::Properties::HW_Return_Behavior getBehaviour(int id) override;
   SoundType getType() override;
-  VoiceGroup getSplitPartForKey(int key) override;
+  VoiceGroup getSplitPartForKeyDown(int key) override;
+  VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
   void onKeyDownSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   void onKeyUpSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   void onMidiSettingsReceived() override;
@@ -27,7 +28,8 @@ class ConfigureableDSPHost : public MockDSPHost
   void onKeyDown(const int note, float velocity, InputEventSource from) override;
   void onKeyUp(const int note, float velocity, InputEventSource from) override;
   C15::Properties::HW_Return_Behavior getBehaviour(int id) override;
-  VoiceGroup getSplitPartForKey(int key) override;
+  VoiceGroup getSplitPartForKeyDown(int key) override;
+  VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
   void onKeyDownSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   void onKeyUpSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
 
@@ -56,7 +58,8 @@ class PassOnKeyDownHost : public MockDSPHost
   void onKeyDown(const int note, float velocity, InputEventSource from) override;
   void onKeyDownSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   [[nodiscard]] bool didReceiveKeyDown() const;
-  VoiceGroup getSplitPartForKey(int key) override;
+  VoiceGroup getSplitPartForKeyDown(int key) override;
+  VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
 
  protected:
   bool m_receivedKeyDown = false;
@@ -72,7 +75,8 @@ class PassOnKeyUpHost : public MockDSPHost
   void onKeyUp(const int note, float velocity, InputEventSource from) override;
   [[nodiscard]] bool didReceiveKeyUp() const;
   void onKeyUpSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
-  VoiceGroup getSplitPartForKey(int key) override;
+  VoiceGroup getSplitPartForKeyDown(int key) override;
+  VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
 
  private:
   bool m_receivedKeyUp = false;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2359,25 +2359,14 @@ SoundType dsp_host_dual::getType()
   return SoundType::Invalid;  // should never be reached
 }
 
-// TODO: refactor
-VoiceGroup dsp_host_dual::getSplitPartForKey(int key)
+VoiceGroup dsp_host_dual::getSplitPartForKeyDown(int key)
 {
-  // also a little inconvenient but should work
-  switch(m_alloc.getSplitPartForKeyDown(key))
-  {
-    case AllocatorId::Local_I:
-      return VoiceGroup::I;
-      break;
-    case AllocatorId::Local_II:
-      return VoiceGroup::II;
-      break;
-    case AllocatorId::Local_Both:
-      return VoiceGroup::Global;
-      break;
-  }
-  // NOTE: this should never be reached and represents an invalid state!
-  // (maybe, extend enum for better readability?)
-  return VoiceGroup::NumGroups;
+  return getVoiceGroupFromAllocatorId(m_alloc.getSplitPartForKeyDown(key));
+}
+
+VoiceGroup dsp_host_dual::getSplitPartForKeyUp(int key, InputEventSource from)
+{
+  return getVoiceGroupFromAllocatorId(m_alloc.getSplitPartForKeyUp(key, getInputSourceId(from)));
 }
 
 void dsp_host_dual::onKeyDown(const int note, float velocity, InputEventSource from)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2435,23 +2435,7 @@ void dsp_host_dual::onKeyUp(const int note, float velocity, InputEventSource fro
 
 void dsp_host_dual::onKeyDownSplit(const int note, float velocity, VoiceGroup part, DSPInterface::InputEventSource from)
 {
-  // InputEvent can be singular (TCD or Primary) or separate (Primary or Secondary or Both)
-  // Secondary can exist, so the SourceId can be 0 (TCD), 1 (Primary) or 2 (Secondary) -- Both translates to Primary
-  uint32_t inputSourceId = 0;
-  switch(from)
-  {
-    case InputEventSource::Internal:
-      break;
-    case InputEventSource::External_Use_Split:
-    case InputEventSource::External_Primary:
-    case InputEventSource::External_Both:
-      inputSourceId = 1;
-      break;
-    case InputEventSource::External_Secondary:
-      inputSourceId = 2;
-      break;
-  }
-
+  const uint32_t inputSourceId = getInputSourceId(from);
   bool valid = false;
   if(m_layer_mode == LayerMode::Split)
   {

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2359,10 +2359,11 @@ SoundType dsp_host_dual::getType()
   return SoundType::Invalid;  // should never be reached
 }
 
+// TODO: refactor
 VoiceGroup dsp_host_dual::getSplitPartForKey(int key)
 {
   // also a little inconvenient but should work
-  switch(m_alloc.getSplitPartForKey(key))
+  switch(m_alloc.getSplitPartForKeyDown(key))
   {
     case AllocatorId::Local_I:
       return VoiceGroup::I;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -94,6 +94,24 @@ class DSPInterface
   virtual SoundType getType() = 0;
   virtual VoiceGroup getSplitPartForKey(int key) = 0;
   virtual void onMidiSettingsReceived() = 0;
+  static inline uint32_t getInputSourceId(const InputEventSource _inputSource)
+  {
+    // InputEvent can be singular (TCD or Primary) or separate (Primary or Secondary or Both)
+    // Secondary can exist, so the SourceId can be 0 (TCD), 1 (Primary) or 2 (Secondary) -- Both translates to Primary
+    switch(_inputSource)
+    {
+      case InputEventSource::Internal:
+        return 0;
+      case InputEventSource::External_Use_Split:
+      case InputEventSource::External_Primary:
+      case InputEventSource::External_Both:
+        return 1;
+      case InputEventSource::External_Secondary:
+        return 2;
+    }
+    // should never be reached
+    return 0;
+  }
 };
 
 class dsp_host_dual : public DSPInterface

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -92,7 +92,8 @@ class DSPInterface
   virtual void onKeyUpSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) = 0;
   virtual C15::Properties::HW_Return_Behavior getBehaviour(int id) = 0;
   virtual SoundType getType() = 0;
-  virtual VoiceGroup getSplitPartForKey(int key) = 0;
+  virtual VoiceGroup getSplitPartForKeyDown(int key) = 0;
+  virtual VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) = 0;
   virtual void onMidiSettingsReceived() = 0;
   static inline uint32_t getInputSourceId(const InputEventSource _inputSource)
   {
@@ -171,7 +172,8 @@ class dsp_host_dual : public DSPInterface
   using HWSourceValues = std::array<float, static_cast<size_t>(C15::Parameters::Hardware_Sources::_LENGTH_)>;
   HWSourceValues getHWSourceValues() const;
   SoundType getType() override;
-  VoiceGroup getSplitPartForKey(int key) override;
+  VoiceGroup getSplitPartForKeyDown(int key) override;
+  VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
 
   using CC_Range_7_Bit = Midi::FullCCRange<Midi::Formats::_7_Bits_>;
   using CC_Range_14_Bit = Midi::clipped14BitCCRange;
@@ -179,6 +181,24 @@ class dsp_host_dual : public DSPInterface
   using CC_Range_Vel = Midi::clipped14BitVelRange;
 
  private:
+  static inline VoiceGroup getVoiceGroupFromAllocatorId(const AllocatorId _id)
+  {
+    // a little inconvenient and redundant...
+    switch(_id)
+    {
+      case AllocatorId::Local_I:
+        return VoiceGroup::I;
+        break;
+      case AllocatorId::Local_II:
+        return VoiceGroup::II;
+        break;
+      case AllocatorId::Local_Both:
+        return VoiceGroup::Global;
+        break;
+    }
+    // fail safety
+    return VoiceGroup::NumGroups;
+  }
   using LayerMode = C15::Properties::LayerMode;
   // parameters
   Engine::Param_Handle m_params;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -618,7 +618,7 @@ class VoiceAllocation
     clear_keyState();
   }
 
-  inline AllocatorId getSplitPartForKey(const uint32_t _key)
+  inline AllocatorId getSplitPartForKeyDown(const uint32_t _key)
   {
     const uint32_t state = (_key <= m_splitPoint[0]) + ((_key >= m_splitPoint[1]) << 1);
     switch(state)
@@ -634,6 +634,14 @@ class VoiceAllocation
         break;
     }
     return AllocatorId::None;
+  }
+
+  inline AllocatorId getSplitPartForKeyUp(const uint32_t _keyPos, const uint32_t _inputSourceId)
+  {
+    KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
+    if(!keyState->m_active)
+      return AllocatorId::None;
+    return keyState->m_origin;
   }
 
  private:

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -639,8 +639,6 @@ class VoiceAllocation
   inline AllocatorId getSplitPartForKeyUp(const uint32_t _keyPos, const uint32_t _inputSourceId)
   {
     KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
-    if(!keyState->m_active)
-      return AllocatorId::None;
     return keyState->m_origin;
   }
 

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -455,7 +455,7 @@ VoiceGroup InputEventStage::calculateSplitPartForEvent(DSPInterface::InputEventS
   {
     case DSPInterface::InputEventSource::Internal:
     case DSPInterface::InputEventSource::External_Use_Split:
-      return m_dspHost->getSplitPartForKey(keyNumber);
+      return m_dspHost->getSplitPartForKeyDown(keyNumber);
     case DSPInterface::InputEventSource::External_Primary:
       return VoiceGroup::I;
     case DSPInterface::InputEventSource::External_Secondary:

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.h
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.h
@@ -47,7 +47,8 @@ class InputEventStage
 
   //Algorithm
   void onHWChanged(int hwID, float pos, DSPInterface::HWChangeSource source);
-  VoiceGroup calculateSplitPartForEvent(DSPInterface::InputEventSource inputEvent, const int keyNumber);
+  VoiceGroup calculateSplitPartForKeyDown(DSPInterface::InputEventSource inputEvent, const int keyNumber);
+  VoiceGroup calculateSplitPartForKeyUp(DSPInterface::InputEventSource inputEvent, const int keyNumber);
   DSPInterface::InputEventSource getInputSourceFromParsedChannel(MidiReceiveChannel channel);
 
   static constexpr uint16_t midiReceiveChannelMask(const MidiReceiveChannel& _channel);


### PR DESCRIPTION
- [x] **VoiceAlloc**: refactor `getSplitPartForKey(int key)` into `getSplitPartForKeyDown(int key)` and `getSplitPartForKeyUp(int key, int sourceId)`
- [x] **DSPInterface** (and descendants `dsp_host_dual, MockDSPHost, ...`): refactor `getSplitPartForKey(int key)` into `getSplitPartForKey(int key, InputEventSource from, bool upOrDown)` (or alternatively separate keyDown and keyUp versions)
- [x] **InputEventStage** (`onMIDIEvent, onTCDEvent`): refactor `calculateSplitPartForEvent` in similar fashion (only on KeyDown, the Split Point parameters should ever be used; for KeyUp there now is a separate event flow available)

- runs acceptance-tests and audio-engine-tests without fail
- sound check revealed bug is fixed

closes #2698 