### PR TITLE
issue 2836

### DIFF
--- a/projects/epc/playground/src/device-settings/SettingsActions.cpp
+++ b/projects/epc/playground/src/device-settings/SettingsActions.cpp
@@ -97,7 +97,6 @@ SettingsActions::SettingsActions(UpdateDocumentContributor* parent, Settings& se
     auto requestedState = request->get("state") == "1";
     SettingsUseCases useCase(settings);
     useCase.setAllRoutingEntries(requestedState);
-    nltools::Log::error(ExceptionTools::handle_eptr(std::current_exception()));
   });
 
   addAction("enable-bbb-wifi-for-epc2", [](auto) {

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
@@ -72,13 +72,24 @@ Glib::ustring RoutingSettings::getDisplayString() const
 void RoutingSettings::setState(RoutingSettings::tRoutingIndex hwIdx, RoutingSettings::tAspectIndex settingIdx,
                                bool state)
 {
+  auto updatePair = [](bool& toSet, bool& other, bool value) {
+    other = !value;
+    toSet = value;
+  };
+
   auto idx = static_cast<size_t>(hwIdx);
   auto& val = m_data.at(idx).at(static_cast<size_t>(settingIdx));
   auto changed = false;
 
   if(val != state)
   {
-    val = state;
+    if(hwIdx != tRoutingIndex::Notes && settingIdx == tAspectIndex::RECEIVE_SPLIT)
+      updatePair(val, m_data.at(idx).at(static_cast<size_t>(tAspectIndex::RECEIVE_PRIMARY)), state);
+    else if(hwIdx != tRoutingIndex::Notes && settingIdx == tAspectIndex::RECEIVE_PRIMARY)
+      updatePair(val, m_data.at(idx).at(static_cast<size_t>(tAspectIndex::RECEIVE_SPLIT)), state);
+    else
+      val = state;
+
     changed = true;
   }
 

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
@@ -43,6 +43,11 @@ void RoutingSettings::load(const Glib::ustring& text, Initiator initiator)
       idx++;
     }
   }
+
+  if(initiator == Initiator::EXPLICIT_LOAD)
+  {
+    sanitizeReceiveHWSourcesAndPC();
+  }
 }
 
 Glib::ustring RoutingSettings::save() const
@@ -67,10 +72,20 @@ Glib::ustring RoutingSettings::getDisplayString() const
 void RoutingSettings::setState(RoutingSettings::tRoutingIndex hwIdx, RoutingSettings::tAspectIndex settingIdx,
                                bool state)
 {
-  auto& val = m_data.at(static_cast<size_t>(hwIdx)).at(static_cast<size_t>(settingIdx));
+  auto idx = static_cast<size_t>(hwIdx);
+  auto& val = m_data.at(idx).at(static_cast<size_t>(settingIdx));
+  auto changed = false;
+
   if(val != state)
   {
     val = state;
+    changed = true;
+  }
+
+  auto wasSanitized = sanitizeReceiveHWSourcesAndPC();
+
+  if(changed || wasSanitized)
+  {
     notify();
   }
 }
@@ -92,7 +107,9 @@ void RoutingSettings::setAllValues(bool value)
     }
   }
 
-  if(anyChanged)
+  auto wasSanitized = sanitizeReceiveHWSourcesAndPC();
+
+  if(anyChanged || wasSanitized)
     notify();
 }
 
