### PR TITLE
fix non-local key assignments

### DIFF
--- a/projects/epc/acceptance-tests/src/mock/MockDSPHosts.cpp
+++ b/projects/epc/acceptance-tests/src/mock/MockDSPHosts.cpp
@@ -42,11 +42,11 @@ VoiceGroup MockDSPHost::getNonLocalSplitKeyAssignmentForKeyUp(int key)
   return VoiceGroup::I;
 }
 
-void MockDSPHost::registerNonLocalSplitKeyAssignment(const int note, VoiceGroup part)
+void MockDSPHost::registerNonLocalKeyAssignment(const int note, VoiceGroup part)
 {
 }
 
-void MockDSPHost::unregisterNonLocalSplitKeyAssignment(const int note)
+void MockDSPHost::unregisterNonLocalKeyAssignment(const int note)
 {
 }
 

--- a/projects/epc/acceptance-tests/src/mock/MockDSPHosts.h
+++ b/projects/epc/acceptance-tests/src/mock/MockDSPHosts.h
@@ -13,8 +13,8 @@ class MockDSPHost : public DSPInterface
   VoiceGroup getSplitPartForKeyDown(int key) override;
   VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
   VoiceGroup getNonLocalSplitKeyAssignmentForKeyUp(int key) override;
-  void registerNonLocalSplitKeyAssignment(const int note, VoiceGroup part) override;
-  void unregisterNonLocalSplitKeyAssignment(const int note) override;
+  void registerNonLocalKeyAssignment(const int note, VoiceGroup part) override;
+  void unregisterNonLocalKeyAssignment(const int note) override;
   void onKeyDownSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   void onKeyUpSplit(const int note, float velocity, VoiceGroup part, InputEventSource from) override;
   void fadeOutResetVoiceAllocAndEnvelopes() override;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -2514,21 +2514,21 @@ VoiceGroup dsp_host_dual::getNonLocalSplitKeyAssignmentForKeyUp(int key)
   return getVoiceGroupFromAllocatorId(allocID);
 }
 
-void dsp_host_dual::registerNonLocalSplitKeyAssignment(const int note, VoiceGroup part)
+void dsp_host_dual::registerNonLocalKeyAssignment(const int note, VoiceGroup part)
 {
-  // register key assignment despite local off (similar to splitKeyDown, but not quite)
+  // register key assignment despite local off (similar to keyDown/splitKeyDown, but not quite)
   if(m_layer_mode == LayerMode::Split)
   {
     switch(part)
     {
       case VoiceGroup::I:  // applies to Part I only
-        m_alloc.registerNonLocalSplitKeyAssignment(note, AllocatorId::Local_I);
+        m_alloc.registerNonLocalKeyAssignment(note, AllocatorId::Local_I);
         break;
       case VoiceGroup::II:  // applies to Part II only
-        m_alloc.registerNonLocalSplitKeyAssignment(note, AllocatorId::Local_II);
+        m_alloc.registerNonLocalKeyAssignment(note, AllocatorId::Local_II);
         break;
       case VoiceGroup::Global:  // applies to both Parts I, II at once
-        m_alloc.registerNonLocalSplitKeyAssignment(note, AllocatorId::Local_Both);
+        m_alloc.registerNonLocalKeyAssignment(note, AllocatorId::Local_Both);
         break;
       default:
       case VoiceGroup::NumGroups:
@@ -2536,12 +2536,16 @@ void dsp_host_dual::registerNonLocalSplitKeyAssignment(const int note, VoiceGrou
         break;
     }
   }
+  else
+  {
+    m_alloc.registerNonLocalKeyAssignment(note, AllocatorId::Global);
+  }
 }
 
-void dsp_host_dual::unregisterNonLocalSplitKeyAssignment(const int note)
+void dsp_host_dual::unregisterNonLocalKeyAssignment(const int note)
 {
-  // unregister key assignment despite local off (similar to splitKeyUp, but not quite)
-  m_alloc.unregisterNonLocalSplitKeyAssignment(note);
+  // unregister key assignment despite local off (similar to keyUp/splitKeyUp, but not quite)
+  m_alloc.unregisterNonLocalKeyAssignment(note);
 }
 
 void dsp_host_dual::onKeyDown(const int note, float velocity, InputEventSource from)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -707,7 +707,7 @@ DSPInterface::OutputResetEventSource
       m_poly[layerId].m_key_active = 0;
       if(m_layer_mode != LayerMode::Split)
       {
-        m_alloc.m_internal_and_external_keys.m_global = 0;
+        m_alloc.m_local_and_nonlocal_keys.m_global = 0;
         // apply reset to other poly components (when not in split mode)
         const uint32_t lId = 1 - layerId;
         m_poly[lId].resetEnvelopes();
@@ -716,7 +716,7 @@ DSPInterface::OutputResetEventSource
       }
       else
       {
-        m_alloc.m_internal_and_external_keys.m_local[layerId] = 0;
+        m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;
       }
     });
     // return detected reset event
