### PR TITLE
Note Reset enhancements

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -707,7 +707,7 @@ DSPInterface::OutputResetEventSource
       m_poly[layerId].m_key_active = 0;
       if(m_layer_mode != LayerMode::Split)
       {
-        m_alloc.m_local_and_nonlocal_keys.m_global = 0;
+        m_alloc.m_internal_keys.m_global = 0;
         // apply reset to other poly components (when not in split mode)
         const uint32_t lId = 1 - layerId;
         m_poly[lId].resetEnvelopes();
@@ -716,7 +716,7 @@ DSPInterface::OutputResetEventSource
       }
       else
       {
-        m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;
+        m_alloc.m_internal_keys.m_local[layerId] = 0;
       }
     });
     // return detected reset event
@@ -764,7 +764,7 @@ DSPInterface::OutputResetEventSource
       m_poly[layerId].m_key_active = 0;
       if(m_layer_mode != LayerMode::Split)
       {
-        m_alloc.m_local_and_nonlocal_keys.m_global = 0;
+        m_alloc.m_internal_keys.m_global = 0;
         // apply reset to other poly components (when not in split mode)
         const uint32_t lId = 1 - layerId;
         m_poly[lId].resetEnvelopes();
@@ -772,7 +772,7 @@ DSPInterface::OutputResetEventSource
       }
       else
       {
-        m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;
+        m_alloc.m_internal_keys.m_local[layerId] = 0;
       }
     });
     // return detected reset event
@@ -1716,7 +1716,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::determineOutputEventSource(c
     return OutputResetEventSource::None;
   if(_type != LayerMode::Split)
     return OutputResetEventSource::Global;
-  switch(m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys())
+  switch(m_alloc.m_internal_keys.pressedLocalKeys())
   {
     case AllocatorId::Local_I:
       return OutputResetEventSource::Local_I;
@@ -1750,7 +1750,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSingle(const nltools::
     {
       nltools::Log::info("recall single voice reset");
     }
-    m_alloc.m_local_and_nonlocal_keys.init();  // reset all pressed keys
+    m_alloc.m_internal_keys.init();  // reset all pressed keys
     m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position, oldLayerMode,
                       m_layer_mode);
     m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position, m_layer_mode);
@@ -1895,8 +1895,8 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
 
   auto msg = &_msg;
   // #3009: prepare reset detection with pressed local keys
-  bool internalReset[2] = { m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys(0),
-                            m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys(1) };
+  bool internalReset[2] = { m_alloc.m_internal_keys.pressedLocalKeys(0),
+                            m_alloc.m_internal_keys.pressedLocalKeys(1) };
   const bool externalReset = layerChanged && areKeysPressed(fromType(oldLayerMode));
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
@@ -1912,7 +1912,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
       {
         nltools::Log::info("recall split voice reset(layerId:", layerId, ")");
       }
-      m_alloc.m_local_and_nonlocal_keys.m_local[layerId] = 0;  // reset all pressed keys in part
+      m_alloc.m_internal_keys.m_local[layerId] = 0;  // reset all pressed keys in part
       m_alloc.setUnison(layerId, m_params.get_local_unison_voices(layer)->m_position, oldLayerMode, m_layer_mode);
       m_alloc.setMonoEnable(layerId, m_params.get_local_mono_enable(layer)->m_position, m_layer_mode);
       const uint32_t uVoice = m_alloc.m_unison - 1;
@@ -2045,12 +2045,12 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
   if(layerChanged)
   {
     // non-split -> split: (global or none)
-    m_alloc.m_local_and_nonlocal_keys.m_global = 0;  // reset all pressed global keys
+    m_alloc.m_internal_keys.m_global = 0;  // reset all pressed global keys
     return determineOutputEventSource(externalReset, oldLayerMode);
     ;
   }
   // split -> split: determine actual outputEvent (I, II: pressed keys && poly change)
-  return m_alloc.m_local_and_nonlocal_keys.pressedLocalKeys(internalReset[0], internalReset[1]);
+  return m_alloc.m_internal_keys.pressedLocalKeys(internalReset[0], internalReset[1]);
 }
 
 DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::msg::LayerPresetMessage& _msg)
