### PR TITLE
prepare ParameterDB to use SoundType

### DIFF
--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -31,14 +31,15 @@ static const auto c_invalidSnapshotValue = std::numeric_limits<tControlPositionV
 
 bool wasDefaultedAndNotUnselected();
 const tControlPositionValue &getPriorDefaultValue();
+
 Parameter::Parameter(ParameterGroup *group, ParameterId id, const ScaleConverter *scaling, tControlPositionValue def,
                      tControlPositionValue coarseDenominator, tControlPositionValue fineDenominator)
     : UpdateDocumentContributor(group)
     , SyncedItem(group->getRoot()->getSyncMaster(), "/parameter/" + id.toString())
     , m_id(id)
     , m_value(this, scaling, def, coarseDenominator, fineDenominator)
-    , m_lastSnapshotedValue(c_invalidSnapshotValue)
     , m_voiceGroup { group->getVoiceGroup() }
+    , m_lastSnapshotedValue(c_invalidSnapshotValue)
 {
 }
 
@@ -392,17 +393,29 @@ void Parameter::invalidate()
 
 Glib::ustring Parameter::getLongName() const
 {
-  return ParameterDB::get().getLongName(getID());
+  if(auto eb = getParentEditBuffer())
+  {
+    return eb->getParameterDB().getLongName(getID());
+  }
+  return getID().toString();
 }
 
 Glib::ustring Parameter::getShortName() const
 {
-  return ParameterDB::get().getShortName(getID());
+  if(auto eb = getParentEditBuffer())
+  {
+    return eb->getParameterDB().getShortName(getID());
+  }
+  return getID().toString();
 }
 
 Glib::ustring Parameter::getInfoText() const
 {
-  return ParameterDB::get().getDescription(getID());
+  if(auto eb = getParentEditBuffer())
+  {
+    return eb->getParameterDB().getDescription(getID());
+  }
+  return getID().toString();
 }
 
 Glib::ustring Parameter::getMiniParameterEditorName() const

--- a/projects/epc/playground/src/parameters/names/ParameterDB.h
+++ b/projects/epc/playground/src/parameters/names/ParameterDB.h
@@ -6,12 +6,12 @@
 #include <optional>
 
 class Parameter;
+class EditBuffer;
 
-class ParameterDB
+class ParameterDB : public sigc::trackable
 {
  public:
-  static ParameterDB& get();
-
+  explicit ParameterDB(EditBuffer& eb);
   virtual ~ParameterDB();
 
   [[nodiscard]] Glib::ustring getLongName(const ParameterId& id) const;
@@ -27,6 +27,7 @@ class ParameterDB
   }
 
  private:
-  [[nodiscard]] Glib::ustring replaceVoiceGroupInDynamicLabels(Glib::ustring name, VoiceGroup originGroup) const;
-  ParameterDB();
+  [[nodiscard]] Glib::ustring replaceInDynamicLabels(Glib::ustring name, VoiceGroup originGroup, SoundType type) const;
+
+  EditBuffer& m_editBuffer;
 };

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -41,6 +41,7 @@
 EditBuffer::EditBuffer(PresetManager *parent, Settings &settings, std::unique_ptr<AudioEngineProxy> &aeContainer)
     : ParameterGroupSet(parent)
     , SyncedItem(parent->getRoot()->getSyncMaster(), "/editbuffer")
+    , m_parameterDB(*this)
     , m_deferredJobs(100, std::bind(&EditBuffer::doDeferedJobs, this))
     , m_isModified(false)
     , m_recallSet(this)
@@ -1722,4 +1723,9 @@ void EditBuffer::setHWSourcesToLoadRulePostionsAndModulate(UNDO::Transaction *tr
       }
     }
   }
+}
+
+ParameterDB &EditBuffer::getParameterDB()
+{
+  return m_parameterDB;
 }

--- a/projects/epc/playground/src/presets/EditBuffer.h
+++ b/projects/epc/playground/src/presets/EditBuffer.h
@@ -3,6 +3,7 @@
 #include "ParameterGroupSet.h"
 #include "presets/recall/RecallParameterGroups.h"
 #include "nltools/GenericScopeGuard.h"
+#include "parameters/names/ParameterDB.h"
 #include <nltools/threading/Expiration.h>
 #include <sync/SyncedItem.h>
 #include <tools/DelayedJob.h>
