### PR TITLE
added FineBipolar160StScaleConverter and FineBipolar200StScaleConverters

### DIFF
--- a/projects/epc/playground/src/groups/CombFilterGroup.cpp
+++ b/projects/epc/playground/src/groups/CombFilterGroup.cpp
@@ -16,6 +16,8 @@
 #include "parameters/scale-converters/CombDecayBipolarMsScaleConverter.h"
 #include "parameters/scale-converters/LinearBipolar100StScaleConverter.h"
 #include "parameter_declarations.h"
+#include "parameters/scale-converters/FineBipolar160StScaleConverter.h"
+#include "parameters/scale-converters/FineBipolar200StScaleConverter.h"
 #include <parameters/scale-converters/LinearBipolar200PercentScaleConverter.h>
 #include <parameters/scale-converters/PitchCombLinearStModulationScaleConverter.h>
 #include <parameters/ModulateableParameterWithUnusualModUnit.h>
@@ -44,7 +46,7 @@ void CombFilterGroup::init()
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Comb_Flt_Pitch_Env_C, getVoiceGroup() },
                                                               SC::get<FineBipolar80StScaleConverter>(),
-                                                              ScaleConverter::get<FineBipolar80StScaleConverter>()));
+                                                              SC::get<FineBipolar160StScaleConverter>()));
 
   appendParameter(new ModulateableParameter(this, { C15::PID::Comb_Flt_Decay, getVoiceGroup() },
                                             SC::get<CombDecayBipolarMsScaleConverter>()));
@@ -64,7 +66,7 @@ void CombFilterGroup::init()
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Comb_Flt_AP_Env_C, getVoiceGroup() },
                                                               SC::get<FineBipolar80StScaleConverter>(),
-                                                              ScaleConverter::get<FineBipolar80StScaleConverter>()));
+                                                              SC::get<FineBipolar160StScaleConverter>()));
 
   appendParameter(new ModulateableParameter(this, { C15::PID::Comb_Flt_AP_Res, getVoiceGroup() },
                                             SC::get<Linear100PercentScaleConverter>()));
@@ -78,7 +80,7 @@ void CombFilterGroup::init()
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Comb_Flt_LP_Env_C, getVoiceGroup() },
                                                               SC::get<LinearBipolar100StScaleConverter>(),
-                                                              SC::get<LinearBipolar100StScaleConverter>()));
+                                                              SC::get<FineBipolar200StScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Comb_Flt_PM, getVoiceGroup() },
                                                               SC::get<LinearBipolar100PercentScaleConverter>(),

--- a/projects/epc/playground/src/groups/OscillatorAGroup.cpp
+++ b/projects/epc/playground/src/groups/OscillatorAGroup.cpp
@@ -17,6 +17,7 @@
 #include "parameters/scale-converters/Fine105PercentScaleConverter.h"
 #include "parameters/scale-converters/Linear80To140StScaleConverter.h"
 #include "parameter_declarations.h"
+#include "parameters/scale-converters/FineBipolar160StScaleConverter.h"
 #include <parameters/scale-converters/LinearBipolar200PercentScaleConverter.h>
 #include <parameters/scale-converters/PitchOscLinearStScaleModulationConverter.h>
 #include <parameters/ModulateableParameterWithUnusualModUnit.h>
@@ -42,7 +43,7 @@ void OscillatorAGroup::init()
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Osc_A_Pitch_Env_C, getVoiceGroup() },
                                                               ScaleConverter::get<FineBipolar80StScaleConverter>(),
