### PR TITLE
closes #2284

### DIFF
--- a/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
+++ b/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
@@ -18,9 +18,6 @@ Glib::ustring PresetManagerMetadataSerializer::getTagName()
 
 void PresetManagerMetadataSerializer::writeTagContent(Writer &writer) const
 {
-  writer.writeTextElement("selected-bank-uuid", m_pm->getSelectedBankUuid().raw());
-  writer.writeTextElement("selected-midi-bank-uuid", m_pm->getMidiSelectedBank().raw());
-
   EditBufferSerializer eb(m_pm->getEditBuffer(), getProgressCB());
   eb.write(writer);
 
@@ -30,14 +27,6 @@ void PresetManagerMetadataSerializer::writeTagContent(Writer &writer) const
 
 void PresetManagerMetadataSerializer::readTagContent(Reader &reader) const
 {
-  reader.onTextElement("selected-bank-uuid", [&](const auto &text, const auto &) {
-    m_pm->selectBank(reader.getTransaction(), Uuid { text });
-  });
-
-  reader.onTextElement("selected-midi-bank-uuid", [&](const auto &text, const auto &) {
-    m_pm->selectMidiBank(reader.getTransaction(), Uuid { text });
-  });
-
   reader.onTag(EditBufferSerializer::getTagName(),
                [&](const auto &) mutable { return new EditBufferSerializer(m_pm->getEditBuffer(), getProgressCB()); });
 

--- a/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
+++ b/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
@@ -27,6 +27,14 @@ void PresetManagerMetadataSerializer::writeTagContent(Writer &writer) const
 
 void PresetManagerMetadataSerializer::readTagContent(Reader &reader) const
 {
+  reader.onTextElement("selected-bank-uuid",
+                       [&](const auto &text, const auto &)
+                       { m_pm->selectBank(reader.getTransaction(), Uuid { text }); });
+
+  reader.onTextElement("selected-midi-bank-uuid",
+                       [&](const auto &text, const auto &)
+                       { m_pm->selectMidiBank(reader.getTransaction(), Uuid { text }); });
+
   reader.onTag(EditBufferSerializer::getTagName(),
                [&](const auto &) mutable { return new EditBufferSerializer(m_pm->getEditBuffer(), getProgressCB()); });
 

--- a/projects/epc/playground/src/serialization/PresetManagerSerializer.cpp
+++ b/projects/epc/playground/src/serialization/PresetManagerSerializer.cpp
@@ -23,6 +23,7 @@ void PresetManagerSerializer::writeTagContent(Writer &writer) const
 {
   writer.writeTextElement("serialize-date", TimeTools::getAdjustedIso());
   writer.writeTextElement("selected-bank-uuid", m_pm->getSelectedBankUuid().raw());
+  writer.writeTextElement("selected-midi-bank-uuid", m_pm->getMidiSelectedBank().raw());
 
   addStatus("Writing PresetManager");
 
@@ -38,6 +39,10 @@ void PresetManagerSerializer::readTagContent(Reader &reader) const
 
   reader.onTextElement("selected-bank-uuid", [&](const auto &text, const auto &) {
     m_pm->selectBank(reader.getTransaction(), Uuid { text });
+  });
+
+  reader.onTextElement("selected-midi-bank-uuid", [&](const auto &text, const auto&) {
+    m_pm->selectMidiBank(reader.getTransaction(), Uuid { text });
   });
 
   reader.onTag(PresetBankSerializer::getTagName(), [&](const auto &) mutable {

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue2284.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue2284.cpp
@@ -1,0 +1,48 @@
+#include <testing/TestHelper.h>
+#include <presets/EditBuffer.h>
+#include <presets/Bank.h>
+#include <presets/Preset.h>
+#include <parameter_declarations.h>
+#include <use-cases/PresetUseCases.h>
+#include <proxies/hwui/panel-unit/boled/setup/ExportBackupEditor.h>
+#include "xml/MemoryOutStream.h"
+#include "xml/MemoryInStream.h"
+#include "xml/FileOutStream.h"
+
+TEST_CASE("Export Backup with MIDI Bank exports MIDI UUID")
+{
+  auto pm = TestHelper::getPresetManager();
+  auto settings = TestHelper::getSettings();
+  PresetManagerUseCases pmUseCases(*pm, *settings);
+  auto bank = pmUseCases.createBankAndStoreEditBuffer();
+  pmUseCases.selectMidiBank(bank);
+
+  CHECK(bank->isMidiSelectedBank());
+
+  const auto fileName = "/tmp/issue-2284.xml";
+
+  std::filesystem::remove(fileName);
+
+  {
+    FileOutStream outStream(fileName, false);
+    ExportBackupEditor::writeBackupToStream(outStream);
+  }
+
+  auto oldNumBanks = pm->getNumBanks();
+  auto uuidOfBank = bank->getUuid();
+
+  pmUseCases.clear();
+
+
+  CHECK(pm->findBank(uuidOfBank) == nullptr);
+
+  {
+    FileInStream inStream(fileName, false);
+    pmUseCases.importBackupFile(inStream, {}, TestHelper::getAudioEngineProxy());
+  }
+
+  REQUIRE(pm->getNumBanks() == oldNumBanks);
+  REQUIRE(pm->findBank(uuidOfBank) != nullptr);
+  bank = pm->findBank(uuidOfBank);
+  CHECK(bank->isMidiSelectedBank());
+}


### PR DESCRIPTION
move selected bank and midi uuid attributes to presetmanager serializer instead of metadata serializer as the metadata is not exported to a backup, selected-bank-uuid was redundant anyways

closes #2284 