### PR TITLE
closes #2984

### DIFF
--- a/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
+++ b/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
@@ -21,6 +21,8 @@ void PresetManagerMetadataSerializer::writeTagContent(Writer &writer) const
   EditBufferSerializer eb(m_pm->getEditBuffer(), getProgressCB());
   eb.write(writer);
 
+  writer.writeTextElement("selected-bank-uuid", m_pm->getSelectedBankUuid().raw());
+
   PresetBankOrderSerializer bankOrder(m_pm);
   bankOrder.write(writer);
 }

--- a/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
+++ b/projects/epc/playground/src/serialization/PresetManagerMetadataSerializer.cpp
@@ -22,6 +22,7 @@ void PresetManagerMetadataSerializer::writeTagContent(Writer &writer) const
   eb.write(writer);
 
   writer.writeTextElement("selected-bank-uuid", m_pm->getSelectedBankUuid().raw());
+  writer.writeTextElement("selected-midi-bank-uuid", m_pm->getMidiSelectedBank().raw());
 
   PresetBankOrderSerializer bankOrder(m_pm);
   bankOrder.write(writer);


### PR DESCRIPTION
added selected-bank-uuid back to metadata serializer to load selected bank on start

