### PR TITLE
Update bbb-check-phy.sh

### DIFF
--- a/projects/bbb/scripts/bbb-check-phy.sh
+++ b/projects/bbb/scripts/bbb-check-phy.sh
@@ -9,7 +9,7 @@
 # and avoid a infinite loop
 
 REBOOTCOUNT=0
-TIMEOUT=3
+TIMEOUT=5
 
 check_state_loop_hard() {
 


### PR DESCRIPTION
Issue: The C15 re-boots twice in a row, after being turned off for a longer period of time. 
Reason: Apparently the new constellation (Intel Nuc 10i3 + BBB Red) sometimes seems to cause the network to be down for longer than the 3 seconds we measured in the past (Nuc 7i3 + BBB RevC). This fix should allows the system to be more tolerable.