### PR TITLE
part aware reset behavior - addendum

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1995,30 +1995,34 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   }
   if(layerChanged)
   {
-    // split -> non split:
-    if(resetDetected[1])
-      // active keys in part II, reset possibly both
-      return outputEvent;
-    if(resetDetected[0])
-      // active keys in part I, reset global
-      return OutputResetEventSource::Global;
-    // no active keys
-    return OutputResetEventSource::None;
+    // non-split -> split: (global or none)
+    return outputEvent;
   }
   else
   {
     // split -> split:
-    switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys())
+    switch(outputEvent)
     {
-      case AllocatorId::Local_I:
-        return OutputResetEventSource::Local_I;
-      case AllocatorId::Local_II:
-        return OutputResetEventSource::Local_II;
-      case AllocatorId::Local_Both:
-        return OutputResetEventSource::Local_Both;
+      case OutputResetEventSource::Local_I:
+        // keys pressed in I - reset detected in I?
+        return resetDetected[0] ? outputEvent : OutputResetEventSource::None;
+      case OutputResetEventSource::Local_II:
+        // keys pressed in II - reset detected in II?
+        return resetDetected[1] ? outputEvent : OutputResetEventSource::None;
+      case OutputResetEventSource::Local_Both:
+        // keys pressed in both - reset detected in both?
+        switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys(resetDetected[0], resetDetected[1]))
+        {
+          case AllocatorId::Local_I:
+            return OutputResetEventSource::Local_I;
+          case AllocatorId::Local_II:
+            return OutputResetEventSource::Local_II;
+          case AllocatorId::Local_Both:
+            return OutputResetEventSource::Local_Both;
+        }
     }
-    return OutputResetEventSource::None;
   }
+  return OutputResetEventSource::None;
 }
 
 DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::msg::LayerPresetMessage& _msg)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -80,7 +80,11 @@ struct AssignedKeyCount  // tracking active keys
   }
   AllocatorId pressedLocalKeys()
   {
-    const uint32_t count = (m_local[0] > 0) + (2 * (m_local[1] > 0));
+    return pressedLocalKeys(m_local[0] > 0, m_local[1] > 0);
+  }
+  AllocatorId pressedLocalKeys(const bool _partI, const bool _partII)
+  {
+    const uint32_t count = _partI + (2 * _partII);
     switch(count)
     {
       case 1:


### PR DESCRIPTION
I spotted a flaw in the reset behavior when recalling Split Sounds.
As it turns out, the logic behind the reset detection gets rather complicated.

Here is an attempt to describe the current behavior:

1. LayerChanged: Has the Sound Type changed? (if yes: case non-split -> split, otherwise: case split -> split) (the voice allocation will reset if LayerChanfed)
2. Are keys pressed (depending on the old sound type)?
3. PolyChanged: While loading the parts: did Unison or Mono change in a part? (if yes, the voice allocation will reset for that part)
4. After loading the parameters: did the Sound Type change? (if yes: return outputResetEvent according to 2., otherwise: combine pressed keys with PolyChanged reflecting the parts)