### PR TITLE
part-aware reset behavior

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1696,7 +1696,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::
   // update unison and mono groups
   auto polyChanged = evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
   // reset detection
-  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary(fromType(oldLayerMode));
+  const bool resetDetected = (layerChanged || polyChanged) && areKeysPressed(fromType(oldLayerMode));
   const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetected, oldLayerMode);
   if(resetDetected)
   {
@@ -1848,7 +1848,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
 
   auto msg = &_msg;
   bool resetDetected[2] = { false, false };
-  const bool resetDetermined = layerChanged || resetIsNecessary(fromType(oldLayerMode));
+  const bool resetDetermined = layerChanged || areKeysPressed(fromType(oldLayerMode));
   const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetermined, oldLayerMode);
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
@@ -2034,7 +2034,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::m
   // update unison and mono groups
   auto polyChanged = evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
   // reset detection
-  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary(fromType(oldLayerMode));
+  const bool resetDetected = (layerChanged || polyChanged) && areKeysPressed(fromType(oldLayerMode));
   const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetected, oldLayerMode);
   if(resetDetected)
   {
@@ -2653,7 +2653,7 @@ void dsp_host_dual::resetReturningHWSource(HardwareSource hwui)
   DSPInterface::resetReturningHWSource(hwui);
 }
 
-bool dsp_host_dual::resetIsNecessary(SoundType _current)
+bool dsp_host_dual::areKeysPressed(SoundType _current)
 {
   switch(_current)
   {

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1671,15 +1671,13 @@ DSPInterface::OutputResetEventSource dsp_host_dual::determineOutputEventSource(c
     return OutputResetEventSource::None;
   if(_type != LayerMode::Split)
     return OutputResetEventSource::Global;
-  const uint32_t count
-      = m_alloc.m_internal_and_external_keys.m_local[0] + (2 * m_alloc.m_internal_and_external_keys.m_local[1]);
-  switch(count)
+  switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys())
   {
-    case 1:
+    case AllocatorId::Local_I:
       return OutputResetEventSource::Local_I;
-    case 2:
+    case AllocatorId::Local_II:
       return OutputResetEventSource::Local_II;
-    case 3:
+    case AllocatorId::Local_Both:
       return OutputResetEventSource::Local_Both;
   }
   return OutputResetEventSource::None;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2010,15 +2010,13 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   else
   {
     // split -> split:
-    const uint32_t count
-        = m_alloc.m_internal_and_external_keys.m_local[0] + (2 * m_alloc.m_internal_and_external_keys.m_local[1]);
-    switch(count)
+    switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys())
     {
-      case 1:
+      case AllocatorId::Local_I:
         return OutputResetEventSource::Local_I;
-      case 2:
+      case AllocatorId::Local_II:
         return OutputResetEventSource::Local_II;
-      case 3:
+      case AllocatorId::Local_Both:
         return OutputResetEventSource::Local_Both;
     }
     return OutputResetEventSource::None;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1664,6 +1664,27 @@ void dsp_host_dual::evalVoiceFadeChg(const uint32_t _layer)
   }
 }
 
+DSPInterface::OutputResetEventSource dsp_host_dual::determineOutputEventSource(const bool _detected,
+                                                                               const LayerMode _type)
+{
+  if(!_detected)
+    return OutputResetEventSource::None;
+  if(_type != LayerMode::Split)
+    return OutputResetEventSource::Global;
+  const uint32_t count
+      = m_alloc.m_internal_and_external_keys.m_local[0] + (2 * m_alloc.m_internal_and_external_keys.m_local[1]);
+  switch(count)
+  {
+    case 1:
+      return OutputResetEventSource::Local_I;
+    case 2:
+      return OutputResetEventSource::Local_II;
+    case 3:
+      return OutputResetEventSource::Local_Both;
+  }
+  return OutputResetEventSource::None;
+}
+
 DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::msg::SinglePresetMessage& _msg)
 {
   auto oldLayerMode = std::exchange(m_layer_mode, LayerMode::Single);
@@ -1677,7 +1698,8 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::
   // update unison and mono groups
   auto polyChanged = evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
   // reset detection
-  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary();
+  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary(fromType(oldLayerMode));
+  const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetected, oldLayerMode);
   if(resetDetected)
   {
     if(LOG_RESET)
@@ -1813,11 +1835,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::
     debugLevels();
   }
   // return detected reset event