@@ -764,7 +764,7 @@ DSPInterface::OutputResetEventSource
       m_poly[layerId].m_key_active = 0;
       if(m_layer_mode != LayerMode::Split)
       {
-        m_alloc.m_internal_and_external_keys.m_global = 0;
+        m_alloc.m_local_and_nonlocal_keys.m_global = 0;
         // apply reset to other poly components (when not in split mode)
         const uint32_t lId = 1 - layerId;
         m_poly[lId].resetEnvelopes();
@@ -772,7 +772,7 @@ DSPInterface::OutputResetEventSource
       }
       else
       {
-        m_alloc.m_internal_and_external_keys.m_local[layerId] = 0;
+        m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;
       }
     });
     // return detected reset event
@@ -1702,7 +1702,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::determineOutputEventSource(c
     return OutputResetEventSource::None;
   if(_type != LayerMode::Split)
     return OutputResetEventSource::Global;
-  switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys())
+  switch(m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys())
   {
     case AllocatorId::Local_I:
       return OutputResetEventSource::Local_I;
@@ -1736,7 +1736,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::
     {
       nltools::Log::info("recall single voice reset");
     }
-    m_alloc.m_internal_and_external_keys.init();  // reset all pressed keys
+    m_alloc.m_local_and_nonlocal_keys.init();  // reset all pressed keys
     m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position, oldLayerMode,
                       m_layer_mode);
     m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position, m_layer_mode);
@@ -1897,7 +1897,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
       {
         nltools::Log::info("recall split voice reset(layerId:", layerId, ")");
       }
-      m_alloc.m_internal_and_external_keys.m_local[layerId] = 0;  // reset all pressed keys in part
+      m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;  // reset all pressed keys in part
       m_alloc.setUnison(layerId, m_params.get_local_unison_voices(layer)->m_position, oldLayerMode, m_layer_mode);
       m_alloc.setMonoEnable(layerId, m_params.get_local_mono_enable(layer)->m_position, m_layer_mode);
       const uint32_t uVoice = m_alloc.m_unison - 1;
@@ -2029,7 +2029,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   }
   if(layerChanged)
   {
-    m_alloc.m_internal_and_external_keys.m_global = 0;  // reset all pressed global keys
+    m_alloc.m_local_and_nonlocal_keys.m_global = 0;  // reset all pressed global keys
     // non-split -> split: (global or none)
     return outputEvent;
   }
@@ -2046,7 +2046,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
         return resetDetected[1] ? outputEvent : OutputResetEventSource::None;
       case OutputResetEventSource::Local_Both:
         // keys pressed in both - reset detected in both?
-        switch(m_alloc.m_internal_and_external_keys.pressedLocalKeys(resetDetected[0], resetDetected[1]))
+        switch(m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys(resetDetected[0], resetDetected[1]))
         {
           case AllocatorId::Local_I:
             return OutputResetEventSource::Local_I;
@@ -2082,7 +2082,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::m
     {
       nltools::Log::info("recall layer voice reset");
     }
-    m_alloc.m_internal_and_external_keys.init();  // reset all pressed keys
+    m_alloc.m_local_and_nonlocal_keys.init();  // reset all pressed keys
     m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position, oldLayerMode,
                       m_layer_mode);
     m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position, m_layer_mode);
