### PR TITLE
WebUI: issue 3220: Fix Slider Moves out of bounds

### DIFF
--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/parameters/ModulateableValueControl.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/parameters/ModulateableValueControl.java
@@ -10,6 +10,7 @@ abstract class ModulateableValueControl extends ValueControl {
 
 	private boolean drawCorona;
 	private boolean drawThicker;
+	private boolean hasBottomMargin;
 
 	ModulateableValueControl(MapsLayout parent, int parameterID) {
 		super(parent, parameterID);
@@ -67,6 +68,14 @@ abstract class ModulateableValueControl extends ValueControl {
 
 		double coronaLevel = 5;
 		drawCorona = levelOfDetail >= coronaLevel;
+
+		double marginLevel = 4.5;
+		hasBottomMargin = levelOfDetail <= marginLevel;
+	}
+
+	@Override
+	public double getBottomMargin() {
+		return hasBottomMargin ? 10 : 0;
 	}
 
 	@Override

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/parameters/PlayControls/MacroControls/MacroControlParameter.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/parameters/PlayControls/MacroControls/MacroControlParameter.java
@@ -19,6 +19,7 @@ public abstract class MacroControlParameter extends Parameter implements Renamea
 
 	private String info = "";
 
+
 	private class MacroControlValueDisplay extends ValueDisplayLarge {
 		private MacroControlValueDisplay(MapsLayout parent, int parameterID) {
 			super(parent, parameterID);
@@ -26,8 +27,24 @@ public abstract class MacroControlParameter extends Parameter implements Renamea
 	}
 
 	private class MacroControlSlider extends SliderHorizontalWithHandle {
+		private boolean hasBottomMargin = false;
+
 		private MacroControlSlider(MapsLayout parent, int parameterID) {
 			super(parent, parameterID);
+		}
+
+		@Override
+		public void doFirstLayoutPass(double levelOfDetail) {
+			super.doFirstLayoutPass(levelOfDetail);
+			
+			double marginLevel = 4.5;
+			hasBottomMargin = levelOfDetail <= marginLevel;
+		}
+
+		@Override
+		public double getBottomMargin()
+		{
+			return hasBottomMargin ? 10 : 0;
 		}
 	}
 


### PR DESCRIPTION
added bottom margin to sliders when zoom level would have pushed them out of their boxes. closes #3220