-  if(resetDetected)
-  {
-    return oldLayerMode == LayerMode::Split ? OutputResetEventSource::Local_Both : OutputResetEventSource::Global;
-  }
-  return OutputResetEventSource::None;
+  return outputEvent;
 }
 
 DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::msg::SplitPresetMessage& _msg)
@@ -1831,17 +1849,18 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   }
 
   auto msg = &_msg;
-  bool resetDetected[2];
+  bool resetDetected[2] = { false, false };
+  const bool resetDetermined = layerChanged || resetIsNecessary(fromType(oldLayerMode));
+  const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetermined, oldLayerMode);
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
     const auto layer = static_cast<C15::Properties::LayerId>(layerId);
 
     // update unison and mono groups
     auto polyChanged = evalPolyChg(layer, msg->unison[layerId].unisonVoices, msg->mono[layerId].monoEnable);
-
+    resetDetected[layerId] = polyChanged;
     // reset detection
-    resetDetected[layerId] = (layerChanged || polyChanged) && resetIsNecessary();
-    if(resetDetected[layerId])
+    if((layerChanged || polyChanged))
     {
       if(LOG_RESET)
       {
@@ -1976,13 +1995,24 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   {
     debugLevels();
   }
-  // return detected reset event
-  if(resetDetected[0] || resetDetected[1])
+  if(layerChanged)
   {
-    //return oldLayerMode == LayerMode::Split ? OutputResetEventSource::Local_Both : OutputResetEventSource::Global;
-    if(oldLayerMode != LayerMode::Split)
+    // split -> non split:
+    if(resetDetected[1])
+      // active keys in part II, reset possibly both
+      return outputEvent;
+    if(resetDetected[0])
+      // active keys in part I, reset global
       return OutputResetEventSource::Global;
-    switch(resetDetected[0] + (resetDetected[1] << 1))
+    // no active keys
+    return OutputResetEventSource::None;
+  }
+  else
+  {
+    // split -> split:
+    const uint32_t count
+        = m_alloc.m_internal_and_external_keys.m_local[0] + (2 * m_alloc.m_internal_and_external_keys.m_local[1]);
+    switch(count)
     {
       case 1:
         return OutputResetEventSource::Local_I;
@@ -1991,8 +2021,8 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
       case 3:
         return OutputResetEventSource::Local_Both;
     }
+    return OutputResetEventSource::None;
   }
-  return OutputResetEventSource::None;
 }
 
 DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::msg::LayerPresetMessage& _msg)
@@ -2008,7 +2038,8 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::m
   // update unison and mono groups
   auto polyChanged = evalPolyChg(C15::Properties::LayerId::I, msg->unison.unisonVoices, msg->mono.monoEnable);
   // reset detection
-  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary();
+  const bool resetDetected = (layerChanged || polyChanged) && resetIsNecessary(fromType(oldLayerMode));
+  const OutputResetEventSource outputEvent = determineOutputEventSource(resetDetected, oldLayerMode);
   if(resetDetected)
   {
     if(LOG_RESET)
@@ -2150,11 +2181,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::m
     debugLevels();
   }
   // return detected reset event
-  if(resetDetected)
-  {
-    return oldLayerMode == LayerMode::Split ? OutputResetEventSource::Local_Both : OutputResetEventSource::Global;
-  }
-  return OutputResetEventSource::None;
+  return outputEvent;
 }
 
 void dsp_host_dual::globalParRcl(const nltools::msg::ParameterGroups::HardwareSourceParameter& _param)
@@ -2630,7 +2657,15 @@ void dsp_host_dual::resetReturningHWSource(HardwareSource hwui)
   DSPInterface::resetReturningHWSource(hwui);
 }
 
