### PR TITLE
3100

### DIFF
--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
@@ -98,6 +98,7 @@ Glib::ustring PhysicalControlParameter::getDisplayString() const
 
 void PhysicalControlParameter::loadFromPreset(UNDO::Transaction *transaction, const tControlPositionValue &value)
 {
+  m_changingFromHWUI = m_lastChangedFromHWUI;
   m_returnModeBeforeLastLoad = getReturnMode();
   m_valueBeforeLastLoad = getControlPositionValue();
   setIndirect(transaction, value);


### PR DESCRIPTION
added takeover of m_lastChanged from HUWI on Presetload, If the parameter was changed from hwui before the ! will not be removed on preset load and if the focus stayed the same (preset was loaded via webui or base-unit). closes #3100