@@ -2075,7 +2075,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallLayer(const nltools::m
     {
       nltools::Log::info("recall layer voice reset");
     }
-    m_alloc.m_local_and_nonlocal_keys.init();  // reset all pressed keys
+    m_alloc.m_internal_keys.init();  // reset all pressed keys
     m_alloc.setUnison(0, m_params.get_local_unison_voices(C15::Properties::LayerId::I)->m_position, oldLayerMode,
                       m_layer_mode);
     m_alloc.setMonoEnable(0, m_params.get_local_mono_enable(C15::Properties::LayerId::I)->m_position, m_layer_mode);
@@ -2697,9 +2697,9 @@ bool dsp_host_dual::areKeysPressed(SoundType _current)
   {
     case SoundType::Layer:
     case SoundType::Single:
-      return m_alloc.m_local_and_nonlocal_keys.m_global > 0;
+      return m_alloc.m_internal_keys.m_global > 0;
     case SoundType::Split:
-      return (m_alloc.m_local_and_nonlocal_keys.m_local[0] + m_alloc.m_local_and_nonlocal_keys.m_local[1]) > 0;
+      return (m_alloc.m_internal_keys.m_local[0] + m_alloc.m_internal_keys.m_local[1]) > 0;
   }
   return false;
 }

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -1895,8 +1895,7 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
 
   auto msg = &_msg;
   // #3009: prepare reset detection with pressed local keys
-  bool internalReset[2] = { m_alloc.m_internal_keys.pressedLocalKeys(0),
-                            m_alloc.m_internal_keys.pressedLocalKeys(1) };
+  bool internalReset[2] = { m_alloc.m_internal_keys.pressedLocalKeys(0), m_alloc.m_internal_keys.pressedLocalKeys(1) };
   const bool externalReset = layerChanged && areKeysPressed(fromType(oldLayerMode));
   for(uint32_t layerId = 0; layerId < m_params.m_layer_count; layerId++)
   {
@@ -2047,7 +2046,6 @@ DSPInterface::OutputResetEventSource dsp_host_dual::recallSplit(const nltools::m
     // non-split -> split: (global or none)
     m_alloc.m_internal_keys.m_global = 0;  // reset all pressed global keys
     return determineOutputEventSource(externalReset, oldLayerMode);
-    ;
   }
   // split -> split: determine actual outputEvent (I, II: pressed keys && poly change)
   return m_alloc.m_internal_keys.pressedLocalKeys(internalReset[0], internalReset[1]);

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -96,6 +96,10 @@ struct AssignedKeyCount  // tracking active keys
     }
     return AllocatorId::None;
   }
+  bool pressedLocalKeys(const bool _index)
+  {
+    return m_local[_index] > 0;
+  }
 };
 
 struct VoiceAssignment

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -310,7 +310,7 @@ class VoiceAllocation
 {
  public:
   PolyKeyPacket<GlobalVoices, PivotKey> m_traversal;
-  AssignedKeyCount m_local_and_nonlocal_keys;  // note: should we need separate loc/non-loc, duplicate
+  AssignedKeyCount m_internal_keys;
   uint32_t m_unison = {};
   inline VoiceAllocation()
   {
@@ -330,7 +330,7 @@ class VoiceAllocation
       m_keyState[0][k].m_keyNumber = m_keyState[1][k].m_keyNumber = m_keyState[2][k].m_keyNumber = k;
     }
     //
-    m_local_and_nonlocal_keys.init();
+    m_internal_keys.init();
   }
   inline bool onSingleKeyDown(const uint32_t _keyPos, const float _vel, const uint32_t _inputSourceId)
   {
@@ -357,7 +357,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_local_and_nonlocal_keys.m_global += isInternalKey;
+        m_internal_keys.m_global += isInternalKey;
       }
     }
     return validity;
@@ -386,7 +386,7 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
-            m_local_and_nonlocal_keys.m_local[0] += isInternalKey;
+            m_internal_keys.m_local[0] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -398,7 +398,7 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
-            m_local_and_nonlocal_keys.m_local[1] += isInternalKey;
+            m_internal_keys.m_local[1] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 1, true);
             if(firstVoice != -1)
@@ -410,8 +410,8 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_Both:
             unisonVoices = m_local[0].getUnison();
-            m_local_and_nonlocal_keys.m_local[0] += isInternalKey;
-            m_local_and_nonlocal_keys.m_local[1] += isInternalKey;
+            m_internal_keys.m_local[0] += isInternalKey;
+            m_internal_keys.m_local[1] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -466,7 +466,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], LocalVoices + firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_local_and_nonlocal_keys.m_global += isInternalKey;
+        m_internal_keys.m_global += isInternalKey;
       }
     }
     return validity;
@@ -492,9 +492,9 @@ class VoiceAllocation
         keyUp_unisonLoop(firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_local_and_nonlocal_keys.m_global > 0)
