### PR TITLE
issue 3069 (store mode bank wrap)

### DIFF
--- a/projects/epc/playground/src/presets/StoreModeData.h
+++ b/projects/epc/playground/src/presets/StoreModeData.h
@@ -7,7 +7,7 @@ struct StoreModeData
 {
  public:
   StoreModeData();
-  constexpr static size_t invalid = std::numeric_limits<size_t>::max();
-  size_t bankPos = invalid;
-  size_t presetPos = invalid;
+  constexpr static int invalid = std::numeric_limits<int>::max();
+  int bankPos = invalid;
+  int presetPos = invalid;
 };

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListSelectStorePosition.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListSelectStorePosition.cpp
@@ -127,8 +127,8 @@ void PresetListSelectStorePosition::sanitizeBankPosition(PresetManager *pm)
 {
   if(auto numBanks = pm->getNumBanks())
   {
-    m_storeModeData->bankPos = std::min(m_storeModeData->bankPos, numBanks - 1);
-    m_storeModeData->bankPos = std::max(m_storeModeData->bankPos, size_t(0));
+    m_storeModeData->bankPos = std::min(m_storeModeData->bankPos, int(numBanks) - 1);
+    m_storeModeData->bankPos = std::max(m_storeModeData->bankPos, 0);
     return;
   }
 
@@ -141,8 +141,8 @@ void PresetListSelectStorePosition::sanitizePresetPosition(Bank *bank)
   {
     if(auto numPresets = bank->getNumPresets())
     {
-      m_storeModeData->presetPos = std::min(m_storeModeData->presetPos, numPresets - 1);
-      m_storeModeData->presetPos = std::max(m_storeModeData->presetPos, size_t(0));
+      m_storeModeData->presetPos = std::min(m_storeModeData->presetPos, int(numPresets) - 1);
+      m_storeModeData->presetPos = std::max(m_storeModeData->presetPos, 0);
       return;
     }
   }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListSelectStorePosition.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetListSelectStorePosition.h
@@ -31,7 +31,7 @@ class PresetListSelectStorePosition : public PresetListBase
   void onChange();
   void onBankChanged();
 
-  static constexpr size_t invalidIndex = size_t(-1);
+  static constexpr int invalidIndex = int(-1);
 
   Preset *m_selectedPreset = nullptr;
   sigc::connection m_bankConnection;


### PR DESCRIPTION
fix up store-preset-list to not wrap on first bank and DEC event, but rather stay at the current selection. had to change indices to signed int instead of size_t for sanitize to work, closes #3069