-bool dsp_host_dual::resetIsNecessary()
+bool dsp_host_dual::resetIsNecessary(SoundType _current)
 {
-  return m_alloc.m_assigned_keys > 0;
+  switch(_current)
+  {
+    case SoundType::Layer:
+    case SoundType::Single:
+      return m_alloc.m_internal_and_external_keys.m_global > 0;
+    case SoundType::Split:
+      return (m_alloc.m_internal_and_external_keys.m_local[0] + m_alloc.m_internal_and_external_keys.m_local[1]) > 0;
+  }
+  return false;
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -218,13 +218,12 @@ class dsp_host_dual : public DSPInterface
   {
     switch(_current)
     {
-      case LayerMode::Single:
-        return SoundType::Single;
       case LayerMode::Split:
         return SoundType::Split;
       case LayerMode::Layer:
         return SoundType::Layer;
     }
+    return SoundType::Single;
   }
   // parameters
   Engine::Param_Handle m_params;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -101,7 +101,7 @@ class DSPInterface
   virtual void resetReturningHWSource(HardwareSource hwui)
   {
   }
-  virtual bool resetIsNecessary()
+  virtual bool resetIsNecessary(SoundType _current)
   {
     return true;
   }
@@ -145,7 +145,7 @@ class dsp_host_dual : public DSPInterface
   using SimpleRawMidiMessage = nltools::msg::Midi::SimpleMessage;
   float getReturnValueFor(HardwareSource hwid) override;
   void resetReturningHWSource(HardwareSource hwui) override;
-  bool resetIsNecessary() override;
+  bool resetIsNecessary(SoundType _current) override;
   using MidiOut = std::function<void(const SimpleRawMidiMessage&)>;
 
   void onHWChanged(HardwareSource id, float value, bool didBehaviourChange) override;
@@ -213,8 +213,19 @@ class dsp_host_dual : public DSPInterface
         return VoiceGroup::Invalid;
     }
   }
-
   using LayerMode = C15::Properties::LayerMode;
+  static inline SoundType fromType(const LayerMode& _current)
+  {
+    switch(_current)
+    {
+      case LayerMode::Single:
+        return SoundType::Single;
+      case LayerMode::Split:
+        return SoundType::Split;
+      case LayerMode::Layer:
+        return SoundType::Layer;
+    }
+  }
   // parameters
   Engine::Param_Handle m_params;
   Time_Param m_edit_time, m_transition_time;
@@ -268,6 +279,7 @@ class dsp_host_dual : public DSPInterface
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _unisonVoices,
                    const nltools::msg::ParameterGroups::UnmodulateableParameter& _monoEnable);
   void evalVoiceFadeChg(const uint32_t _layer);
+  OutputResetEventSource determineOutputEventSource(const bool _detected, const LayerMode _type);
   OutputResetEventSource recallSingle(const nltools::msg::SinglePresetMessage& _msg);
   OutputResetEventSource recallSplit(const nltools::msg::SplitPresetMessage& _msg);
   OutputResetEventSource recallLayer(const nltools::msg::LayerPresetMessage& _msg);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -101,7 +101,8 @@ class DSPInterface
   virtual void resetReturningHWSource(HardwareSource hwui)
   {
   }
-  virtual bool resetIsNecessary(SoundType _current)
+  // areKeysPressed
+  virtual bool areKeysPressed(SoundType _current)
   {
     return true;
   }
@@ -145,7 +146,7 @@ class dsp_host_dual : public DSPInterface
   using SimpleRawMidiMessage = nltools::msg::Midi::SimpleMessage;
   float getReturnValueFor(HardwareSource hwid) override;
   void resetReturningHWSource(HardwareSource hwui) override;
-  bool resetIsNecessary(SoundType _current) override;
+  bool areKeysPressed(SoundType _current) override;
   using MidiOut = std::function<void(const SimpleRawMidiMessage&)>;
 
   void onHWChanged(HardwareSource id, float value, bool didBehaviourChange) override;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -64,6 +64,18 @@ struct KeyAssignment
   }
 };
 
