### PR TITLE
fix buffer underruns on epc2

### DIFF
--- a/projects/epc/audio-engine/system/audio-engine.service.in
+++ b/projects/epc/audio-engine/system/audio-engine.service.in
@@ -14,7 +14,7 @@ ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/EMPHASE/id ]; do sleep 
 ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/PCH/id ]; do sleep 0.1; done"
 
 # CONFIGURE AUDIO DEVICE DRIVER
-ExecStartPre=-/usr/bin/bash -c "[ -e /sys/module/snd_hda_intel/parameters/bdl_pos_adj ] && rmmod snd_hda_intel && modprobe snd_hda_intel bdl_pos_adj=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+ExecStartPre=-/usr/bin/bash -c "uname -r | grep -v -F "4.9.9" && rmmod snd_hda_intel && modprobe snd_hda_intel bdl_pos_adj=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
 
 # SETUP FRAME SIZE DEPENDENT ON CPU
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment FRAMES_PER_PERIOD=49"

--- a/projects/epc/audio-engine/system/audio-engine.service.in
+++ b/projects/epc/audio-engine/system/audio-engine.service.in
@@ -14,7 +14,7 @@ ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/EMPHASE/id ]; do sleep 
 ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/PCH/id ]; do sleep 0.1; done"
 
 # CONFIGURE AUDIO DEVICE DRIVER
-ExecStartPre=-/usr/bin/bash -c "uname -r | grep -v -F "4.9.9" && rmmod snd_hda_intel && modprobe snd_hda_intel bdl_pos_adj=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+ExecStartPre=-/usr/bin/bash -c "uname -r | grep -v -F \"4.9.9\" && rmmod snd_hda_intel && modprobe snd_hda_intel bdl_pos_adj=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
 
 # SETUP FRAME SIZE DEPENDENT ON CPU
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment FRAMES_PER_PERIOD=49"

--- a/projects/epc/audio-engine/system/audio-engine.service.in
+++ b/projects/epc/audio-engine/system/audio-engine.service.in
@@ -13,9 +13,11 @@ ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/EMPHASE/id ]; do sleep 
 # WAIT FOR AUDIO DEVICE
 ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/PCH/id ]; do sleep 0.1; done"
 
+# CONFIGURE AUDIO DEVICE DRIVER
+ExecStartPre=-/usr/bin/bash -c "[ -e /sys/module/snd_hda_intel/parameters/bdl_pos_adj ] && rmmod snd_hda_intel && modprobe snd_hda_intel bdl_pos_adj=1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+
 # SETUP FRAME SIZE DEPENDENT ON CPU
 ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment FRAMES_PER_PERIOD=49"
-ExecStartPre=/usr/bin/bash -c "if cat /proc/cpuinfo | grep \"model name\" | grep \"7010\" > /dev/null; then /usr/bin/systemctl set-environment FRAMES_PER_PERIOD=49; fi"
 ExecStartPre=/usr/bin/bash -c "if cat /proc/cpuinfo | grep \"model name\" | grep \"5010\" > /dev/null; then /usr/bin/systemctl set-environment FRAMES_PER_PERIOD=64; fi"
 
 # START THE ENGINE


### PR DESCRIPTION
* remove unnecessary setting of FRAMES_PER_PERIOD to the value it has anyway
* reload snd_hda_intel driver if it exists (should do nothing on old epc)