### PR TITLE
 closes #2833

### DIFF
--- a/projects/epc/playground/src/presets/Bank.cpp
+++ b/projects/epc/playground/src/presets/Bank.cpp
@@ -475,17 +475,11 @@ bool Bank::empty() const
   return m_presets.empty();
 }
 
-//void Bank::copyFrom(UNDO::Transaction *transaction, const Bank *other)
-//{
-//  setName(transaction, other->getName(false));
-//  setX(transaction, other->getX());
-//  setY(transaction, other->getY());
-//
-//  AttributesOwner::copyFrom(transaction, other);
-//  other->forEachPreset([&](auto p) { m_presets.append(transaction, std::make_unique<Preset>(this, *p, ignoreUuids)); });
-//
-//  updateLastModifiedTimestamp(transaction);
-//}
+bool Bank::isCollapsed() const
+{
+  const auto value = getAttribute("collapsed", "false");
+  return value == "true";
+}
 
 std::string to_string(Bank::AttachmentDirection dir)
 {

--- a/projects/epc/playground/src/presets/Bank.h
+++ b/projects/epc/playground/src/presets/Bank.h
@@ -43,33 +43,35 @@ class Bank : public AttributesOwner, public SyncedItem
   void writeDocument(Writer &writer, tUpdateID knownRevision) const override;
 
   // accessors
-  bool empty() const;
-  std::string getName(bool withFallback) const;
-  std::string getX() const;
-  std::string getY() const;
-  const Uuid &getSelectedPresetUuid() const;
-  Preset *getSelectedPreset() const;
-  const Uuid &getAttachedToBankUuid() const;
-  std::string getAttachDirection() const;
-  size_t getNumPresets() const;
-  size_t getPresetPosition(const Uuid &uuid) const;
-  size_t getPresetPosition(const Preset *preset) const;
-  Preset *findPreset(const Uuid &uuid) const;
-  Preset *findPresetNear(const Uuid &anchorUuid, int seek) const;
-  Preset *findSelectedPreset() const;
-  Preset *getPresetAt(size_t idx) const;
-  void forEachPreset(std::function<void(Preset *)> cb) const;
-  Bank *getMasterTop() const;
-  Bank *getMasterLeft() const;
-  Bank *getSlaveRight() const;
-  Bank *getSlaveBottom() const;
-  time_t getLastChangedTimestamp() const;
-  const Uuid &getUuid() const;
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] bool isCollapsed() const;
+  [[nodiscard]] std::string getName(bool withFallback) const;
+  [[nodiscard]] std::string getX() const;
+  [[nodiscard]] std::string getY() const;
+  [[nodiscard]] const Uuid &getSelectedPresetUuid() const;
+  [[nodiscard]] Preset *getSelectedPreset() const;
+  [[nodiscard]] const Uuid &getAttachedToBankUuid() const;
+  [[nodiscard]] std::string getAttachDirection() const;
+  [[nodiscard]] size_t getNumPresets() const;
+  [[nodiscard]] size_t getPresetPosition(const Uuid &uuid) const;
+  [[nodiscard]] size_t getPresetPosition(const Preset *preset) const;
+  [[nodiscard]] Preset *findPreset(const Uuid &uuid) const;
+  [[nodiscard]] Preset *findPresetNear(const Uuid &anchorUuid, int seek) const;
+  [[nodiscard]] Preset *findSelectedPreset() const;
+  [[nodiscard]] Preset *getPresetAt(size_t idx) const;
+  [[nodiscard]] Bank *getMasterTop() const;
+  [[nodiscard]] Bank *getMasterLeft() const;
+  [[nodiscard]] Bank *getSlaveRight() const;
+  [[nodiscard]] Bank *getSlaveBottom() const;
+  [[nodiscard]] time_t getLastChangedTimestamp() const;
+  [[nodiscard]] const Uuid &getUuid() const;
+
   nlohmann::json serialize() const override;
 
   void attachBank(UNDO::Transaction *transaction, const Uuid &otherBank, AttachmentDirection dir);
   void invalidate();
 
+  void forEachPreset(std::function<void(Preset *)> cb) const;
   Preset *clonePreset(const Preset *p);
 
   // transactions

--- a/projects/epc/playground/src/use-cases/BankUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/BankUseCases.cpp
@@ -197,10 +197,14 @@ void BankUseCases::selectPreset(int pos)
 
 void BankUseCases::setAttribute(const Glib::ustring& key, const Glib::ustring& value)
 {
-  auto scope = m_bank->getUndoScope().startTransaction("Set Bank attribute");
-  auto transaction = scope->getTransaction();
-  m_bank->setAttribute(transaction, key, value);
-  m_bank->updateLastModifiedTimestamp(transaction);
+  const auto oldValue = m_bank->getAttribute(key, "");
+  if(oldValue != value)
+  {
+    auto scope = m_bank->getUndoScope().startTransaction("Set Bank attribute");
+    auto transaction = scope->getTransaction();
+    m_bank->setAttribute(transaction, key, value);
+    m_bank->updateLastModifiedTimestamp(transaction);
+  }
 }
 
 bool BankUseCases::isDirectLoadActive() const
@@ -210,11 +214,15 @@ bool BankUseCases::isDirectLoadActive() const
 
 void BankUseCases::setCollapsed(bool b)
 {
-  std::string name = b ? "Collapse" : "Maximize";
-  auto scope = m_bank->getUndoScope().startTransaction(name + " Bank");
-  auto transaction = scope->getTransaction();
-  m_bank->setAttribute(transaction, "collapsed", b ? "true" : "false");
-  m_bank->updateLastModifiedTimestamp(transaction);
+  if(m_bank->isCollapsed() != b)
+  {
+    std::string name = b ? "Collapse" : "Maximize";
+    auto bankName = m_bank->getName(true);
+    auto scope = m_bank->getUndoScope().startTransaction(name + " Bank " + bankName);
+    auto transaction = scope->getTransaction();
+    m_bank->setAttribute(transaction, "collapsed", b ? "true" : "false");
+    m_bank->updateLastModifiedTimestamp(transaction);
+  }
 }
 
 void BankUseCases::exportBankToFile(const std::string& outFile)


### PR DESCRIPTION
added check to `BankUseCases` for `setAttribute` and `setCollapsed`, if the desired value is already set, no new transaction will be opened