@@ -132,6 +133,7 @@ class EditBuffer : public ParameterGroupSet, public SyncedItem
   };
 
   PartOrigin getPartOrigin(VoiceGroup vg) const;
+  ParameterDB& getParameterDB();
 
   std::shared_ptr<ScopedGuard::Lock> getParameterFocusLockGuard();
   bool isParameterFocusLocked() const;
@@ -240,6 +242,7 @@ class EditBuffer : public ParameterGroupSet, public SyncedItem
   friend class EditBufferUseCases;
   friend class SoundUseCases;
 
+  ParameterDB m_parameterDB;
   Uuid m_lastLoadedPreset;
 
   Glib::ustring m_name;

--- a/projects/epc/playground/src/presets/PresetParameterGroup.cpp
+++ b/projects/epc/playground/src/presets/PresetParameterGroup.cpp
@@ -105,7 +105,10 @@ void PresetParameterGroup::writeDiff(Writer &writer, const GroupId &groupId, con
   std::string name = groupId.getName();
 
   if(!m_parameters.empty())
-    name = ParameterDB::get().getLongGroupName(m_parameters.front()->getID()).value_or(name);
+  {
+    auto& db = Application::get().getPresetManager()->getEditBuffer()->getParameterDB();
+    name = db.getLongGroupName(m_parameters.front()->getID()).value_or(name);
+  }
 
   writer.writeTag("group", Attribute("name", name), Attribute("afound", "true"), Attribute("bfound", "true"), [&] {
     std::vector<int> writtenParameters;
@@ -122,7 +125,8 @@ void PresetParameterGroup::writeDiff(Writer &writer, const GroupId &groupId, con
       if(std::find(writtenParameters.begin(), writtenParameters.end(), parameter->getID().getNumber())
          == writtenParameters.end())
       {
-        auto paramName = ParameterDB::get().getLongName(parameter->getID());
+        auto& db = Application::get().getPresetManager()->getEditBuffer()->getParameterDB();
+        auto paramName = db.getLongName(parameter->getID());
         writer.writeTag("parameter", Attribute("name", paramName), Attribute("afound", "false"),
                         Attribute("bfound", "true"), [] {});
       }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.cpp
@@ -94,7 +94,7 @@ void PanelUnitPresetMode::setStateForButton(Buttons buttonId, const std::list<in
 
   for(const auto i : parameters)
   {
-    auto signalFlowIndicator = ParameterDB::get().getSignalPathIndication(i);
+    auto signalFlowIndicator = editBuffer->getParameterDB().getSignalPathIndication(i);
 
     Parameter* parameter = nullptr;
 

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterInfoText.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterInfoText.cpp
@@ -34,9 +34,12 @@ void ParameterInfoText::onParameterSelected(Parameter *oldParam, Parameter *newP
 
 void ParameterInfoText::onParameterChanged(const Parameter *newParameter)
 {
-  auto &db = ParameterDB::get();
-  onTextLoaded(db.getDescription(newParameter->getID()));
-  scrollTop();
+  if(auto eb = newParameter->getParentEditBuffer())
+  {
+    auto &db = eb->getParameterDB();
+    onTextLoaded(db.getDescription(newParameter->getID()));
+    scrollTop();
+  }
 }
 
 void ParameterInfoText::onTextLoaded(const Glib::ustring &text)

--- a/projects/epc/playground/src/testing/unit-tests/data/UnicodeTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/data/UnicodeTests.cpp
@@ -38,7 +38,8 @@ TEST_CASE("NL chars are sorted properly")
 
 TEST_CASE("Macro Labels are sortable A < B < C < D < E < F")
 {
-  auto& db = ParameterDB::get();
+  auto eb = TestHelper::getEditBuffer();
+  ParameterDB db(*eb);
   auto mca = db.getLongName({ C15::PID::MC_A, VoiceGroup::Global });
   auto mcb = db.getLongName({ C15::PID::MC_B, VoiceGroup::Global });
   auto mcc = db.getLongName({ C15::PID::MC_C, VoiceGroup::Global });


### PR DESCRIPTION
prepare Playground::ParameterDB for sound type consumption for name-replacements and made it no longer be an singleton