+      if(m_internal_keys.m_global > 0)
       {
-        m_local_and_nonlocal_keys.m_global -= isInternalKey;
+        m_internal_keys.m_global -= isInternalKey;
       }
     }
     return validity;
@@ -520,9 +520,9 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
-            if(m_local_and_nonlocal_keys.m_local[0] > 0)
+            if(m_internal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0] -= isInternalKey;
+              m_internal_keys.m_local[0] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             // unison loop
@@ -530,9 +530,9 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
-            if(m_local_and_nonlocal_keys.m_local[1] > 0)
+            if(m_internal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1] -= isInternalKey;
+              m_internal_keys.m_local[1] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 1, true) * unisonVoices;
             // unison loop
@@ -541,17 +541,17 @@ class VoiceAllocation
           case AllocatorId::Local_Both:
             // part[I]
             unisonVoices = m_local[0].getUnison();
-            if(m_local_and_nonlocal_keys.m_local[0] > 0)
+            if(m_internal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0] -= isInternalKey;
+              m_internal_keys.m_local[0] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             keyUp_unisonLoop(firstVoice, unisonVoices);
             // part[II]
             unisonVoices = m_local[1].getUnison();
-            if(m_local_and_nonlocal_keys.m_local[1] > 0)
+            if(m_internal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1] -= isInternalKey;
+              m_internal_keys.m_local[1] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 1, false) * unisonVoices;
             keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
@@ -584,9 +584,9 @@ class VoiceAllocation
         keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
       }
       keyUp_confirm(keyState);
-      if(m_local_and_nonlocal_keys.m_global > 0)
+      if(m_internal_keys.m_global > 0)
       {
-        m_local_and_nonlocal_keys.m_global -= isInternalKey;
+        m_internal_keys.m_global -= isInternalKey;
       }
     }
     return validity;
@@ -608,17 +608,17 @@ class VoiceAllocation
         switch(_determinedPart)
         {
           case AllocatorId::Local_I:
-            m_local_and_nonlocal_keys.m_local[0]++;
+            m_internal_keys.m_local[0]++;
             break;
           case AllocatorId::Local_II:
-            m_local_and_nonlocal_keys.m_local[1]++;
+            m_internal_keys.m_local[1]++;
             break;
           case AllocatorId::Local_Both:
-            m_local_and_nonlocal_keys.m_local[0]++;
-            m_local_and_nonlocal_keys.m_local[1]++;
+            m_internal_keys.m_local[0]++;
+            m_internal_keys.m_local[1]++;
             break;
           case AllocatorId::Global:
-            m_local_and_nonlocal_keys.m_global++;
+            m_internal_keys.m_global++;
             break;
         }
       }
@@ -641,31 +641,31 @@ class VoiceAllocation
         switch(keyState->m_origin)
         {
           case AllocatorId::Local_I:
-            if(m_local_and_nonlocal_keys.m_local[0] > 0)
+            if(m_internal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0]--;
+              m_internal_keys.m_local[0]--;
             }
             break;
           case AllocatorId::Local_II:
-            if(m_local_and_nonlocal_keys.m_local[1] > 0)
+            if(m_internal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1]--;
+              m_internal_keys.m_local[1]--;
             }
             break;
           case AllocatorId::Local_Both:
-            if(m_local_and_nonlocal_keys.m_local[0] > 0)
+            if(m_internal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0]--;
+              m_internal_keys.m_local[0]--;
             }
-            if(m_local_and_nonlocal_keys.m_local[1] > 0)
+            if(m_internal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1]--;
+              m_internal_keys.m_local[1]--;
             }
             break;
           case AllocatorId::Global:
-            if(m_local_and_nonlocal_keys.m_global > 0)
+            if(m_internal_keys.m_global > 0)
             {
-              m_local_and_nonlocal_keys.m_global--;
+              m_internal_keys.m_global--;
             }
             break;
         }
@@ -793,7 +793,7 @@ class VoiceAllocation
         keyState.m_origin = AllocatorId::None;
       }
     }
-    m_local_and_nonlocal_keys.init();
+    m_internal_keys.init();
   }
 
   inline AllocatorId getSplitPartForKeyDown(const uint32_t _key)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/voice_allocation.h
@@ -338,6 +338,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_released ?
       validity = !keyState->m_active;
@@ -356,7 +357,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_local_and_nonlocal_keys.m_global++;
+        m_local_and_nonlocal_keys.m_global += isInternalKey;
       }
     }
     return validity;
