### PR TITLE
Issue 2722

### DIFF
--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -15,7 +15,6 @@ C15Synth::C15Synth(AudioEngineOptions* options)
     , m_syncExternalsTask(std::async(std::launch::async, [this] { syncExternalsLoop(); }))
     , m_syncPlaygroundTask(std::async(std::launch::async, [this] {syncPlaygroundLoop(); }))
     , m_inputEventStage { m_dsp.get(), &m_midiOptions, [this] {
-                            nltools::Log::error("syncPG notified");
                             m_syncPlaygroundWaiter.notify_all(); },
                           [this](auto msg) { queueExternalMidiOut(msg); } }
 {
@@ -156,7 +155,6 @@ void C15Synth::syncExternalMidiBridge()
   {
     auto msg = m_externalMidiOutBuffer.pop();
     auto copy = msg;
-    nltools::Log::error("syncExternalMidiBridge");
     send(nltools::msg::EndPoint::ExternalMidiOverIPBridge, copy);
   }
 }
@@ -360,7 +358,6 @@ void C15Synth::onHWSourceMessage(const nltools::msg::HWSourceChangedMessage& msg
 
 void C15Synth::queueExternalMidiOut(const dsp_host_dual::SimpleRawMidiMessage& m)
 {
-  nltools::Log::error("queueExternalMidiOut");
   m_externalMidiOutBuffer.push(m);
   m_syncExternalsWaiter.notify_all();
 }

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -161,7 +161,6 @@ void C15Synth::syncExternalMidiBridge()
 
 void C15Synth::syncPlayground()
 {
-  nltools::Log::error("syncPlayground");
   auto engineHWSourceValues = m_dsp->getHWSourceValues();
   for(size_t i = 0; i < std::tuple_size_v<dsp_host_dual::HWSourceValues>; i++)
   {
@@ -171,11 +170,6 @@ void C15Synth::syncPlayground()
       send(EndPoint::Playground, HardwareSourceChangedNotification { i, static_cast<double>(engineHWSourceValues[i]) });
     }
   }
-}
-
-bool matchPattern(unsigned char data, uint8_t PATTERN, uint8_t MASK)
-{
-  return (data & MASK) == PATTERN;
 }
 
 void C15Synth::doMidi(const MidiEvent& event)

--- a/projects/epc/audio-engine/src/synth/C15Synth.h
+++ b/projects/epc/audio-engine/src/synth/C15Synth.h
@@ -69,7 +69,8 @@ class C15Synth : public Synth, public sigc::trackable
  private:
   void queueExternalMidiOut(const dsp_host_dual::SimpleRawMidiMessage& m);
 
-  void syncExternals();
+  void syncExternalsLoop();
+  void syncPlaygroundLoop();
   void syncExternalMidiBridge();
   void syncPlayground();
 
@@ -81,8 +82,11 @@ class C15Synth : public Synth, public sigc::trackable
   RingBuffer<nltools::msg::Midi::SimpleMessage> m_externalMidiOutBuffer;
 
   std::mutex m_syncExternalsMutex;
+  std::mutex m_syncPlaygroundMutex;
   std::condition_variable m_syncExternalsWaiter;
+  std::condition_variable m_syncPlaygroundWaiter;
   std::atomic<bool> m_quit { false };
   std::future<void> m_syncExternalsTask;
+  std::future<void> m_syncPlaygroundTask;
   InputEventStage m_inputEventStage;
 };

