### PR TITLE
fix Preset-Manager-Layout Crash + Load Performance

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
@@ -72,6 +72,7 @@ void PresetManagerLayout::setup()
   m_presets = nullptr;
   m_loadMode = nullptr;
   m_bankButton = nullptr;
+  m_changedIndicator = nullptr;
 
   clear();
 
@@ -140,6 +141,8 @@ void PresetManagerLayout::setupBankSelect()
   addControl(new UndoIndicator(Rect(22, 15, 10, 8)));
   addControl(new AnyParameterLockedIndicator(Rect(244, 2, 10, 11)));
   m_loadMode = addControl(new LoadModeMenu(Rect(195, 36, 58, 62)));
+  m_changedIndicator = addControl(new ChangedParameterIndicator(Rect(0, 14, 64, 14)));
+  m_changedIndicator->setVisible(hwui->isModifierSet(ButtonModifier::SHIFT));
 
   auto isDualEB = Application::get().getPresetManager()->getEditBuffer()->isDual();
 

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/PresetManagerLayout.cpp
@@ -141,8 +141,6 @@ void PresetManagerLayout::setupBankSelect()
   addControl(new UndoIndicator(Rect(22, 15, 10, 8)));
   addControl(new AnyParameterLockedIndicator(Rect(244, 2, 10, 11)));
   m_loadMode = addControl(new LoadModeMenu(Rect(195, 36, 58, 62)));
-  m_changedIndicator = addControl(new ChangedParameterIndicator(Rect(0, 14, 64, 14)));
-  m_changedIndicator->setVisible(hwui->isModifierSet(ButtonModifier::SHIFT));
 
   auto isDualEB = Application::get().getPresetManager()->getEditBuffer()->isDual();
 

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/ChangedParameterIndicator.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/ChangedParameterIndicator.cpp
@@ -5,7 +5,8 @@
 #include <proxies/hwui/FrameBuffer.h>
 
 ChangedParameterIndicator::ChangedParameterIndicator(const Rect& pos)