-                                                              ScaleConverter::get<FineBipolar80StScaleConverter>()));
+                                                              ScaleConverter::get<FineBipolar160StScaleConverter>()));
 
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_A_Fluct, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
@@ -57,8 +58,10 @@ void OscillatorAGroup::init()
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_A_PM_Self_Env_A, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::Osc_A_PM_Self_Shp, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(
+      new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Osc_A_PM_Self_Shp, getVoiceGroup() },
+                                                  ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+                                                  ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(
       this, { C15::PID::Osc_A_PM_B, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
@@ -67,8 +70,9 @@ void OscillatorAGroup::init()
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_A_PM_B_Env_B, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::Osc_A_PM_B_Shp, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(new ModulateableParameterWithUnusualModUnit(
+      this, { C15::PID::Osc_A_PM_B_Shp, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+      ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(
       this, { C15::PID::Osc_A_PM_FB, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),

--- a/projects/epc/playground/src/groups/OscillatorBGroup.cpp
+++ b/projects/epc/playground/src/groups/OscillatorBGroup.cpp
@@ -15,6 +15,7 @@
 #include "parameters/scale-converters/IdentityScaleConverter.h"
 #include "parameters/scale-converters/FineBipolar80StScaleConverter.h"
 #include "parameter_declarations.h"
+#include "parameters/scale-converters/FineBipolar160StScaleConverter.h"
 #include <parameters/scale-converters/LinearBipolar200PercentScaleConverter.h>
 #include <parameters/scale-converters/PitchOscLinearStScaleModulationConverter.h>
 #include <parameters/ModulateableParameterWithUnusualModUnit.h>
@@ -40,7 +41,7 @@ void OscillatorBGroup::init()
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Osc_B_Pitch_Env_C, getVoiceGroup() },
                                                               ScaleConverter::get<FineBipolar80StScaleConverter>(),
-                                                              ScaleConverter::get<FineBipolar80StScaleConverter>()));
+                                                              ScaleConverter::get<FineBipolar160StScaleConverter>()));
 
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_B_Fluct, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
@@ -55,8 +56,10 @@ void OscillatorBGroup::init()
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_B_PM_Self_Env_B, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::Osc_B_PM_Self_Shp, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(
+      new ModulateableParameterWithUnusualModUnit(this, { C15::PID::Osc_B_PM_Self_Shp, getVoiceGroup() },
+                                                  ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+                                                  ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(
       this, { C15::PID::Osc_B_PM_A, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
@@ -65,8 +68,9 @@ void OscillatorBGroup::init()
   appendParameter(new ModulateableParameter(this, { C15::PID::Osc_B_PM_A_Env_A, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::Osc_B_PM_A_Shp, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(new ModulateableParameterWithUnusualModUnit(
+      this, { C15::PID::Osc_B_PM_A_Shp, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+      ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(
       this, { C15::PID::Osc_B_PM_FB, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),

--- a/projects/epc/playground/src/groups/SVFilterGroup.cpp
+++ b/projects/epc/playground/src/groups/SVFilterGroup.cpp
@@ -9,6 +9,7 @@
 #include "parameters/scale-converters/LinearBipolar60StScaleConverter.h"
 #include "parameters/scale-converters/LinearBipolar100PercentScaleConverter.h"
 #include "parameter_declarations.h"
+#include "parameters/scale-converters/FineBipolar200StScaleConverter.h"
 #include <parameters/scale-converters/LinearBipolar200PercentScaleConverter.h>
 #include <parameters/ModulateableParameterWithUnusualModUnit.h>
 
@@ -38,8 +39,9 @@ void SVFilterGroup::init()
   appendParameter(new Parameter(this, { C15::PID::SV_Flt_Cut_KT, getVoiceGroup() },
                                 ScaleConverter::get<Linear200PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::SV_Flt_Cut_Env_C, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100StScaleConverter>()));
+  appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::SV_Flt_Cut_Env_C, getVoiceGroup() },
+                                                              ScaleConverter::get<LinearBipolar100StScaleConverter>(),
+                                                              ScaleConverter::get<FineBipolar200StScaleConverter>()));
 
   appendParameter(new ModulateableParameter(this, { C15::PID::SV_Flt_Res, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
@@ -47,8 +49,10 @@ void SVFilterGroup::init()
   appendParameter(new Parameter(this, { C15::PID::SV_Flt_Res_KT, getVoiceGroup() },
                                 ScaleConverter::get<LinearBipolar100StScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::SV_Flt_Res_Env_C, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(
+      new ModulateableParameterWithUnusualModUnit(this, { C15::PID::SV_Flt_Res_Env_C, getVoiceGroup() },
+                                                  ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+                                                  ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(this, { C15::PID::SV_Flt_Spread, getVoiceGroup() },
                                                               ScaleConverter::get<LinearBipolar60StScaleConverter>(),
@@ -57,8 +61,9 @@ void SVFilterGroup::init()
   appendParameter(new ModulateableParameter(this, { C15::PID::SV_Flt_LBH, getVoiceGroup() },
                                             ScaleConverter::get<Linear100PercentScaleConverter>()));
 
-  appendParameter(new ModulateableParameter(this, { C15::PID::SV_Flt_Par, getVoiceGroup() },
-                                            ScaleConverter::get<LinearBipolar100PercentScaleConverter>()));
+  appendParameter(new ModulateableParameterWithUnusualModUnit(
+      this, { C15::PID::SV_Flt_Par, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),
+      ScaleConverter::get<LinearBipolar200PercentScaleConverter>()));
 
   appendParameter(new ModulateableParameterWithUnusualModUnit(
       this, { C15::PID::SV_Flt_FM, getVoiceGroup() }, ScaleConverter::get<LinearBipolar100PercentScaleConverter>(),

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.cpp
@@ -1,0 +1,9 @@
+#include "FineBipolar160StScaleConverter.h"
+#include "parameters/scale-converters/dimension/PitchDimension.h"
+
+FineBipolar160StScaleConverter::FineBipolar160StScaleConverter()
+: LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-160, 160), PitchDimension::get())
+{
+}
+
+FineBipolar160StScaleConverter::~FineBipolar160StScaleConverter() noexcept = default;

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <parameters/scale-converters/LinearScaleConverter.h>
+
+class FineBipolar160StScaleConverter : public LinearScaleConverter
+{
+ public:
+  FineBipolar160StScaleConverter();
+  ~FineBipolar160StScaleConverter() noexcept override;
+};

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.cpp
@@ -1,0 +1,9 @@
+#include "FineBipolar200StScaleConverter.h"
+#include "parameters/scale-converters/dimension/PitchDimension.h"
+
+FineBipolar200StScaleConverter::FineBipolar200StScaleConverter()
+: LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-200, 200), PitchDimension::get())
+{
+}
+
+FineBipolar200StScaleConverter::~FineBipolar200StScaleConverter() noexcept = default;

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <parameters/scale-converters/LinearScaleConverter.h>
+
+class FineBipolar200StScaleConverter : public LinearScaleConverter
+{
+ public:
+  FineBipolar200StScaleConverter();
+  ~FineBipolar200StScaleConverter() noexcept override;
+};


### PR DESCRIPTION
changed following scale-converters for mc-amounts:
OSC A/B:
Osc_X_Pitch_Env_C -> FineBipolar160StScaleConverter
Osc_X_PM_Self_Shp -> LinearBipolar200PercentScaleConverter
Osc_X_PM_X_Shp -> LinearBipolar200PercentScaleConverter

Comb:
Pitch Env C -> FineBipolar160StScaleConverter
Hi Cut Env C -> FineBipolar200StScaleConverter
Allpass Env C -> FineBipolar160StScaleConverter

SVF:
Resonance Env C -> LinearBipolar200PercentScaleConverter
Cutoff Env C -> FineBipolar200StScaleConverter
SV_Flt_Par -> LinearBipolar200PercentScaleConverter

@MatthiasSeeber Do we need to change the ParameterList.ods ?

closes #3221 