### PR TITLE
issue #3054: Add utf-8 capable locale to epc2 os

### DIFF
--- a/build-tools/epc2/create-update/createUpdate.sh
+++ b/build-tools/epc2/create-update/createUpdate.sh
@@ -72,7 +72,7 @@ build_c15() {
   cmake -DCMAKE_INSTALL_DIR=/usr/local/C15 -DTARGET_PLATFORM=epc2 -DCMAKE_BUILD_TYPE=Release -DBUILD_EPC_SCRIPTS=On -DBUILD_AUDIOENGINE=On -DBUILD_PLAYGROUND=On -DBUILD_WEB=Off /srcdir
   make -j8
   make install 
-
+   
   mkdir -p /usr/local/C15/web
   tar -xzf /web/web.tar.gz -C /usr/local/C15/web
 }
@@ -127,9 +127,13 @@ ENDOFHERE
 }
 
 perform_tweaks() {
-    useradd -m sscl
-    echo 'sscl:sscl' | chpasswd
-    echo "sscl ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+  useradd -m sscl
+  echo 'sscl:sscl' | chpasswd
+  echo "sscl ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    
+  echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+  locale-gen
+  echo "LANG=en_US.UTF-8" > /etc/locale.conf
 }
 
 package_update() {

--- a/projects/epc/playground/src/playground-helpers.cpp
+++ b/projects/epc/playground/src/playground-helpers.cpp
@@ -82,7 +82,7 @@ namespace Environment
       {
         if(g_strcmp0(ret, desiredLocale))
         {
-          DebugLevel::warning("Desired locale was", desiredLocale, ", but current locale is:", ret);
+          DebugLevel::throwException("Desired locale was", desiredLocale, ", but current locale is:", ret);
         }
         else
         {


### PR DESCRIPTION
The macro controls names use utf-8 encoded characters for
(A)... (E). The epc2 os so far only supported ascii encoding,
thus any string function processing macro control names
failed.
This patch will not only add proper utf-8 support to the OS, but
also make the playground crash immediately if en_US.UTF-8 support
is not found on the system.