+struct AssignedKeyCount  // tracking active keys
+{
+  uint32_t m_global = 0;           // count global (single, layer) number of assigned keys
+  uint32_t m_local[2] = { 0, 0 };  // count local (split) number of assigned keys (each part)
+  void init()
+  {
+    m_global = 0;
+    m_local[0] = 0;
+    m_local[1] = 0;
+  }
+};
+
 struct VoiceAssignment
 {
   uint32_t m_keyNumber = 0, m_inputSourceId = 0;
@@ -272,7 +284,8 @@ class VoiceAllocation
 {
  public:
   PolyKeyPacket<GlobalVoices, PivotKey> m_traversal;
-  uint32_t m_unison = {}, m_assigned_keys = {};
+  AssignedKeyCount m_internal_and_external_keys;  // note: should we need separate int/ext, duplicate
+  uint32_t m_unison = {};
   inline VoiceAllocation()
   {
   }
@@ -291,7 +304,7 @@ class VoiceAllocation
       m_keyState[0][k].m_keyNumber = m_keyState[1][k].m_keyNumber = m_keyState[2][k].m_keyNumber = k;
     }
     //
-    m_assigned_keys = 0;
+    m_internal_and_external_keys.init();
   }
   inline bool onSingleKeyDown(const uint32_t _keyPos, const float _vel, const uint32_t _inputSourceId)
   {
@@ -317,7 +330,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_assigned_keys++;
+        m_internal_and_external_keys.m_global++;
       }
     }
     return validity;
@@ -345,6 +358,7 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
+            m_internal_and_external_keys.m_local[0]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -356,6 +370,7 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
+            m_internal_and_external_keys.m_local[1]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 1, true);
             if(firstVoice != -1)
@@ -367,6 +382,8 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_Both:
             unisonVoices = m_local[0].getUnison();
+            m_internal_and_external_keys.m_local[0]++;
+            m_internal_and_external_keys.m_local[1]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -390,7 +407,6 @@ class VoiceAllocation
         {
           // confirm
           keyDown_confirm(keyState);
-          m_assigned_keys++;
         }
       }
     }
@@ -421,7 +437,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], LocalVoices + firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_assigned_keys++;
+        m_internal_and_external_keys.m_global++;
       }
     }
     return validity;
@@ -446,9 +462,9 @@ class VoiceAllocation
         keyUp_unisonLoop(firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_assigned_keys > 0)
+      if(m_internal_and_external_keys.m_global > 0)
       {
-        m_assigned_keys--;
+        m_internal_and_external_keys.m_global--;
       }
     }
     return validity;
@@ -473,12 +489,20 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
+            if(m_internal_and_external_keys.m_local[0] > 0)
+            {
+              m_internal_and_external_keys.m_local[0]--;
+            }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             // unison loop
             keyUp_unisonLoop(firstVoice, unisonVoices);
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
+            if(m_internal_and_external_keys.m_local[1] > 0)
+            {
+              m_internal_and_external_keys.m_local[1]--;
+            }
             firstVoice = keyUp_process_part(keyState, 1, true) * unisonVoices;
             // unison loop
             keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
@@ -486,20 +510,24 @@ class VoiceAllocation
           case AllocatorId::Local_Both:
             // part[I]
             unisonVoices = m_local[0].getUnison();
+            if(m_internal_and_external_keys.m_local[0] > 0)
+            {
+              m_internal_and_external_keys.m_local[0]--;
+            }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             keyUp_unisonLoop(firstVoice, unisonVoices);
             // part[II]
             unisonVoices = m_local[1].getUnison();
+            if(m_internal_and_external_keys.m_local[1] > 0)
+            {
+              m_internal_and_external_keys.m_local[1]--;
+            }
             firstVoice = keyUp_process_part(keyState, 1, false) * unisonVoices;
             keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
             break;
         }
       }
       keyUp_confirm(keyState);