--- a/projects/epc/playground/src/device-settings/midi/HardwareControlEnables.cpp
+++ b/projects/epc/playground/src/device-settings/midi/HardwareControlEnables.cpp
@@ -4,7 +4,9 @@
 HardwareControlEnables::HardwareControlEnables(Settings& s)
     : Setting(s)
 {
-  m_data.fill({ true });
+  for(auto& row: m_data) {
+    row.fill(true);
+  }
 }
 
 bool HardwareControlEnables::getState(HardwareControlEnables::tHWIdx hwIdx,

--- a/projects/epc/playground/src/device-settings/midi/HardwareControlEnables.cpp
+++ b/projects/epc/playground/src/device-settings/midi/HardwareControlEnables.cpp
@@ -4,7 +4,7 @@
 HardwareControlEnables::HardwareControlEnables(Settings& s)
     : Setting(s)
 {
-  m_data.fill({ false });
+  m_data.fill({ true });
 }
 
 bool HardwareControlEnables::getState(HardwareControlEnables::tHWIdx hwIdx,

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
@@ -55,7 +55,6 @@ AudioEngineProxy::AudioEngineProxy()
                           sigc::mem_fun(this, &AudioEngineProxy::connectSettingsToAudioEngineMessage));
 
   receive<HardwareSourceChangedNotification>(EndPoint::Playground, [this](auto &msg) {
-    nltools::Log::error("Received HWSourceChangedNotification for", msg.hwSource, "value:", msg.position);
     auto playController = Application::get().getPlaycontrollerProxy();
     auto id = msg.hwSource;
     auto value = msg.position;

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
@@ -55,6 +55,7 @@ AudioEngineProxy::AudioEngineProxy()
                           sigc::mem_fun(this, &AudioEngineProxy::connectSettingsToAudioEngineMessage));
 
   receive<HardwareSourceChangedNotification>(EndPoint::Playground, [this](auto &msg) {
+    nltools::Log::error("Received HWSourceChangedNotification for", msg.hwSource, "value:", msg.position);
     auto playController = Application::get().getPlaycontrollerProxy();
     auto id = msg.hwSource;
     auto value = msg.position;
@@ -76,18 +77,6 @@ AudioEngineProxy::AudioEngineProxy()
         BankUseCases useCase(bank);
         useCase.selectPreset(msg.program);
       }
-  });
-
-  receive<Midi::HardwareChangeMessage>(EndPoint::Playground, [](const auto &msg) {
-    if(Application::exists())
-    {
-      auto eb = Application::get().getPresetManager()->getEditBuffer();
-      if(auto parameter
-         = eb->findAndCastParameterByID<PhysicalControlParameter>({ msg.parameterID, VoiceGroup::Global }))
-      {
-        parameter->onChangeFromPlaycontroller(static_cast<tControlPositionValue>(msg.value));
-      }
-    }
   });
 
   pm->onLoadHappened(sigc::mem_fun(this, &AudioEngineProxy::onPresetManagerLoaded));

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -244,8 +244,8 @@ namespace nltools
           Pedal2 = 1,
           Pedal3 = 2,
           Pedal4 = 3,
-          Aftertouch = 4,
-          Bender = 5,
+          Bender = 4,
+          Aftertouch = 5,
           Ribbon1 = 6,
           Ribbon2 = 7,
           LENGTH = 8

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -51,17 +51,6 @@ namespace nltools
         uint8_t program;
         SoundType programType = SoundType::Invalid;
       };
-
-      struct HardwareChangeMessage
-      {
-        constexpr static MessageType getType()
-        {
-          return MessageType::MidiHardwareChange;
-        }
-
-        int parameterID;
-        float value;
-      };
     }
 
     using tID = int;


### PR DESCRIPTION
This issue said that no hardware source is working. I suspect that this is an configuration and communication issue rather than an software issue. 
Previously I added more granular MIDI/Local Settings for HW-Sources. They can be currently only found inside the WebUI -> Settings -> MIDI-Tab -> Very Bottom.
I unfortunately made the mistake of defaulting all enable-switches to 'off'. This prevents the changes to propagate thorough the system and it appears as if the Sources were not working. 

This PR fixes the defaults to be true. Also it changes the notifcation system in the InputEventStage to be able to notify either the Playground Sync or the Midi Sync. As I and @MatthiasSeeber  talked about 2 Weeks ago.

preview build can be found here: https://we.tl/t-XPsHETPTRE (this build is one commit behind, but the commit only removed dead code and one missed log-statement)

closes #2722