### PR TITLE
closes #3015

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/PedalEditor.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/PedalEditor.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 PedalEditor::PedalEditor(PedalType *m)
-    : m_mode(std::move(m))
+    : m_mode(m)
 {
   m_mode->onChange(mem_fun(this, &PedalEditor::onSettingChanged));
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/PedalEditor.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/PedalEditor.h
@@ -20,5 +20,5 @@ class PedalEditor : public MenuEditor
   int getSelectedIndex() const override;
 
  private:
-  std::shared_ptr<PedalType> m_mode;
+  PedalType* m_mode;
 };


### PR DESCRIPTION
change implementation of PedalEditor to save the PedalSetting as raw pointer instead of creating a shared_ptr from this ptr
closes #3015