### PR TITLE
issue-3117: Fix undo when Overwriting presets

### DIFF
--- a/projects/epc/playground/src/presets/PresetDualParameterGroups.h
+++ b/projects/epc/playground/src/presets/PresetDualParameterGroups.h
@@ -55,6 +55,8 @@ class PresetDualParameterGroups : public AttributesOwner
 
   [[nodiscard]] tParameterGroups getGroups(const VoiceGroup& vg) const;
 
+  void TEST_deleteGroup(const GroupId& id);
+
  protected:
   void copyFrom(UNDO::Transaction* transaction, const PresetDualParameterGroups* other);
   void copyFrom(UNDO::Transaction* transaction, const EditBuffer* other);

--- a/projects/epc/playground/src/presets/PresetParameter.cpp
+++ b/projects/epc/playground/src/presets/PresetParameter.cpp
@@ -67,6 +67,11 @@ void PresetParameter::setField(UNDO::Transaction *transaction, Fields field, con
   transaction->addUndoSwap(m_fields, cp);
 }
 
+void PresetParameter::copyFrom(UNDO::Transaction *transaction, const std::unique_ptr<PresetParameter> &other)
+{
+  copyFrom(transaction, other.get());
+}
+
 void PresetParameter::copyFrom(UNDO::Transaction *transaction, const PresetParameter *other)
 {
   auto eb = Application::get().getPresetManager()->getEditBuffer();

--- a/projects/epc/playground/src/presets/PresetParameter.h
+++ b/projects/epc/playground/src/presets/PresetParameter.h
@@ -48,6 +48,7 @@ class PresetParameter
   // transactions
   void setValue(UNDO::Transaction *transaction, tControlPositionValue v);
   void setField(UNDO::Transaction *transaction, Fields field, const std::string &value);
+  void copyFrom(UNDO::Transaction *transaction, const std::unique_ptr<PresetParameter> &other);
   void copyFrom(UNDO::Transaction *transaction, const PresetParameter *other);
   void copyFrom(UNDO::Transaction *transaction, const ::Parameter *other);
 

--- a/projects/epc/playground/src/presets/PresetParameterGroup.cpp
+++ b/projects/epc/playground/src/presets/PresetParameterGroup.cpp
@@ -40,34 +40,47 @@ VoiceGroup PresetParameterGroup::getVoiceGroup() const
   return m_voiceGroup;
 }
 
-void PresetParameterGroup::copyFrom(UNDO::Transaction *transaction, const PresetParameterGroup *other)
+template <typename Other> void PresetParameterGroup::copyFrom(UNDO::Transaction *transaction, const Other *other)
 {
-  for(auto &g : m_parameters)
-    if(auto o = other->findParameterByID(g->getID()))
-      g->copyFrom(transaction, o);
+  for(auto &otherParam : other->getParameters())
+  {
+    if(auto old = findParameterByID(otherParam->getID()))
+    {
+      old->copyFrom(transaction, otherParam);
+    }
+    else
+    {
+      auto swap = UNDO::createSwapData(std::make_unique<PresetParameter>(*otherParam));
+
+      auto doAndRedo = [=](auto) {
+        std::unique_ptr<PresetParameter> s;
+        swap->swapWith(s);
+        m_parameters.push_back(std::move(s));
+      };
+      auto undo = [=](auto) {
+        auto &place = m_parameters.back();
+        swap->swapWith(place);
+        m_parameters.pop_back();
+      };
+
+      transaction->addSimpleCommand(doAndRedo, undo);
+    }
+  }
 
   transaction->addUndoSwap(m_voiceGroup, other->getVoiceGroup());
 }
 
-void PresetParameterGroup::copyFrom(UNDO::Transaction *transaction, const ::ParameterGroup *other)
-{
-  for(auto &g : m_parameters)
-    if(auto o = other->getParameterByID(g->getID()))
-      g->copyFrom(transaction, o);
-
-  transaction->addUndoSwap(m_voiceGroup, other->getVoiceGroup());
-}
+template void PresetParameterGroup::copyFrom(UNDO::Transaction *transaction, const PresetParameterGroup *other);
+template void PresetParameterGroup::copyFrom(UNDO::Transaction *transaction, const ::ParameterGroup *other);
 
 void PresetParameterGroup::assignVoiceGroup(UNDO::Transaction *transaction, VoiceGroup vg)
 {
   transaction->addUndoSwap(m_voiceGroup, vg);
 
-  transaction->addSimpleCommand(
-      [=](auto)
-      {
-        for(auto &g : m_parameters)
-          g->assignVoiceGroup(vg);
-      });
+  transaction->addSimpleCommand([=](auto) {
+    for(auto &g : m_parameters)
+      g->assignVoiceGroup(vg);
+  });
 }
 
 void PresetParameterGroup::writeDiff(Writer &writer, const GroupId &groupId, const PresetParameterGroup *other) const