-      if(m_assigned_keys > 0)
-      {
-        m_assigned_keys--;
-      }
     }
     return validity;
   }
@@ -524,9 +552,9 @@ class VoiceAllocation
         keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_assigned_keys > 0)
+      if(m_internal_and_external_keys.m_global > 0)
       {
-        m_assigned_keys--;
+        m_internal_and_external_keys.m_global--;
       }
     }
     return validity;
@@ -545,7 +573,23 @@ class VoiceAllocation
         // store key assignment with determined association without allocating voices
         keyState->m_active = true;
         keyState->m_origin = _determinedPart;
-        m_assigned_keys++;
+        switch(_determinedPart)
+        {
+          case AllocatorId::Local_I:
+            m_internal_and_external_keys.m_local[0]++;
+            break;
+          case AllocatorId::Local_II:
+            m_internal_and_external_keys.m_local[1]++;
+            break;
+          case AllocatorId::Local_Both:
+            m_internal_and_external_keys.m_local[0]++;
+            m_internal_and_external_keys.m_local[1]++;
+            break;
+          case AllocatorId::Global:
+          case AllocatorId::Dual:
+            m_internal_and_external_keys.m_global++;
+            break;
+        }
       }
     }
     return validity;
@@ -563,11 +607,39 @@ class VoiceAllocation
       {
         // reset key assignment with determined association without de-allocating voices
         keyState->m_active = false;
-        keyState->m_origin = AllocatorId::None;
-        if(m_assigned_keys > 0)
+        switch(keyState->m_origin)
         {
-          m_assigned_keys--;
+          case AllocatorId::Local_I:
+            if(m_internal_and_external_keys.m_local[0] > 0)
+            {
+              m_internal_and_external_keys.m_local[0]--;
+            }
+            break;
+          case AllocatorId::Local_II:
+            if(m_internal_and_external_keys.m_local[1] > 0)
+            {
+              m_internal_and_external_keys.m_local[1]--;
+            }
+            break;
+          case AllocatorId::Local_Both:
+            if(m_internal_and_external_keys.m_local[0] > 0)
+            {
+              m_internal_and_external_keys.m_local[0]--;
+            }
+            if(m_internal_and_external_keys.m_local[1] > 0)
+            {
+              m_internal_and_external_keys.m_local[1]--;
+            }
+            break;
+          case AllocatorId::Global:
+          case AllocatorId::Dual:
+            if(m_internal_and_external_keys.m_global > 0)
+            {
+              m_internal_and_external_keys.m_global--;
+            }
+            break;
         }
+        keyState->m_origin = AllocatorId::None;
       }
     }
     return validity;
@@ -691,7 +763,7 @@ class VoiceAllocation
         keyState.m_origin = AllocatorId::None;
       }
     }
-    m_assigned_keys = 0;
+    m_internal_and_external_keys.init();
   }
 
   inline AllocatorId getSplitPartForKeyDown(const uint32_t _key)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -74,6 +74,24 @@ struct AssignedKeyCount  // tracking active keys
     m_local[0] = 0;
     m_local[1] = 0;
   }
+  AllocatorId pressedGlobalKeys()
+  {
+    return m_global > 0 ? AllocatorId::Global : AllocatorId::None;
+  }
+  AllocatorId pressedLocalKeys()
+  {
+    const uint32_t count = (m_local[0] > 0) + (2 * (m_local[1] > 0));
+    switch(count)
+    {
+      case 1:
+        return AllocatorId::Local_I;
+      case 2:
+        return AllocatorId::Local_II;
+      case 3:
+        return AllocatorId::Local_Both;
+    }
+    return AllocatorId::None;
+  }
 };
 
 struct VoiceAssignment

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -1110,7 +1110,7 @@ template <typename tChannelEnum> void InputEventStage::doSendAllNotesOff(tChanne
     m_midiOut({ static_cast<uint8_t>(CCModeChange | iChannel), CCNum, 0 });
   }
 }
