### PR TITLE
closes #2798

### DIFF
--- a/projects/epc/acceptance-tests/src/MIDI/Issue2798.cpp
+++ b/projects/epc/acceptance-tests/src/MIDI/Issue2798.cpp
@@ -1,0 +1,57 @@
+#include <testing/TestHelper.h>
+#include <synth/input/InputEventStage.h>
+#include <mock/MockDSPHosts.h>
+#include <nltools/messaging/Message.h>
+
+TEST_CASE("When Notes Local is turned off All Notes off gets send", "[MIDI][TCD]")
+{
+
+  std::vector<nltools::msg::Midi::SimpleMessage> sendMidi;
+  std::vector<MidiChannelModeMessages> messages;
+  MockDSPHost host;
+  MidiRuntimeOptions options;
+  InputEventStage eventStage(&host, &options, {}, [&](auto m){ sendMidi.emplace_back(m); }, [&](auto c){ messages.emplace_back(c); });
+
+  auto msg = nltools::msg::Setting::MidiSettingsMessage{};
+  msg.routings = TestHelper::createFullMappings(true);
+  msg.sendChannel = MidiSendChannel::CH_1;
+  msg.sendSplitChannel = MidiSendChannelSplit::CH_2;
+  options.update(msg);
+  eventStage.onMidiSettingsMessageReceived(msg, false, false);
+
+  WHEN("Previous Notes Enable is disabled")
+  {
+    msg.routings = TestHelper::createFullMappings(true);
+    TestHelper::updateMappings(msg.routings, nltools::msg::Setting::MidiSettingsMessage::RoutingAspect::SEND_PRIMARY, false);
+    TestHelper::updateMappings(msg.routings, nltools::msg::Setting::MidiSettingsMessage::RoutingAspect::SEND_SPLIT, false);
+    options.update(msg);
+
+    WHEN("DSPHost is Single")
+    {
+      host.setType(SoundType::Single);
+      eventStage.onMidiSettingsMessageReceived(msg, true, true);
+
+      THEN("All Notes Off was send")
+      {
+        REQUIRE(sendMidi.size() == 1);
+        CHECK(sendMidi[0].rawBytes[1] == 123);
+        CHECK(sendMidi[0].rawBytes[2] == 0);
+      }
+    }
+
+    WHEN("DSPHost is Split")
+    {
+      host.setType(SoundType::Split);
+      eventStage.onMidiSettingsMessageReceived(msg, true, true);
+
+      THEN("All Notes Off was send")
+      {
+        REQUIRE(sendMidi.size() == 2);
+        CHECK(sendMidi[0].rawBytes[1] == 123);
+        CHECK(sendMidi[0].rawBytes[2] == 0);
+        CHECK(sendMidi[1].rawBytes[1] == 123);
+        CHECK(sendMidi[1].rawBytes[2] == 0);
+      }
+    }
+  }
+}

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -500,7 +500,10 @@ void C15Synth::onTuneReferenceMessage(const nltools::msg::Setting::TuneReference
 
 void C15Synth::onMidiSettingsMessage(const nltools::msg::Setting::MidiSettingsMessage& msg)
 {
+  const auto oldPrimSendState = m_midiOptions.shouldSendMIDINotesOnPrimary();
+  const auto oldSecSendState = m_midiOptions.shouldSendMIDINotesOnSplit();
   m_midiOptions.update(msg);
+  m_inputEventStage.onMidiSettingsMessageReceived(msg, oldPrimSendState, oldSecSendState);
   m_dsp->onMidiSettingsReceived();
 }
 

--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -502,8 +502,18 @@ void C15Synth::onMidiSettingsMessage(const nltools::msg::Setting::MidiSettingsMe
 {
   const auto oldPrimSendState = m_midiOptions.shouldSendMIDINotesOnPrimary();
   const auto oldSecSendState = m_midiOptions.shouldSendMIDINotesOnSplit();
+  const auto oldPrimChannel = m_midiOptions.getMIDIPrimarySendChannel();
+  const auto oldSplitChannel = m_midiOptions.getMIDISplitSendChannel();
+  const auto newPrimChannel = msg.sendChannel;
+  const auto newSplitChannel = msg.sendSplitChannel;
+  const auto didPrimChange = oldPrimChannel != newPrimChannel;
+  const auto didSplitChange = oldSplitChannel != newSplitChannel;
+
   m_midiOptions.update(msg);
-  m_inputEventStage.onMidiSettingsMessageReceived(msg, oldPrimSendState, oldSecSendState);
+
+  m_inputEventStage.handlePressedNotesOnMidiSettingsChanged(msg, oldPrimSendState, oldSecSendState, didPrimChange,
+                                                            didSplitChange, oldPrimChannel,
+                                                            oldSplitChannel);
   m_dsp->onMidiSettingsReceived();
 }
 

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.h
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.h
@@ -42,8 +42,10 @@ class InputEventStage
   void onMIDIMessage(const MidiEvent& midiEvent);
   void onUIHWSourceMessage(const nltools::msg::HWSourceChangedMessage& message, bool didBehaviourChange);
   void setNoteShift(int i);
-  void onMidiSettingsMessageReceived(const nltools::msg::Setting::MidiSettingsMessage& msg, bool oldPrimSendState,
-                                     bool oldSecSendState);
+  void handlePressedNotesOnMidiSettingsChanged(const nltools::msg::Setting::MidiSettingsMessage& msg,
+                                               bool oldPrimSendState, bool oldSecSendState, bool didPrimChange,
+                                               bool didSecChange, MidiSendChannel oldPrimSendChannel,
+                                               MidiSendChannelSplit oldSplitSendChannel);
 
   static int parameterIDToHWID(int id);
 

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.h
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.h
@@ -29,6 +29,7 @@ class InputEventStage
 {
  public:
   using RoutingIndex = nltools::msg::Setting::MidiSettingsMessage::RoutingIndex;
+  using RoutingAspect = nltools::msg::Setting::MidiSettingsMessage::RoutingAspect;
   using MIDIOutType = nltools::msg::Midi::SimpleMessage;
   using MIDIOut = std::function<void(MIDIOutType)>;
   using HWChangedNotification = std::function<void()>;
@@ -41,6 +42,8 @@ class InputEventStage
   void onMIDIMessage(const MidiEvent& midiEvent);
   void onUIHWSourceMessage(const nltools::msg::HWSourceChangedMessage& message, bool didBehaviourChange);
   void setNoteShift(int i);
+  void onMidiSettingsMessageReceived(const nltools::msg::Setting::MidiSettingsMessage& msg, bool oldPrimSendState,
+                                     bool oldSecSendState);
 
   static int parameterIDToHWID(int id);
 

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -291,9 +291,8 @@ namespace nltools
           LENGTH = 5
         };
 
-        typedef std::array<std::array<bool, static_cast<size_t>(RoutingAspect::LENGTH)>,
-                           static_cast<size_t>(RoutingIndex::LENGTH)>
-            tRoutingMappings;
+        typedef std::array<bool, static_cast<size_t>(RoutingAspect::LENGTH)> tEntry;
+        typedef std::array<tEntry, static_cast<size_t>(RoutingIndex::LENGTH)> tRoutingMappings;
 
         MidiReceiveChannel receiveChannel;
         MidiReceiveChannelSplit receiveSplitChannel;


### PR DESCRIPTION
Stuck external notes should be fixed by sending CC 123 'All Notes Off' on both channels (if split is applicable) if the sending of MIDI notes is turned off