@@ -101,32 +118,32 @@ bool RoutingSettings::getState(int hwId, RoutingSettings::tAspectIndex aspect) c
   tRoutingIndex idx = tRoutingIndex::LENGTH;
   switch(hwId)
   {
-      case HW_SOURCE_ID_PEDAL_1:
-        idx = tRoutingIndex::Pedal1;
-        break;
-      case HW_SOURCE_ID_PEDAL_2:
-        idx = tRoutingIndex::Pedal2;
-        break;
-      case HW_SOURCE_ID_PEDAL_3:
-        idx = tRoutingIndex::Pedal3;
-        break;
-      case HW_SOURCE_ID_PEDAL_4:
-        idx = tRoutingIndex::Pedal4;
-        break;
-      case HW_SOURCE_ID_PITCHBEND:
-        idx = tRoutingIndex::Bender;
-        break;
-      case HW_SOURCE_ID_AFTERTOUCH:
-        idx = tRoutingIndex::Aftertouch;
-        break;
-      case HW_SOURCE_ID_RIBBON_1:
-        idx = tRoutingIndex::Ribbon1;
-        break;
-      case HW_SOURCE_ID_RIBBON_2:
-        idx = tRoutingIndex::Ribbon2;
-        break;
-      default:
-        break;
+    case HW_SOURCE_ID_PEDAL_1:
+      idx = tRoutingIndex::Pedal1;
+      break;
+    case HW_SOURCE_ID_PEDAL_2:
+      idx = tRoutingIndex::Pedal2;
+      break;
+    case HW_SOURCE_ID_PEDAL_3:
+      idx = tRoutingIndex::Pedal3;
+      break;
+    case HW_SOURCE_ID_PEDAL_4:
+      idx = tRoutingIndex::Pedal4;
+      break;
+    case HW_SOURCE_ID_PITCHBEND:
+      idx = tRoutingIndex::Bender;
+      break;
+    case HW_SOURCE_ID_AFTERTOUCH:
+      idx = tRoutingIndex::Aftertouch;
+      break;
+    case HW_SOURCE_ID_RIBBON_1:
+      idx = tRoutingIndex::Ribbon1;
+      break;
+    case HW_SOURCE_ID_RIBBON_2:
+      idx = tRoutingIndex::Ribbon2;
+      break;
+    default:
+      break;
   }
   return getState(idx, aspect);
 }
@@ -141,6 +158,32 @@ void RoutingSettings::setAllAspectsForIndex(RoutingSettings::tRoutingIndex hwIdx
     aspect = state;
   }
 
-  if(anyChanged)
+  auto changed = sanitizeReceiveHWSourcesAndPC();
+
+  if(anyChanged || changed)
     notify();
+}
+
+bool RoutingSettings::sanitizeReceiveHWSourcesAndPC()
+{
+  using HW = RoutingSettings::tRoutingIndex;
+
+  auto changed = false;
+
+  for(auto idx : { HW::Aftertouch, HW::Bender, HW::Ribbon1, HW::Ribbon2, HW::Pedal1, HW::Pedal2, HW::Pedal3, HW::Pedal4,
+                   HW::ProgramChange })
+  {
+    auto i = static_cast<size_t>(idx);
+    auto rP = static_cast<size_t>(tAspectIndex::RECEIVE_PRIMARY);
+    auto rS = static_cast<size_t>(tAspectIndex::RECEIVE_SPLIT);
+    auto receivePrim = m_data[i][rP];
+    auto receiveSplit = m_data[i][rS];
+    if(receivePrim && receiveSplit)
+    {
+      m_data[i][rS] = false;
+      changed = true;
+    }
+  }
+
+  return changed;
 }

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
@@ -73,7 +73,8 @@ void RoutingSettings::setState(RoutingSettings::tRoutingIndex hwIdx, RoutingSett
                                bool state)
 {
   auto updatePair = [](bool& toSet, bool& other, bool value) {
-    other = !value;
+    if(value)
+      other = false;
     toSet = value;
   };
 

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.h
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.h
@@ -24,4 +24,5 @@ class RoutingSettings : public Setting
   void setAllValues(bool value);
  private:
   tData m_data;
+  bool sanitizeReceiveHWSourcesAndPC();
 };


### PR DESCRIPTION
added sanitize to all set-ops for RoutingSetting, to prevent ReceiveSplit and ReceivePrimary not to be enabled at the same time for all entrys exept notes, those are allowed, closes #2836