-    : Label(StringAndSuffix{""}, pos)
+    : Label(StringAndSuffix { "" }, pos)
+    , m_worker(std::chrono::milliseconds { 50 })
 {
   auto eb = Application::get().getPresetManager()->getEditBuffer();
   eb->onChange(sigc::mem_fun(this, &ChangedParameterIndicator::update));
@@ -13,46 +14,51 @@ ChangedParameterIndicator::ChangedParameterIndicator(const Rect& pos)
 
 void ChangedParameterIndicator::update()
 {
-  auto eb = Application::get().getPresetManager()->getEditBuffer();
-  auto partGroupI = eb->getParameterGroupByID(GroupId("Part", VoiceGroup::I));
-  auto partGroupII = eb->getParameterGroupByID(GroupId("Part", VoiceGroup::II));
-  auto monoGroupI = eb->getParameterGroupByID(GroupId("Mono", VoiceGroup::I));
-  auto monoGroupII = eb->getParameterGroupByID(GroupId("Mono", VoiceGroup::II));
-  auto unisonGroupI = eb->getParameterGroupByID(GroupId("Unison", VoiceGroup::I));
-  auto unisonGroupII = eb->getParameterGroupByID(GroupId("Unison", VoiceGroup::II));
-  auto masterGroup = eb->getParameterGroupByID(GroupId("Master", VoiceGroup::Global));
-  auto scaleGroup = eb->getParameterGroupByID(GroupId("Scale", VoiceGroup::Global));
+  m_worker.doTask(
+      [this]()
+      {
+        auto eb = Application::get().getPresetManager()->getEditBuffer();
+        auto partGroupI = eb->getParameterGroupByID(GroupId("Part", VoiceGroup::I));
+        auto partGroupII = eb->getParameterGroupByID(GroupId("Part", VoiceGroup::II));
+        auto monoGroupI = eb->getParameterGroupByID(GroupId("Mono", VoiceGroup::I));
+        auto monoGroupII = eb->getParameterGroupByID(GroupId("Mono", VoiceGroup::II));
+        auto unisonGroupI = eb->getParameterGroupByID(GroupId("Unison", VoiceGroup::I));
+        auto unisonGroupII = eb->getParameterGroupByID(GroupId("Unison", VoiceGroup::II));
+        auto masterGroup = eb->getParameterGroupByID(GroupId("Master", VoiceGroup::Global));
+        auto scaleGroup = eb->getParameterGroupByID(GroupId("Scale", VoiceGroup::Global));
 
-  auto partChanged = false;
-  auto monoChanged = false;
-  auto unisonChanged = false;
-  auto masterChanged = masterGroup->isAnyParameterChanged();
-  auto scaleChanged = scaleGroup->isAnyParameterChanged();
+        auto partChanged = false;
+        auto monoChanged = false;
+        auto unisonChanged = false;
+        auto masterChanged = masterGroup->isAnyParameterChanged();
+        auto scaleChanged = scaleGroup->isAnyParameterChanged();
 
-  switch(eb->getType())
-  {
-    case SoundType::Single:
-      partChanged = false;
-      monoChanged = monoGroupI->isAnyParameterChanged();
-      unisonChanged = unisonGroupI->isAnyParameterChanged();
-      break;
-    case SoundType::Layer:
-      partChanged = partGroupI->isAnyParameterChanged() || partGroupII->isAnyParameterChanged();
-      monoChanged = monoGroupI->isAnyParameterChanged();
-      unisonChanged = unisonGroupI->isAnyParameterChanged();
-      break;
-    case SoundType::Split:
-      partChanged = partGroupI->isAnyParameterChanged() || partGroupII->isAnyParameterChanged();
-      monoChanged = monoGroupI->isAnyParameterChanged() || monoGroupII->isAnyParameterChanged();
-      unisonChanged = unisonGroupI->isAnyParameterChanged() || unisonGroupII->isAnyParameterChanged();
-      break;
-    default:
-      break;
-  }
+        switch(eb->getType())
+        {
+          case SoundType::Single:
+            partChanged = false;
+            monoChanged = monoGroupI->isAnyParameterChanged();
+            unisonChanged = unisonGroupI->isAnyParameterChanged();
+            break;
+          case SoundType::Layer:
+            partChanged = partGroupI->isAnyParameterChanged() || partGroupII->isAnyParameterChanged();
+            monoChanged = monoGroupI->isAnyParameterChanged();
+            unisonChanged = unisonGroupI->isAnyParameterChanged();
+            break;
+          case SoundType::Split:
+            partChanged = partGroupI->isAnyParameterChanged() || partGroupII->isAnyParameterChanged();
+            monoChanged = monoGroupI->isAnyParameterChanged() || monoGroupII->isAnyParameterChanged();
+            unisonChanged = unisonGroupI->isAnyParameterChanged() || unisonGroupII->isAnyParameterChanged();
+            break;
+          default:
+            break;
+        }
 
-  std::stringstream ss;
-  ss << (partChanged ? "P" : "") << (monoChanged ? "\uE040" : "") << (unisonChanged ? "\uE041" : "") << (masterChanged ? "M" : "") << (scaleChanged ? "S" : "");
-  setText({ss.str(), 0});
+        std::stringstream ss;
+        ss << (partChanged ? "P" : "") << (monoChanged ? "\uE040" : "") << (unisonChanged ? "\uE041" : "")
+           << (masterChanged ? "M" : "") << (scaleChanged ? "S" : "");
+        setText({ ss.str(), 0 });
+      });
 }
 
 int ChangedParameterIndicator::getZPriority() const

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/ChangedParameterIndicator.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/ChangedParameterIndicator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "proxies/hwui/controls/Label.h"
+#include "nltools/threading/Throttler.h"
 
 class ChangedParameterIndicator : public Label
 {
@@ -9,4 +10,6 @@ class ChangedParameterIndicator : public Label
 
  private:
   void update();
+
+  Throttler m_worker;
 };


### PR DESCRIPTION
set ChangedModifierIndicator peter to null on every focus-change ((Bank, Preset), (Store, Edit, Select))
add Throttler to ChangedModifier to not stall loading + drawing performance