### PR TITLE
issue 3171

### DIFF
--- a/projects/bbb/midi-over-ip/src/IO.cpp
+++ b/projects/bbb/midi-over-ip/src/IO.cpp
@@ -32,7 +32,7 @@ Input::Input(const std::string &name)
   if(pipe(m_cancelPipe))
     nltools::Log::warning("Couldn't create pipe");
 
-  m_bg = std::async(std::launch::async, [=] { readMidi(); });
+  m_bg = std::async(std::launch::async, [=] { if(m_handle) readMidi(); });
 }
 
 Input::~Input()


### PR DESCRIPTION
- [x] MidiOverIp: if Midi Device is already blocked (from AudioEngine), do not read from it

closes #3171