### PR TITLE
toggling the test tone should always produce logs

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -988,20 +988,18 @@ void dsp_host_dual::onSettingToneToggle(const uint16_t _setting)
 {
   m_tone_state = (_setting == 0 ? m_tone_state + 1 : _setting - 1) % 3;
   m_fade.muteAndDo([&] { m_global.update_tone_mode(m_tone_state); });
-  if(LOG_SETTINGS)
+  // this is a crucial developer tool that should always produce logs!
+  switch(m_tone_state)
   {
-    switch(m_tone_state)
-    {
-      case 0:
-        nltools::Log::info("test tone - off (synth only)");
-        break;
-      case 1:
-        nltools::Log::info("test tone - only (synth off)");
-        break;
-      case 2:
-        nltools::Log::info("test tone - on (synth on)");
-        break;
-    }
+    case 0:
+      nltools::Log::info("test tone - off (synth only)");
+      break;
+    case 1:
+      nltools::Log::info("test tone - only (synth off)");
+      break;
+    case 2:
+      nltools::Log::info("test tone - on (synth on)");
+      break;
   }
 }
 


### PR DESCRIPTION
This was recently wrapped in a compile time (constexpr bool LOG_SETTINGS), logging only when enabled. These "flags" are intended to ease development, but should be disabled for production.

However, logging Test Tone Events is crucial and should not depend on that (it also is virtually unreachable for the user). So, Test Tone Events now again always produce logs (from the Command Line and from PlayController Events).