@@ -2704,9 +2704,9 @@ bool dsp_host_dual::areKeysPressed(SoundType _current)
   {
     case SoundType::Layer:
     case SoundType::Single:
-      return m_alloc.m_internal_and_external_keys.m_global > 0;
+      return m_alloc.m_local_and_nonlocal_keys.m_global > 0;
     case SoundType::Split:
-      return (m_alloc.m_internal_and_external_keys.m_local[0] + m_alloc.m_internal_and_external_keys.m_local[1]) > 0;
+      return (m_alloc.m_local_and_nonlocal_keys.m_local[0] + m_alloc.m_local_and_nonlocal_keys.m_local[1]) > 0;
   }
   return false;
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -91,8 +91,8 @@ class DSPInterface
   virtual VoiceGroup getSplitPartForKeyDown(int key) = 0;
   virtual VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) = 0;
   virtual VoiceGroup getNonLocalSplitKeyAssignmentForKeyUp(int key) = 0;
-  virtual void registerNonLocalSplitKeyAssignment(const int note, VoiceGroup part) = 0;
-  virtual void unregisterNonLocalSplitKeyAssignment(const int note) = 0;
+  virtual void registerNonLocalKeyAssignment(const int note, VoiceGroup part) = 0;
+  virtual void unregisterNonLocalKeyAssignment(const int note) = 0;
   virtual void fadeOutResetVoiceAllocAndEnvelopes() = 0;
   virtual float getReturnValueFor(HardwareSource hwid)
   {
@@ -190,8 +190,8 @@ class dsp_host_dual : public DSPInterface
   VoiceGroup getSplitPartForKeyDown(int key) override;
   VoiceGroup getSplitPartForKeyUp(int key, InputEventSource from) override;
   VoiceGroup getNonLocalSplitKeyAssignmentForKeyUp(int key) override;
-  void registerNonLocalSplitKeyAssignment(const int note, VoiceGroup part) override;
-  void unregisterNonLocalSplitKeyAssignment(const int note) override;
+  void registerNonLocalKeyAssignment(const int note, VoiceGroup part) override;
+  void unregisterNonLocalKeyAssignment(const int note) override;
 
   using CC_Range_7_Bit = Midi::FullCCRange<Midi::Formats::_7_Bits_>;
   using CC_Range_14_Bit = Midi::clipped14BitCCRange;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -581,7 +581,7 @@ class VoiceAllocation
     }
     return validity;
   }
-  inline bool registerNonLocalSplitKeyAssignment(const uint32_t _keyPos, const AllocatorId _determinedPart)
+  inline bool registerNonLocalKeyAssignment(const uint32_t _keyPos, const AllocatorId _determinedPart)
   {
     // validation 1 - keyPos_in_range ?
     bool validity = _keyPos < Keys;
@@ -608,7 +608,6 @@ class VoiceAllocation
             m_internal_and_external_keys.m_local[1]++;
             break;
           case AllocatorId::Global:
-          case AllocatorId::Dual:
             m_internal_and_external_keys.m_global++;
             break;
         }
@@ -616,7 +615,7 @@ class VoiceAllocation
     }
     return validity;
   }
-  inline bool unregisterNonLocalSplitKeyAssignment(const uint32_t _keyPos)
+  inline bool unregisterNonLocalKeyAssignment(const uint32_t _keyPos)
   {
     // validation 1 - keyPos_in_range ?
     bool validity = _keyPos < Keys;
@@ -654,7 +653,6 @@ class VoiceAllocation
             }
             break;
           case AllocatorId::Global:
-          case AllocatorId::Dual:
             if(m_internal_and_external_keys.m_global > 0)
             {
               m_internal_and_external_keys.m_global--;

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -306,7 +306,7 @@ class VoiceAllocation
 {
  public:
   PolyKeyPacket<GlobalVoices, PivotKey> m_traversal;
-  AssignedKeyCount m_internal_and_external_keys;  // note: should we need separate int/ext, duplicate
+  AssignedKeyCount m_local_and_nonlocal_keys;  // note: should we need separate loc/non-loc, duplicate
   uint32_t m_unison = {};
   inline VoiceAllocation()
   {
@@ -326,7 +326,7 @@ class VoiceAllocation
       m_keyState[0][k].m_keyNumber = m_keyState[1][k].m_keyNumber = m_keyState[2][k].m_keyNumber = k;
     }
     //
-    m_internal_and_external_keys.init();
+    m_local_and_nonlocal_keys.init();
   }
   inline bool onSingleKeyDown(const uint32_t _keyPos, const float _vel, const uint32_t _inputSourceId)
   {
@@ -352,7 +352,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_internal_and_external_keys.m_global++;
+        m_local_and_nonlocal_keys.m_global++;
       }
     }
     return validity;