@@ -84,30 +97,27 @@ void PresetParameterGroup::writeDiff(Writer &writer, const GroupId &groupId, con
   if(!m_parameters.empty())
     name = ParameterDB::get().getLongGroupName(m_parameters.front()->getID()).value_or(name);
 
-  writer.writeTag(
-      "group", Attribute("name", name), Attribute("afound", "true"), Attribute("bfound", "true"),
-      [&]
+  writer.writeTag("group", Attribute("name", name), Attribute("afound", "true"), Attribute("bfound", "true"), [&] {
+    std::vector<int> writtenParameters;
+
+    for(auto &parameter : m_parameters)
+    {
+      auto otherParameter = other->findParameterByID({ parameter->getID().getNumber(), other->getVoiceGroup() });
+      parameter->writeDiff(writer, parameter->getID(), otherParameter);
+      writtenParameters.emplace_back(parameter->getID().getNumber());
+    }
+
+    for(auto &parameter : other->getParameters())
+    {
+      if(std::find(writtenParameters.begin(), writtenParameters.end(), parameter->getID().getNumber())
+         == writtenParameters.end())
       {
-        std::vector<int> writtenParameters;
-
-        for(auto &parameter : m_parameters)
-        {
-          auto otherParameter = other->findParameterByID({ parameter->getID().getNumber(), other->getVoiceGroup() });
-          parameter->writeDiff(writer, parameter->getID(), otherParameter);
-          writtenParameters.emplace_back(parameter->getID().getNumber());
-        }
-
-        for(auto &parameter : other->getParameters())
-        {
-          if(std::find(writtenParameters.begin(), writtenParameters.end(), parameter->getID().getNumber())
-             == writtenParameters.end())
-          {
-            auto paramName = ParameterDB::get().getLongName(parameter->getID());
-            writer.writeTag("parameter", Attribute("name", paramName), Attribute("afound", "false"),
-                            Attribute("bfound", "true"), [] {});
-          }
-        }
-      });
+        auto paramName = ParameterDB::get().getLongName(parameter->getID());
+        writer.writeTag("parameter", Attribute("name", paramName), Attribute("afound", "false"),
+                        Attribute("bfound", "true"), [] {});
+      }
+    }
+  });
 }
 
 void PresetParameterGroup::writeDocument(Writer &writer) const
@@ -117,4 +127,9 @@ void PresetParameterGroup::writeDocument(Writer &writer) const
     const auto param = static_cast<const PresetParameter *>(p.get());
     param->writeDocument(writer);
   }
+}
+
+void PresetParameterGroup::TEST_deleteParameter(const ParameterId &id)
+{
+  m_parameters.erase(std::find_if(m_parameters.begin(), m_parameters.end(), [&](auto &p) { return p->getID() == id; }));
 }

--- a/projects/epc/playground/src/presets/PresetParameterGroup.h
+++ b/projects/epc/playground/src/presets/PresetParameterGroup.h
@@ -28,8 +28,8 @@ class PresetParameterGroup
   void writeDocument(Writer &writer) const;
 
   // transactions
-  void copyFrom(UNDO::Transaction *transaction, const PresetParameterGroup *other);
-  void copyFrom(UNDO::Transaction *transaction, const ::ParameterGroup *other);
+  template <typename Other> void copyFrom(UNDO::Transaction *transaction, const Other *other);
+
   void assignVoiceGroup(UNDO::Transaction *transaction, VoiceGroup vg);
 
   [[nodiscard]] const std::vector<ParameterPtr> &getParameters() const
@@ -41,6 +41,8 @@ class PresetParameterGroup
 
   // algorithm
   void writeDiff(Writer &writer, const GroupId &groupId, const PresetParameterGroup *other) const;
+
+  void TEST_deleteParameter(const ParameterId &id);
 
  private:
   std::vector<ParameterPtr> m_parameters;

