### PR TITLE
issue-3047: Fix race condition between sshd on bbb and ssh on epc

### DIFF
--- a/projects/epc/playground/CMakeLists.txt
+++ b/projects/epc/playground/CMakeLists.txt
@@ -141,7 +141,9 @@ install(TARGETS ${BINARY_NAME} DESTINATION ${C15_INSTALL_PATH}/${BINARY_NAME})
 
 install(FILES ${PROJECT_BINARY_DIR}/systemd/${BINARY_NAME}.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 install(FILES ${PROJECT_SOURCE_DIR}/systemd/persistent.mount DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
+install(FILES ${PROJECT_SOURCE_DIR}/systemd/wait-for-bbb-ssh.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR} COMPONENT init)
 
 install(DIRECTORY DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR}/multi-user.target.wants)
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../${BINARY_NAME}.service $ENV{DESTDIR}/${SYSTEMD_SERVICES_INSTALL_DIR}/multi-user.target.wants/${BINARY_NAME}.service)")
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../persistent.mount $ENV{DESTDIR}/${SYSTEMD_SERVICES_INSTALL_DIR}/multi-user.target.wants/persistent.mount)")
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../wait-for-bbb-ssh.service $ENV{DESTDIR}/${SYSTEMD_SERVICES_INSTALL_DIR}/multi-user.target.wants/wait-for-bbb-ssh.service)")

--- a/projects/epc/playground/systemd/playground.service.in
+++ b/projects/epc/playground/systemd/playground.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Nonlinear-Labs Playground
-After=network.target systemd-modules-load.service persistent.mount fix-overlay-order.service
+After=network.target systemd-modules-load.service persistent.mount fix-overlay-order.service wait-for-bbb-ssh.service
 
 [Service]
 ExecStart=@C15_INSTALL_PATH@/playground/playground --bbbb-host=192.168.10.11 --midi-bridge=192.168.10.11 --layouts=@C15_INSTALL_PATH@/playground/resources/templates

--- a/projects/epc/playground/systemd/wait-for-bbb-ssh.service
+++ b/projects/epc/playground/systemd/wait-for-bbb-ssh.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Wait up to 30s for BeagleBone sshd
+After=network.target systemd-modules-load.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "for i in {1..30}; do ssh -o StrictHostKeyChecking=no -o ConnectTimeout=1 root@192.168.10.11 exit && exit || sleep 1; done"
+ExecStart=-mount /mnt/usb-stick
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes, in particular after an update, the sshd on beagle bone takes
some time to start (maybe because of dicing a new host key?).
Any attempts to connect to the server are denied during that phase.
When epc tries to ssh-mount the USB stick connected to BBB, it only
tries once. If this try failes because sshd is not yet ready,
Epc has no access to the USB stick.
This patch adds a dependency to playground service in order to poll
the ssh service at BBB for at most 30s and then brute-force mounts
the usb stick. If mounting fails (because previous attempt already
suceeded), the error is just ignored (note the '-' sign).