### PR TITLE
issue-3063: rootfs should come with host key

### DIFF
--- a/build-tools/epc2/build-rootfs/createRootFS.sh
+++ b/build-tools/epc2/build-rootfs/createRootFS.sh
@@ -30,6 +30,7 @@ install_packages() {
     done < /epc2-binary-dir/collect-packages/base-packages.txt
     PACKAGES_COLLECTION=$(echo $PACKAGES_COLLECTION | tr ' ' '\n' | sort -u | tr '\n' ' ')
     pacstrap -U /rootfs $PACKAGES_COLLECTION
+    arch-chroot /rootfs ssh-keygen -A
     return $?
 }
 


### PR DESCRIPTION
If host keys are missing, they are generated on sshd startup.
Our boot process removes all files created during last run,
so rebooting will first remove the keys, then sshd will re-create
new ones. Clients will complain about changed keys - so better
ship keys with the rootfs.