--- a/projects/epc/playground/src/testing/unit-tests/presets/PresetUndoTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/presets/PresetUndoTests.cpp
@@ -1,0 +1,145 @@
+#include "testing/TestHelper.h"
+#include <presets/Bank.h>
+#include <presets/Preset.h>
+#include <presets/PresetParameter.h>
+#include <libundo/undo/TrashTransaction.h>
+#include <parameter-db/generated/parameter_list.h>
+#include <use-cases/PresetManagerUseCases.h>
+#include <use-cases/BankUseCases.h>
+#include <use-cases/PresetUseCases.h>
+
+TEST_CASE("Undo copyFrom")
+{
+  auto pm = TestHelper::getPresetManager();
+  auto eb = TestHelper::getEditBuffer();
+  auto settings = TestHelper::getSettings();
+
+  PresetManagerUseCases pmUC(*pm, *settings);
+  auto bank = pmUC.addBank();
+
+  BankUseCases bankUC(bank, *settings);
+  auto preset = bankUC.appendEditBuffer();
+
+  ParameterId paramId = { C15::PID::Env_A_Att, VoiceGroup::I };
+
+  {
+    auto scope = pm->getUndoScope().startTransaction("Init State");
+    preset->findParameterByID(paramId, false)->setValue(scope->getTransaction(), 1.0);
+    eb->findParameterByID(paramId)->setCPFromHwui(scope->getTransaction(), 0.5);
+  }
+
+  WHEN("parameter group already exists")
+  {
+    PresetUseCases uc(*preset, *settings);
+    uc.overwriteWithEditBuffer(*eb);
+    CHECK(preset->findParameterByID(paramId, false)->getValue() == 0.5);
+
+    THEN("Undo restores old value")
+    {
+      pm->getUndoScope().undo();
+      CHECK(preset->findParameterByID(paramId, false)->getValue() == 1.0);
+    }
+  }
+
+  WHEN("parameter group is missing")
+  {
+    PresetUseCases uc(*preset, *settings);
+    GroupId groupId = { "Env A", VoiceGroup::I };
+    preset->TEST_deleteGroup(groupId);
+    CHECK(preset->findParameterGroup(groupId) == nullptr);
+    CHECK(preset->findParameterByID(paramId, false) == nullptr);
+
+    THEN("group is added by 'copyFrom'")
+    {
+      uc.overwriteWithEditBuffer(*eb);
+
+      CHECK(preset->findParameterGroup(groupId) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false)->getValue() == 0.5);
+
+      THEN("Undo restores 'group missing state'")
+      {
+        pm->getUndoScope().undo();
+        CHECK(preset->findParameterGroup(groupId) == nullptr);
+        CHECK(preset->findParameterByID(paramId, false) == nullptr);
+
+        THEN("Redo restores group")
+        {
+          pm->getUndoScope().redo();
+          CHECK(preset->findParameterGroup(groupId) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false)->getValue() == 0.5);
+        }
+      }
+    }
+  }
+
+  WHEN("parameter is missing")
+  {
+    PresetUseCases uc(*preset, *settings);
+    GroupId groupId = { "Env A", VoiceGroup::I };
+    preset->findParameterGroup(groupId)->TEST_deleteParameter(paramId);
+    CHECK(preset->findParameterByID(paramId, false) == nullptr);
+    uc.overwriteWithEditBuffer(*eb);
+
+    THEN("parameter is added by 'copyFrom'")
+    {
+      CHECK(preset->findParameterGroup(groupId) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false)->getValue() == 0.5);
+
+      THEN("Undo restores 'param missing state'")
+      {
+        pm->getUndoScope().undo();
+        CHECK(preset->findParameterGroup(groupId) != nullptr);
+        CHECK(preset->findParameterByID(paramId, false) == nullptr);
+
+        THEN("Redo restores param")
+        {
+          pm->getUndoScope().redo();
+          CHECK(preset->findParameterGroup(groupId) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false)->getValue() == 0.5);
+        }
+      }
+    }
+  }
+
+  WHEN("parameter group is missing in VGII")
+  {
+    PresetUseCases uc(*preset, *settings);
+    GroupId groupId = { "Env A", VoiceGroup::II };
+    ParameterId paramId = { C15::PID::Env_A_Att, VoiceGroup::II };
+
+    preset->TEST_deleteGroup(groupId);
+    CHECK(preset->findParameterGroup(groupId) == nullptr);
+    CHECK(preset->findParameterByID(paramId, false) == nullptr);
+
+    THEN("group is added by 'copyVoiceGroup1IntoVoiceGroup2'")
+    {
+      {
+        auto scope = pm->getUndoScope().startTransaction("Foo");
+        preset->copyVoiceGroup1IntoVoiceGroup2(scope->getTransaction(), {});
+      }
+
+      CHECK(preset->findParameterGroup(groupId) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false) != nullptr);
+      CHECK(preset->findParameterByID(paramId, false)->getValue() == 1.0);
+
+      THEN("Undo restores 'group missing state'")
+      {
+        pm->getUndoScope().undo();
+        CHECK(preset->findParameterGroup(groupId) == nullptr);
+        CHECK(preset->findParameterByID(paramId, false) == nullptr);
+
+        THEN("Redo restores group")
+        {
+          pm->getUndoScope().redo();
+          CHECK(preset->findParameterGroup(groupId) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false) != nullptr);
+          CHECK(preset->findParameterByID(paramId, false)->getValue() == 1.0);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The copyFrom methods in preset parameter groups did not
restore parameter values on undo. Attribuites and meta data
of presets have been unrolled, while parameter values have not,
yielding frankensteins moster-presets.

(Here we have our first PR pointing to 'main' - meaning: should be part of next milestone)