@@ -380,7 +380,7 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
-            m_internal_and_external_keys.m_local[0]++;
+            m_local_and_nonlocal_keys.m_local[0]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -392,7 +392,7 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
-            m_internal_and_external_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[1]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 1, true);
             if(firstVoice != -1)
@@ -404,8 +404,8 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_Both:
             unisonVoices = m_local[0].getUnison();
-            m_internal_and_external_keys.m_local[0]++;
-            m_internal_and_external_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[0]++;
+            m_local_and_nonlocal_keys.m_local[1]++;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -459,7 +459,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], LocalVoices + firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_internal_and_external_keys.m_global++;
+        m_local_and_nonlocal_keys.m_global++;
       }
     }
     return validity;
@@ -484,9 +484,9 @@ class VoiceAllocation
         keyUp_unisonLoop(firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_internal_and_external_keys.m_global > 0)
+      if(m_local_and_nonlocal_keys.m_global > 0)
       {
-        m_internal_and_external_keys.m_global--;
+        m_local_and_nonlocal_keys.m_global--;
       }
     }
     return validity;
@@ -511,9 +511,9 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
-            if(m_internal_and_external_keys.m_local[0] > 0)
+            if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_internal_and_external_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0]--;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             // unison loop
@@ -521,9 +521,9 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
-            if(m_internal_and_external_keys.m_local[1] > 0)
+            if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_internal_and_external_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1]--;
             }
             firstVoice = keyUp_process_part(keyState, 1, true) * unisonVoices;
             // unison loop
@@ -532,17 +532,17 @@ class VoiceAllocation
           case AllocatorId::Local_Both:
             // part[I]
             unisonVoices = m_local[0].getUnison();
-            if(m_internal_and_external_keys.m_local[0] > 0)
+            if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_internal_and_external_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0]--;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             keyUp_unisonLoop(firstVoice, unisonVoices);
             // part[II]
             unisonVoices = m_local[1].getUnison();
-            if(m_internal_and_external_keys.m_local[1] > 0)
+            if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_internal_and_external_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1]--;
             }
             firstVoice = keyUp_process_part(keyState, 1, false) * unisonVoices;
             keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
@@ -574,9 +574,9 @@ class VoiceAllocation
         keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_internal_and_external_keys.m_global > 0)
+      if(m_local_and_nonlocal_keys.m_global > 0)
       {
-        m_internal_and_external_keys.m_global--;
+        m_local_and_nonlocal_keys.m_global--;
       }
     }
     return validity;
@@ -587,7 +587,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
-      PrimitiveKeyAssignment* keyState = &m_externalKeyState[_keyPos];
+      PrimitiveKeyAssignment* keyState = &m_nonlocal_keystate[_keyPos];
       // validation 2 - key_released ?
       validity = !keyState->m_active;
       if(validity)
@@ -598,17 +598,17 @@ class VoiceAllocation
         switch(_determinedPart)
         {
           case AllocatorId::Local_I:
-            m_internal_and_external_keys.m_local[0]++;
+            m_local_and_nonlocal_keys.m_local[0]++;
             break;
           case AllocatorId::Local_II:
-            m_internal_and_external_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[1]++;
             break;
           case AllocatorId::Local_Both:
-            m_internal_and_external_keys.m_local[0]++;
-            m_internal_and_external_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[0]++;
+            m_local_and_nonlocal_keys.m_local[1]++;
             break;
           case AllocatorId::Global:
-            m_internal_and_external_keys.m_global++;
+            m_local_and_nonlocal_keys.m_global++;
             break;
         }
       }
@@ -621,7 +621,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
-      PrimitiveKeyAssignment* keyState = &m_externalKeyState[_keyPos];
+      PrimitiveKeyAssignment* keyState = &m_nonlocal_keystate[_keyPos];
       // validation 2 - key_pressed ?
       validity = keyState->m_active;
       if(validity)