@@ -370,6 +371,7 @@ class VoiceAllocation
     //    bool innerValidity = false;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_released ?
       validity = !keyState->m_active;
@@ -384,7 +386,7 @@ class VoiceAllocation
         {
           case AllocatorId::Local_I:
             unisonVoices = m_local[0].getUnison();
-            m_local_and_nonlocal_keys.m_local[0]++;
+            m_local_and_nonlocal_keys.m_local[0] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -396,7 +398,7 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_II:
             unisonVoices = m_local[1].getUnison();
-            m_local_and_nonlocal_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[1] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 1, true);
             if(firstVoice != -1)
@@ -408,8 +410,8 @@ class VoiceAllocation
             break;
           case AllocatorId::Local_Both:
             unisonVoices = m_local[0].getUnison();
-            m_local_and_nonlocal_keys.m_local[0]++;
-            m_local_and_nonlocal_keys.m_local[1]++;
+            m_local_and_nonlocal_keys.m_local[0] += isInternalKey;
+            m_local_and_nonlocal_keys.m_local[1] += isInternalKey;
             // mono/poly process
             firstVoice = keyDown_process_split(keyState, unisonVoices, 0, true);
             if(firstVoice != -1)
@@ -444,6 +446,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_released ?
       validity = !keyState->m_active;
@@ -463,7 +466,7 @@ class VoiceAllocation
         keyDown_unisonLoop(keyState->m_position[0], LocalVoices + firstVoice, unisonVoices, _inputSourceId);
         // confirm
         keyDown_confirm(keyState);
-        m_local_and_nonlocal_keys.m_global++;
+        m_local_and_nonlocal_keys.m_global += isInternalKey;
       }
     }
     return validity;
@@ -474,6 +477,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_pressed ?
       validity = keyState->m_active;
@@ -490,7 +494,7 @@ class VoiceAllocation
       keyUp_confirm(keyState);
       if(m_local_and_nonlocal_keys.m_global > 0)
       {
-        m_local_and_nonlocal_keys.m_global--;
+        m_local_and_nonlocal_keys.m_global -= isInternalKey;
       }
     }
     return validity;
@@ -502,6 +506,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_pressed ?
       validity = keyState->m_active && (keyState->m_origin == _determinedPart);
@@ -517,7 +522,7 @@ class VoiceAllocation
             unisonVoices = m_local[0].getUnison();
             if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             // unison loop
@@ -527,7 +532,7 @@ class VoiceAllocation
             unisonVoices = m_local[1].getUnison();
             if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 1, true) * unisonVoices;
             // unison loop
@@ -538,7 +543,7 @@ class VoiceAllocation
             unisonVoices = m_local[0].getUnison();
             if(m_local_and_nonlocal_keys.m_local[0] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[0]--;
+              m_local_and_nonlocal_keys.m_local[0] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 0, true) * unisonVoices;
             keyUp_unisonLoop(firstVoice, unisonVoices);
@@ -546,7 +551,7 @@ class VoiceAllocation
             unisonVoices = m_local[1].getUnison();
             if(m_local_and_nonlocal_keys.m_local[1] > 0)
             {
-              m_local_and_nonlocal_keys.m_local[1]--;
+              m_local_and_nonlocal_keys.m_local[1] -= isInternalKey;
             }
             firstVoice = keyUp_process_part(keyState, 1, false) * unisonVoices;
             keyUp_unisonLoop(LocalVoices + firstVoice, unisonVoices);
@@ -563,6 +568,7 @@ class VoiceAllocation
     bool validity = _keyPos < Keys;
     if(validity)
     {
+      const bool isInternalKey = _inputSourceId == 0;
       KeyAssignment* keyState = &m_keyState[_inputSourceId][_keyPos];
       // validation 2 - key_pressed ?
       validity = keyState->m_active;
@@ -580,7 +586,7 @@ class VoiceAllocation
       keyUp_confirm(keyState);
       if(m_local_and_nonlocal_keys.m_global > 0)
       {
-        m_local_and_nonlocal_keys.m_global--;
+        m_local_and_nonlocal_keys.m_global -= isInternalKey;
       }
     }
     return validity;


### PR DESCRIPTION
- [x] Recall [Split --> Split] with differing Unison/Mono params in Part(s): reworked reset detection to match internal reset behavior, closes #3009
- [x] reworked AllNotesOff: will only occur when _internal_ (PlayController) keys are pressed (with Note Local Enable on or off), _external_ (Midi) keys are now ignored