-// QUESTION: do we need to check the new/old message (was already checked, we just need the OutputRestEventSource (?)
+
 void InputEventStage::doExternalReset(const tMSG newMessage, const tMSG oldMessage)
 {
   const auto isSplit = m_dspHost->getType() == SoundType::Split;

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -1016,7 +1016,7 @@ bool InputEventStage::didRelevantSectionsChange(const InputEventStage::tMSG &msg
 
 void InputEventStage::onMidiSettingsMessageWasReceived(const tMSG &msg, const tMSG &oldmsg)
 {
-  if(didRelevantSectionsChange(msg, oldmsg) && m_dspHost->resetIsNecessary(m_dspHost->getType()))
+  if(didRelevantSectionsChange(msg, oldmsg) && m_dspHost->areKeysPressed(m_dspHost->getType()))
   {
     doInternalReset();
     doExternalReset(msg, oldmsg);

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -7,14 +7,14 @@ InputEventStage::InputEventStage(DSPInterface *dspHost, MidiRuntimeOptions *opti
                                  InputEventStage::MIDIOut outCB, InputEventStage::ChannelModeMessageCB specialCB)
     : m_tcdDecoder(dspHost, options, &m_shifteable_keys)
     , m_midiDecoder(dspHost, options)
-    , m_dspHost { dspHost }
-    , m_options { options }
+    , m_dspHost{ dspHost }
+    , m_options{ options }
     , m_hwChangedCB(std::move(hwChangedCB))
     , m_channelModeMessageCB(std::move(specialCB))
-    , m_midiOut { std::move(outCB) }
+    , m_midiOut{ std::move(outCB) }
 {
   std::fill(m_latchedHWPositions.begin(), m_latchedHWPositions.end(),
-            std::array<uint16_t, 2> { std::numeric_limits<uint16_t>::max(), std::numeric_limits<uint16_t>::max() });
+            std::array<uint16_t, 2>{ std::numeric_limits<uint16_t>::max(), std::numeric_limits<uint16_t>::max() });
 }
 
 template <>
@@ -1016,7 +1016,7 @@ bool InputEventStage::didRelevantSectionsChange(const InputEventStage::tMSG &msg
 
 void InputEventStage::onMidiSettingsMessageWasReceived(const tMSG &msg, const tMSG &oldmsg)
 {
-  if(didRelevantSectionsChange(msg, oldmsg) && m_dspHost->resetIsNecessary())
+  if(didRelevantSectionsChange(msg, oldmsg) && m_dspHost->resetIsNecessary(m_dspHost->getType()))
   {
     doInternalReset();
     doExternalReset(msg, oldmsg);
@@ -1110,7 +1110,7 @@ template <typename tChannelEnum> void InputEventStage::doSendAllNotesOff(tChanne
     m_midiOut({ static_cast<uint8_t>(CCModeChange | iChannel), CCNum, 0 });
   }
 }
-
+// QUESTION: do we need to check the new/old message (was already checked, we just need the OutputRestEventSource (?)
 void InputEventStage::doExternalReset(const tMSG newMessage, const tMSG oldMessage)
 {
   const auto isSplit = m_dspHost->getType() == SoundType::Split;

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.h
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.h
@@ -110,7 +110,7 @@ class InputEventStage
   MIDIOut m_midiOut;
   KeyShift m_shifteable_keys;
   constexpr static auto NUM_HW = 8;
-  std::array<std::array<uint16_t, 2>, NUM_HW> m_latchedHWPositions {};
+  std::array<std::array<uint16_t, 2>, NUM_HW> m_latchedHWPositions{};
 
   using tHWPosEntry = std::tuple<float, HWChangeSource>;
   std::array<tHWPosEntry, NUM_HW> m_localDisabledPositions;


### PR DESCRIPTION
Recall Events of Single, Split and Layer Presets now act based on the old Preset Type, when Reset was detected. In Split Sounds loaded into Split Sounds, the reset is further influenced by Mono and Unison changes per part (based on the new Preset). A Reset Event will be canceled, if no corresponding keys are active.