@@ -631,31 +631,31 @@ class VoiceAllocation
         switch(keyState->m_origin)
         {
           case AllocatorId::Local_I:
-            if(m_internal_and_external_keys.m_local[0] > 0)
+            if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_internal_and_external_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0]--;
             }
             break;
           case AllocatorId::Local_II:
-            if(m_internal_and_external_keys.m_local[1] > 0)
+            if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_internal_and_external_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1]--;
             }
             break;
           case AllocatorId::Local_Both:
-            if(m_internal_and_external_keys.m_local[0] > 0)
+            if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_internal_and_external_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0]--;
             }
-            if(m_internal_and_external_keys.m_local[1] > 0)
+            if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_internal_and_external_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1]--;
             }
             break;
           case AllocatorId::Global:
-            if(m_internal_and_external_keys.m_global > 0)
+            if(m_local_and_nonlocal_keys.m_global > 0)
             {
-              m_internal_and_external_keys.m_global--;
+              m_local_and_nonlocal_keys.m_global--;
             }
             break;
         }
@@ -775,7 +775,7 @@ class VoiceAllocation
   inline void reset()
   {
     clear_keyState();
-    for(PrimitiveKeyAssignment& keyState : m_externalKeyState)
+    for(PrimitiveKeyAssignment& keyState : m_nonlocal_keystate)
     {
       if(keyState.m_active)
       {
@@ -783,7 +783,7 @@ class VoiceAllocation
         keyState.m_origin = AllocatorId::None;
       }
     }
-    m_internal_and_external_keys.init();
+    m_local_and_nonlocal_keys.init();
   }
 
   inline AllocatorId getSplitPartForKeyDown(const uint32_t _key)
@@ -812,7 +812,7 @@ class VoiceAllocation
 
   inline AllocatorId getNonlocalSplitPartForKeyUp(const uint32_t _keyPos)
   {
-    PrimitiveKeyAssignment* keyState = &m_externalKeyState[_keyPos];
+    PrimitiveKeyAssignment* keyState = &m_nonlocal_keystate[_keyPos];
     return keyState->m_origin;
   }
 
@@ -822,7 +822,7 @@ class VoiceAllocation
   MonoVoiceAllocator<Keys> m_global_mono;
   MonoVoiceAllocator<Keys> m_local_mono[2];
   KeyAssignment m_keyState[3][Keys];
-  PrimitiveKeyAssignment m_externalKeyState[Keys];
+  PrimitiveKeyAssignment m_nonlocal_keystate[Keys];
   VoiceAssignment m_voiceState[GlobalVoices];
   uint32_t m_localIndex[GlobalVoices] = {}, m_localVoice[GlobalVoices] = {}, m_splitPoint[2] = {};
   bool m_glideAllowance[GlobalVoices] = {};

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -118,9 +118,9 @@ void InputEventStage::onTCDEvent()
 
         setAndScheduleKeybedNotify();
       }
-      else if(isSplitSound)
+      else
       {
-        m_dspHost->registerNonLocalSplitKeyAssignment(decoder->getKeyOrController(), determinedPart);
+        m_dspHost->registerNonLocalKeyAssignment(decoder->getKeyOrController(), determinedPart);
       }
 
       if((m_options->shouldSendMIDINotesOnSplit() || m_options->shouldSendMIDINotesOnPrimary()) && soundValid)
@@ -155,9 +155,9 @@ void InputEventStage::onTCDEvent()
 
         setAndScheduleKeybedNotify();
       }
-      else if(isSplitSound)
+      else
       {
-        m_dspHost->unregisterNonLocalSplitKeyAssignment(key);
+        m_dspHost->unregisterNonLocalKeyAssignment(key);
       }
 
       if((m_options->shouldSendMIDINotesOnSplit() || m_options->shouldSendMIDINotesOnPrimary()) && soundValid)


### PR DESCRIPTION
Reworked non-local key assignments to be counted with any Sound Type.

I see potential for further cleanup (which can be discussed) and would like to verify the fix with a test build.

**"Holzhammer" Limitations**: there is no distinction between *internal* (LPC) and *external* (MIDI) keys for the key counter. Consider holding a MIDI Note and change Reset-relevant Parameters, Presets or Settings - an AllNotesOff will be observable (despite not being necessary).

fixes #2939
fixes #2831