### PR TITLE
removed TCDRange from ScaleConverters

### DIFF
--- a/projects/epc/playground/src/device-settings/RibbonRelativeFactor.cpp
+++ b/projects/epc/playground/src/device-settings/RibbonRelativeFactor.cpp
@@ -14,7 +14,7 @@ class RibbonRelFactorScaleConverter : public LinearScaleConverter
 {
  public:
   RibbonRelFactorScaleConverter()
-      : LinearScaleConverter(tTcdRange(256, 2560), tDisplayRange(1, 10), UnitlessDimension::get())
+      : LinearScaleConverter(tDisplayRange(1, 10), UnitlessDimension::get())
   {
   }
 };
@@ -57,8 +57,9 @@ void RibbonRelativeFactor::set(tControlPositionValue amount)
 
 void RibbonRelativeFactor::syncExternals(SendReason reason) const
 {
-  auto v = static_cast<uint16_t>(m_factor.getTcdValue());
-  Application::get().getPlaycontrollerProxy()->sendSetting(RIBBON_REL_FACTOR, v);
+  auto proxy = Application::get().getPlaycontrollerProxy();
+  auto tcdValue = proxy->ribbonRelativeFactorToTCDValue(m_factor.getQuantizedClipped());
+  proxy->sendSetting(RIBBON_REL_FACTOR, tcdValue);
 }
 
 void RibbonRelativeFactor::setDefault()

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
@@ -72,7 +72,8 @@ Glib::ustring RoutingSettings::getDisplayString() const
 void RoutingSettings::setState(RoutingSettings::tRoutingIndex hwIdx, RoutingSettings::tAspectIndex settingIdx,
                                bool state)
 {
-  auto updatePair = [](bool& toSet, bool& other, bool value) {
+  auto updatePair = [](bool& toSet, bool& other, bool value)
+  {
     if(value)
       other = false;
     toSet = value;
@@ -109,19 +110,14 @@ const RoutingSettings::tData& RoutingSettings::getRaw() const
 
 void RoutingSettings::setAllValues(bool value)
 {
-  bool anyChanged = false;
+  auto old_values = m_data;
+
   for(auto& entry : m_data)
-  {
     for(auto& aspect : entry)
-    {
-      anyChanged |= (aspect != value);
       aspect = value;
-    }
-  }
 
-  auto wasSanitized = sanitizeReceiveHWSourcesAndPC();
-
-  if(anyChanged || wasSanitized)
+  sanitizeReceiveHWSourcesAndPC();
+  if(m_data != old_values)
     notify();
 }
 

--- a/projects/epc/playground/src/parameters/ModulateableParameter.cpp
+++ b/projects/epc/playground/src/parameters/ModulateableParameter.cpp
@@ -45,12 +45,6 @@ tDisplayValue ModulateableParameter::getModulationAmount() const
   return m_modulationAmount;
 }
 
-void ModulateableParameter::writeToPlaycontroller(MessageComposer &cmp) const
-{
-  Parameter::writeToPlaycontroller(cmp);
-  cmp << getModulationSourceAndAmountPacked();
-}
-
 uint16_t ModulateableParameter::getModulationSourceAndAmountPacked() const
 {
   if(getModulationSource() == MacroControls::NONE)
@@ -228,17 +222,6 @@ double ModulateableParameter::getModulationAmountFineDenominator() const
 double ModulateableParameter::getModulationAmountCoarseDenominator() const
 {
   return ParameterDB::getCourseModulationDenominator(getID());
-}
-
-void ModulateableParameter::exportReaktorParameter(std::stringstream &target) const
-{
-  super::exportReaktorParameter(target);
-  auto packedModulationInfo = getModulationSourceAndAmountPacked();
-
-  if(m_modSource == MacroControls::NONE)
-    packedModulationInfo = 0x2000;
-
-  target << packedModulationInfo << std::endl;
 }
 
 Glib::ustring ModulateableParameter::stringizeModulationAmount() const

--- a/projects/epc/playground/src/parameters/ModulateableParameter.h
+++ b/projects/epc/playground/src/parameters/ModulateableParameter.h
@@ -12,7 +12,6 @@ class ModulateableParameter : public Parameter
   ModulateableParameter(ParameterGroup *group, ParameterId id, const ScaleConverter *scaling);
   ~ModulateableParameter() override;
 
-  void writeToPlaycontroller(MessageComposer &cmp) const override;
   size_t getHash() const override;
 
   tDisplayValue getModulationAmount() const;
@@ -35,8 +34,6 @@ class ModulateableParameter : public Parameter
 
   void copyFrom(UNDO::Transaction *transaction, const PresetParameter *other) override;
   void copyTo(UNDO::Transaction *transaction, PresetParameter *other) const override;
-
-  void exportReaktorParameter(std::stringstream &target) const override;
 
   virtual Glib::ustring stringizeModulationAmount() const;
   virtual Glib::ustring stringizeModulationAmount(tControlPositionValue amt) const;

--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -364,11 +364,6 @@ tControlPositionValue Parameter::getFactoryDefaultValue() const
   return m_value.getFactoryDefaultValue();
 }
 
-tTcdValue Parameter::getTcdValue() const
-{
-  return m_value.getTcdValue();
-}
-
 tDisplayValue Parameter::getDisplayValue() const
 {
   return m_value.getDisplayValue();
@@ -502,19 +497,6 @@ bool Parameter::shouldWriteDocProperties(UpdateDocumentContributor::tUpdateID kn
   return knownRevision == 0;
 }
 
-void Parameter::writeToPlaycontroller(MessageComposer &cmp) const
-{
-  gint16 v = getTcdValue();
-  cmp << v;
-}
-
-void Parameter::undoableLoadValue(UNDO::Transaction *transaction, const Glib::ustring &value)
-{
-  auto tcdValue = std::stoi(value);
-  auto cpValue = m_value.getScaleConverter()->tcdToControlPosition(tcdValue);
-  loadFromPreset(transaction, cpValue);
-}
-
 void Parameter::undoableRandomize(UNDO::Transaction *transaction, Initiator initiator, double amount)
 {
   auto rnd = g_random_double_range(0.0, 1.0);
@@ -524,11 +506,6 @@ void Parameter::undoableRandomize(UNDO::Transaction *transaction, Initiator init
 
   auto quantized = getValue().getQuantizedValue(newPos, true);
   setCpValue(transaction, initiator, quantized, false);
-}
-
-void Parameter::exportReaktorParameter(std::stringstream &target) const
-{
-  target << getTcdValue() << std::endl;
 }
 
 Layout *Parameter::createLayout(FocusAndMode focusAndMode) const

--- a/projects/epc/playground/src/parameters/Parameter.h
+++ b/projects/epc/playground/src/parameters/Parameter.h
@@ -92,7 +92,6 @@ class Parameter : public UpdateDocumentContributor,
 
   virtual void undoableRandomize(UNDO::Transaction *transaction, Initiator initiator, double amount);
 
-  void undoableLoadValue(UNDO::Transaction *transaction, const Glib::ustring &value);
   virtual void loadDefault(UNDO::Transaction *transaction, Defaults mode);
   void undoableSetDefaultValue(UNDO::Transaction *transaction, const PresetParameter *values);
 
@@ -100,9 +99,6 @@ class Parameter : public UpdateDocumentContributor,
   void undoableUnlock(UNDO::Transaction *transaction);
   virtual bool isLocked() const;
 
-  virtual void exportReaktorParameter(std::stringstream &target) const;
-
-  tTcdValue getTcdValue() const;
   tDisplayValue getDisplayValue() const;
   virtual tControlPositionValue getControlPositionValue() const;
   virtual Glib::ustring getDisplayString() const;
@@ -115,7 +111,6 @@ class Parameter : public UpdateDocumentContributor,
   void writeDocument(Writer &writer, tUpdateID knownRevision) const override;
   virtual void writeDiff(Writer &writer, Parameter *other) const;
   virtual void writeDifferences(Writer &writer, Parameter *other) const;
-  virtual void writeToPlaycontroller(MessageComposer &cmp) const;
   void invalidate();
 
   virtual Glib::ustring getLongName() const;

--- a/projects/epc/playground/src/parameters/RibbonParameter.cpp
+++ b/projects/epc/playground/src/parameters/RibbonParameter.cpp
@@ -366,7 +366,9 @@ void RibbonParameter::sendToPlaycontroller() const
   PhysicalControlParameter::sendToPlaycontroller();
   auto id = getID() == HardwareSourcesGroup::getUpperRibbonParameterID() ? PLAYCONTROLLER_SETTING_ID_UPPER_RIBBON_VALUE
                                                                          : PLAYCONTROLLER_SETTING_ID_LOWER_RIBBON_VALUE;
-  Application::get().getPlaycontrollerProxy()->sendSetting(id, getValue().getTcdValue());
+  auto proxy = Application::get().getPlaycontrollerProxy();
+  auto newValue = proxy->ribbonCPValueToTCDValue(getValue().getQuantizedClipped(), isBiPolar());
+  proxy->sendSetting(id, newValue);
 }
 
 void RibbonParameter::onLocalEnableChanged(bool localEnableState)
@@ -406,5 +408,7 @@ void RibbonParameter::setCPFromSetting(UNDO::Transaction *transaction, const tCo
   Parameter::setCPFromSetting(transaction, cpValue);
   auto id = getID() == HardwareSourcesGroup::getUpperRibbonParameterID() ? PLAYCONTROLLER_SETTING_ID_UPPER_RIBBON_VALUE
                                                                          : PLAYCONTROLLER_SETTING_ID_LOWER_RIBBON_VALUE;
-  Application::get().getPlaycontrollerProxy()->sendSetting(id, getValue().getTcdValue());
+  auto proxy = Application::get().getPlaycontrollerProxy();
+  auto v = proxy->ribbonCPValueToTCDValue(getValue().getQuantizedClipped(), isBiPolar());
+  proxy->sendSetting(id, v);
 }

--- a/projects/epc/playground/src/parameters/scale-converters/BaseKeyScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/BaseKeyScaleConverter.cpp
@@ -3,7 +3,7 @@
 #include "dimension/NoteDimensionIgnoreOctave.h"
 
 BaseKeyScaleConverter::BaseKeyScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 11), tDisplayRange(0, 11), NoteDimensionIgnoreOctave::get())
+    : LinearScaleConverter(tDisplayRange(0, 11), NoteDimensionIgnoreOctave::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/BipolarParabolic100PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/BipolarParabolic100PercentScaleConverter.cpp
@@ -3,7 +3,6 @@
 
 BipolarParabolic100PercentScaleConverter::BipolarParabolic100PercentScaleConverter()
     : ScaleConverter(PercentageDimension3Digits::get())
-    , m_tcdRange(-8000, 8000)
     , m_displayRange(-100, 100)
 {
 }
@@ -15,16 +14,6 @@ BipolarParabolic100PercentScaleConverter::~BipolarParabolic100PercentScaleConver
 bool BipolarParabolic100PercentScaleConverter::isBiPolar() const
 {
   return true;
-}
-
-tTcdValue BipolarParabolic100PercentScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), false);
-}
-
-tControlPositionValue BipolarParabolic100PercentScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, m_tcdRange, false);
 }
 
 tDisplayValue

--- a/projects/epc/playground/src/parameters/scale-converters/BipolarParabolic100PercentScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/BipolarParabolic100PercentScaleConverter.h
@@ -9,12 +9,9 @@ class BipolarParabolic100PercentScaleConverter : public ScaleConverter
   ~BipolarParabolic100PercentScaleConverter() override;
 
   [[nodiscard]] bool isBiPolar() const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
 
  private:
-  tTcdRange m_tcdRange;
   tDisplayRange m_displayRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/CombDecayBipolarMsScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/CombDecayBipolarMsScaleConverter.cpp
@@ -4,7 +4,6 @@
 CombDecayBipolarMsScaleConverter::CombDecayBipolarMsScaleConverter()
     : ScaleConverter(TimeDimension<3>::get())
     , m_displayRange(1, 100000)
-    , m_tcdRange(-8000, 8000)
 {
 }
 
@@ -15,22 +14,6 @@ CombDecayBipolarMsScaleConverter::~CombDecayBipolarMsScaleConverter()
 bool CombDecayBipolarMsScaleConverter::isBiPolar() const
 {
   return true;
-}
-
-tTcdValue CombDecayBipolarMsScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  if(cpValue == 0)
-    return 0;
-
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), false);
-}
-
-tControlPositionValue CombDecayBipolarMsScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  if(v == 0)
-    return 0;
-
-  return getControlPositionRange().scaleValueToRange(v, m_tcdRange, false);
 }
 
 tDisplayValue CombDecayBipolarMsScaleConverter::controlPositionToDisplay(const tControlPositionValue &cpValue) const

--- a/projects/epc/playground/src/parameters/scale-converters/CombDecayBipolarMsScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/CombDecayBipolarMsScaleConverter.h
@@ -10,11 +10,8 @@ class CombDecayBipolarMsScaleConverter : public ScaleConverter
 
   [[nodiscard]] bool isBiPolar() const override;
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
 
  private:
   tDisplayRange m_displayRange;
-  tTcdRange m_tcdRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/EditSmoothingTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/EditSmoothingTimeMSScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/TimeDimension.h"
 
 EditSmoothingTimeMSScaleConverter::EditSmoothingTimeMSScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 200.0), TimeDimension<3>::get())
+    : LinearScaleConverter(tDisplayRange(0, 200.0), TimeDimension<3>::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeAttackDecayTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeAttackDecayTimeMSScaleConverter.cpp
@@ -3,7 +3,6 @@
 
 EnvelopeAttackDecayTimeMSScaleConverter::EnvelopeAttackDecayTimeMSScaleConverter()
     : ScaleConverter(TimeDimension<3>::get())
-    , m_tcdRange(0, 16000)
 {
 }
 
@@ -18,16 +17,6 @@ tDisplayValue
     return 11.3 * cpValue;
 
   return 0.1 * exp((log(16000) - log(0.1)) * cpValue);
-}
-
-tTcdValue EnvelopeAttackDecayTimeMSScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), true);
-}
-
-tControlPositionValue EnvelopeAttackDecayTimeMSScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, m_tcdRange, true);
 }
 
 Glib::ustring EnvelopeAttackDecayTimeMSScaleConverter::controlPositionToDisplayJS() const

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeAttackDecayTimeMSScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeAttackDecayTimeMSScaleConverter.h
@@ -11,11 +11,6 @@ class EnvelopeAttackDecayTimeMSScaleConverter : public ScaleConverter
   ~EnvelopeAttackDecayTimeMSScaleConverter() override;
 
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
   [[nodiscard]] bool isBiPolar() const override;
-
- private:
-  tTcdRange m_tcdRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeDecayTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeDecayTimeMSScaleConverter.cpp
@@ -3,7 +3,6 @@
 
 EnvelopeDecayTimeMSScaleConverter::EnvelopeDecayTimeMSScaleConverter()
     : ScaleConverter(TimeDimension<3>::get())
-    , m_tcdRange(0, 16000)
     , m_displayRange(0.0, 16000.0)
 {
 }
@@ -18,16 +17,6 @@ tDisplayValue EnvelopeDecayTimeMSScaleConverter::controlPositionToDisplay(const 
     return 11.3 * cpValue;
 
   return 0.1 * exp(log(16000) - log(0.1) * cpValue);
-}
-
-tTcdValue EnvelopeDecayTimeMSScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), true);
-}
-
-tControlPositionValue EnvelopeDecayTimeMSScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, m_tcdRange, true);
 }
 
 Glib::ustring EnvelopeDecayTimeMSScaleConverter::controlPositionToDisplayJS() const

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeDecayTimeMSScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeDecayTimeMSScaleConverter.h
@@ -11,12 +11,9 @@ class EnvelopeDecayTimeMSScaleConverter : public ScaleConverter
   ~EnvelopeDecayTimeMSScaleConverter() override;
 
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
   [[nodiscard]] bool isBiPolar() const override;
 
  private:
-  tTcdRange m_tcdRange;
   tDisplayRange m_displayRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeReleaseTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeReleaseTimeMSScaleConverter.cpp
@@ -20,21 +20,6 @@ tDisplayValue EnvelopeReleaseTimeMSScaleConverter::controlPositionToDisplay(cons
   return 0.1 * exp((log(16000) - log(0.1)) * cpValue * 1.01);
 }
 
-tTcdValue EnvelopeReleaseTimeMSScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  tTcdRange tcdRange(0, 16160);
-  tControlPositionRange cpRange(0.0, 1.01);
-  return tcdRange.scaleValueToRange(cpValue * 1.01, cpRange, true);
-}
-
-tControlPositionValue EnvelopeReleaseTimeMSScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  tTcdRange tcdRange(0, 16160);
-  tControlPositionRange cpRange(0.0, 1.01);
-  auto r = cpRange.scaleValueToRange(v, tcdRange, true);
-  return r / 1.01;
-}
-
 Glib::ustring EnvelopeReleaseTimeMSScaleConverter::controlPositionToDisplayJS() const
 {
   std::stringstream s;

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeReleaseTimeMSScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeReleaseTimeMSScaleConverter.h
@@ -17,8 +17,6 @@ class EnvelopeReleaseTimeMSScaleConverter : public ScaleConverter
   EnvelopeReleaseTimeMSScaleConverter &operator=(const EnvelopeReleaseTimeMSScaleConverter &) = delete;
 
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
   [[nodiscard]] bool isBiPolar() const override;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/EnvelopeTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/EnvelopeTimeMSScaleConverter.cpp
@@ -1,7 +1,7 @@
 #include "EnvelopeTimeMSScaleConverter.h"
 
 EnvelopeTimeMSScaleConverter::EnvelopeTimeMSScaleConverter()
-    : TimeScaleConverter(tTcdRange(0, 16000), tDisplayRange(1.0, 160000.0))
+    : TimeScaleConverter(tDisplayRange(1.0, 160000.0))
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Fine105PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Fine105PercentScaleConverter.cpp
@@ -2,14 +2,14 @@
 #include "dimension/PercentageDimensionFine.h"
 
 Fine105PercentScaleConverter::Fine105PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10500), tDisplayRange(0, 105), PercentageDimensionFine::get())
+    : LinearScaleConverter(tDisplayRange(0, 105), PercentageDimensionFine::get())
 {
 }
 
 Fine105PercentScaleConverter::~Fine105PercentScaleConverter() noexcept = default;
 
 Fine200PercentScaleConverter::Fine200PercentScaleConverter()
-  : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 200), PercentageDimensionFine::get())
+  : LinearScaleConverter(tDisplayRange(0, 200), PercentageDimensionFine::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Fine12STScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Fine12STScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionFine.h"
 
 Fine12STScaleConverter::Fine12STScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(0, 12), PitchDimensionFine::get())
+    : LinearScaleConverter(tDisplayRange(0, 12), PitchDimensionFine::get())
 {
 }
 
@@ -11,6 +11,6 @@ Fine12STScaleConverter::~Fine12STScaleConverter()
 }
 
 Fine24STScaleConverter::Fine24STScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(0, 24), PitchDimensionFine::get())
+    : LinearScaleConverter(tDisplayRange(0, 24), PitchDimensionFine::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar1200CTScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar1200CTScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "parameters/scale-converters/dimension/CentDimension.h"
 
 FineBipolar1200CTScaleConverter::FineBipolar1200CTScaleConverter()
-    : LinearScaleConverter(tTcdRange(-1200, 1200), tDisplayRange(-1200, 1200), CentDimension::get())
+    : LinearScaleConverter(tDisplayRange(-1200, 1200), CentDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar12STScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar12STScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionFine.h"
 
 FineBipolar12STScaleConverter::FineBipolar12STScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-12, 12), PitchDimensionFine::get())
+    : LinearScaleConverter(tDisplayRange(-12, 12), PitchDimensionFine::get())
 {
 }
 
@@ -11,6 +11,6 @@ FineBipolar12STScaleConverter::~FineBipolar12STScaleConverter()
 }
 
 FineBipolar24STScaleConverter::FineBipolar24STScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-24, 24), PitchDimensionFine::get())
+    : LinearScaleConverter(tDisplayRange(-24, 24), PitchDimensionFine::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar160StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "parameters/scale-converters/dimension/PitchDimension.h"
 
 FineBipolar160StScaleConverter::FineBipolar160StScaleConverter()
-: LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-160, 160), PitchDimension::get())
+: LinearScaleConverter(tDisplayRange(-160, 160), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar200StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "parameters/scale-converters/dimension/PitchDimension.h"
 
 FineBipolar200StScaleConverter::FineBipolar200StScaleConverter()
-: LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-200, 200), PitchDimension::get())
+: LinearScaleConverter(tDisplayRange(-200, 200), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/FineBipolar80StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/FineBipolar80StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 FineBipolar80StScaleConverter::FineBipolar80StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-80, 80), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-80, 80), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/IdentityScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/IdentityScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/UnitlessDimension.h"
 
 IdentityScaleConverter::IdentityScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 100), UnitlessDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 100), UnitlessDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/KeyScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/KeyScaleConverter.cpp
@@ -4,8 +4,7 @@
 static const short c_range = 1200;
 
 KeyScaleConverter::KeyScaleConverter()
-    : LinearScaleConverter(tTcdRange(-10 * c_range, 10 * c_range), tDisplayRange(-c_range, c_range),
-                           CentDimension::get())
+    : LinearScaleConverter(tDisplayRange(-c_range, c_range), CentDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LevelScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LevelScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/LevelDimension.h"
 
 LevelScaleConverter::LevelScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 1 << 13), tDisplayRange(0, 100), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 100), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear0To140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear0To140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear0To140StScaleConverter::Linear0To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 14000), tDisplayRange(0, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(0, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear100PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear100PercentScaleConverter.cpp
@@ -2,14 +2,14 @@
 #include "dimension/PercentageDimension.h"
 
 Linear100PercentScaleConverter::Linear100PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 100), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 100), PercentageDimension::get())
 {
 }
 
 Linear100PercentScaleConverter::~Linear100PercentScaleConverter() noexcept = default;
 
 Linear200PercentScaleConverter::Linear200PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 200), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 200), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear12CountScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear12CountScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/VoicesDimension.h"
 
 Linear12CountScaleConverter::Linear12CountScaleConverter()
-    : LinearScaleConverter(tTcdRange(1, 12), tDisplayRange(1, 12), VoicesDimension::get())
+    : LinearScaleConverter(tDisplayRange(1, 12), VoicesDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear180DegreeScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear180DegreeScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/DegreeDimension.h"
 
 Linear180DegreeScaleConverter::Linear180DegreeScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 14400), tDisplayRange(0, 180), DegreeDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 180), DegreeDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear20To100StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear20To100StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear20To100StScaleConverter::Linear20To100StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(20, 100), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(20, 100), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear20To140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear20To140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear20To140StScaleConverter::Linear20To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(20, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(20, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear24StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear24StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 Linear24StScaleConverter::Linear24StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(0, 24), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 24), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear24To120StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear24To120StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear24To120StScaleConverter::Linear24To120StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 9600), tDisplayRange(24, 120), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(24, 120), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear25DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear25DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/LevelDimension.h"
 
 Linear25DbScaleConverter::Linear25DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(0, 25), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 25), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear360DegreeScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear360DegreeScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/DegreeDimension.h"
 
 Linear360DegreeScaleConverter::Linear360DegreeScaleConverter()
-    : super(tTcdRange(0, 14400), tDisplayRange(0, 360), DegreeDimension::get())
+    : super(tDisplayRange(0, 360), DegreeDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear40To140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear40To140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "Linear40To140StScaleConverter.h"
 
 Linear40To140StScaleConverter::Linear40To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(40, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(40, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear50DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear50DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/LevelDimension.h"
 
 Linear50DbScaleConverter::Linear50DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(0, 50), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 50), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear60DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear60DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/LevelDimension.h"
 
 Linear60DbScaleConverter::Linear60DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 15360), tDisplayRange(0, 60), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 60), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear60KeyScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear60KeyScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/KeyDimension.h"
 
 Linear60KeyScaleConverter::Linear60KeyScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 60), tDisplayRange(0, 60), KeyDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 60), KeyDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/Linear60StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear60StScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "Linear60StScaleConverter.h"
 
 Linear60StScaleConverter::Linear60StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 6000), tDisplayRange(0, 60), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(0, 60), PitchDimensionCoarse::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/Linear60To140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear60To140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear60To140StScaleConverter::Linear60To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 16000), tDisplayRange(60, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(60, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear70DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear70DbScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "Linear70DbScaleConverter.h"
 
 Linear70DbScaleConverter::Linear70DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 14400), tDisplayRange(0, 70), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 70), LevelDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/Linear80To140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear80To140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear80To140StScaleConverter::Linear80To140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(80, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(80, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Linear96StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Linear96StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 Linear96StScaleConverter::Linear96StScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 9600), tDisplayRange(0, 96), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(0, 96), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar100PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar100PercentScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PercentageDimension.h"
 
 LinearBipolar100PercentScaleConverter::LinearBipolar100PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-100, 100), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(-100, 100), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar100StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar100StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar100StScaleConverter::LinearBipolar100StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-100, 100), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-100, 100), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar120StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar120StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar120StScaleConverter::LinearBipolar120StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7500, 7500), tDisplayRange(-120, 120), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-120, 120), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar140StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar140StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar140StScaleConverter::LinearBipolar140StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7500, 7500), tDisplayRange(-140, 140), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-140, 140), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar150StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar150StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar150StScaleConverter::LinearBipolar150StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7500, 7500), tDisplayRange(-150, 150), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-150, 150), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar1DbstScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar1DbstScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar1DbstScaleConverter.h"
 
 LinearBipolar1DbstScaleConverter::LinearBipolar1DbstScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-1, 1), DBPerSTDimension::get())
+    : LinearScaleConverter(tDisplayRange(-1, 1), DBPerSTDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar200PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar200PercentScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PercentageDimension.h"
 
 LinearBipolar200PercentScaleConverter::LinearBipolar200PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(-2000, 2000), tDisplayRange(-200, 200), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(-200, 200), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar24DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar24DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar24DbScaleConverter.h"
 
 LinearBipolar24DbScaleConverter::LinearBipolar24DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-24, 24), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-24, 24), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar25DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar25DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar25DbScaleConverter.h"
 
 LinearBipolar25DbScaleConverter::LinearBipolar25DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-25, 25), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-25, 25), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar33PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar33PercentScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PercentageDimension.h"
 
 LinearBipolar33PercentScaleConverter::LinearBipolar33PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6600, 6600), tDisplayRange(-33, 33), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(-33, 33), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar36StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar36StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar36StScaleConverter::LinearBipolar36StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-36, 36), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-36, 36), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar48DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar48DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar48DbScaleConverter.h"
 
 LinearBipolar48DbScaleConverter::LinearBipolar48DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-48, 48), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-48, 48), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar48StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar48StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 LinearBipolar48StScaleConverter::LinearBipolar48StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-4800, 4800), tDisplayRange(-48, 48), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-48, 48), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar50DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar50DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar50DbScaleConverter.h"
 
 LinearBipolar50DbScaleConverter::LinearBipolar50DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-50, 50), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-50, 50), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar50PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar50PercentScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PercentageDimension.h"
 
 LinearBipolar50PercentScaleConverter::LinearBipolar50PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-50, 50), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(-50, 50), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar59StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar59StScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar59StScaleConverter::LinearBipolar59StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-59, 59), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-59, 59), PitchDimensionCoarse::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar60DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar60DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolar60DbScaleConverter.h"
 
 LinearBipolar60DbScaleConverter::LinearBipolar60DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-60, 60), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-60, 60), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar60StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar60StScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar60StScaleConverter::LinearBipolar60StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-60, 60), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-60, 60), PitchDimensionCoarse::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar66PercentScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar66PercentScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PercentageDimension.h"
 
 LinearBipolar66PercentScaleConverter::LinearBipolar66PercentScaleConverter()
-    : LinearScaleConverter(tTcdRange(-6600, 6600), tDisplayRange(-66, 66), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(-66, 66), PercentageDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar70DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar70DbScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "LinearBipolar70DbScaleConverter.h"
 
 LinearBipolar70DbScaleConverter::LinearBipolar70DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-70, 70), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-70, 70), LevelDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar80StScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar80StScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar80StScaleConverter::LinearBipolar80StScaleConverter()
-    : LinearScaleConverter(tTcdRange(-8000, 8000), tDisplayRange(-80, 80), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-80, 80), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar96StScaleConverterCoarse.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar96StScaleConverterCoarse.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimensionCoarse.h"
 
 LinearBipolar96StScaleConverterCoarse::LinearBipolar96StScaleConverterCoarse()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-96, 96), PitchDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-96, 96), PitchDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolar96StScaleConverterFine.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolar96StScaleConverterFine.cpp
@@ -2,6 +2,6 @@
 #include "LinearBipolar96StScaleConverterFine.h"
 
 LinearBipolar96StScaleConverterFine::LinearBipolar96StScaleConverterFine()
-    : LinearScaleConverter(tTcdRange(-6000, 6000), tDisplayRange(-96, 96), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-96, 96), PitchDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearBipolarInverted60DBTScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearBipolarInverted60DBTScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "LinearBipolarInverted60DBTScaleConverter.h"
 
 LinearBipolarInverted60DbtScaleConverter::LinearBipolarInverted60DbtScaleConverter()
-    : LinearScaleConverter(tTcdRange(-60, 60), tDisplayRange(-60, 60), DBTDimension::get())
+    : LinearScaleConverter(tDisplayRange(-60, 60), DBTDimension::get())
 
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearCountScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearCountScaleConverter.h
@@ -5,7 +5,7 @@ template <int tCount, typename tDimension> class LinearCountScaleConverter : pub
 {
  public:
   LinearCountScaleConverter()
-      : LinearScaleConverter(tTcdRange(0, tCount - 1), tDisplayRange(0, tCount - 1), tDimension::get())
+      : LinearScaleConverter(tDisplayRange(0, tCount - 1), tDimension::get())
   {
   }
 };

--- a/projects/epc/playground/src/parameters/scale-converters/LinearHerzScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearHerzScaleConverter.cpp
@@ -2,7 +2,6 @@
 #include "LinearHerzScaleConverter.h"
 
 LinearHerzScaleConverter::LinearHerzScaleConverter()
-    : LinearScaleConverter(ScaleConverter::tTcdRange { 0, 16000 }, tDisplayRange { 400, 480 },
-                           FrequencyDimension::get())
+    : LinearScaleConverter(tDisplayRange { 400, 480 }, FrequencyDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearMinus50To0DbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearMinus50To0DbScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/LevelDimension.h"
 
 LinearMinus50To0DbScaleConverter::LinearMinus50To0DbScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 10000), tDisplayRange(-50, 0), LevelDimension::get())
+    : LinearScaleConverter(tDisplayRange(-50, 0), LevelDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/LinearScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearScaleConverter.cpp
@@ -1,9 +1,7 @@
 #include "LinearScaleConverter.h"
 
-LinearScaleConverter::LinearScaleConverter(const tTcdRange &tcdRange, const tDisplayRange &displayRange,
-                                           const Dimension &dim)
+LinearScaleConverter::LinearScaleConverter(const tDisplayRange& displayRange, const Dimension& dim)
     : ScaleConverter(dim)
-    , m_tcdRange(tcdRange)
     , m_displayRange(displayRange)
 {
 }
@@ -22,16 +20,6 @@ tDisplayValue LinearScaleConverter::controlPositionToDisplay(const tControlPosit
   return m_displayRange.scaleValueToRange(cpValue, getControlPositionRange(), true);
 }
 
-tTcdValue LinearScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), false);
-}
-
-tControlPositionValue LinearScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, getTcdRange(), false);
-}
-
 Glib::ustring LinearScaleConverter::controlPositionToDisplayJS() const
 {
   return m_displayRange.getScaleValueToRangeJS(getControlPositionRange(), getDimension());
@@ -39,5 +27,5 @@ Glib::ustring LinearScaleConverter::controlPositionToDisplayJS() const
 
 size_t LinearScaleConverter::hash() const
 {
-  return super::hash() ^ m_tcdRange.hash() ^ (m_displayRange.hash() << 1);
+  return super::hash() ^ (m_displayRange.hash() << 1);
 }

--- a/projects/epc/playground/src/parameters/scale-converters/LinearScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/LinearScaleConverter.h
@@ -5,18 +5,13 @@
 class LinearScaleConverter : public ScaleConverter
 {
   typedef ScaleConverter super;
-  tTcdRange m_tcdRange;
   tDisplayRange m_displayRange;
 
  public:
-  LinearScaleConverter(const tTcdRange &tcdRange, const tDisplayRange &displayRange, const Dimension &dim);
-
+  LinearScaleConverter(const tDisplayRange& displayRange, const Dimension& dim);
   ~LinearScaleConverter() override;
 
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
-
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
   [[nodiscard]] bool isBiPolar() const override;
   [[nodiscard]] size_t hash() const override;

--- a/projects/epc/playground/src/parameters/scale-converters/MacroControlScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/MacroControlScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/PercentageDimension.h"
 
 MacroControlScaleConverter::MacroControlScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 3200), tDisplayRange(0, 100), PercentageDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 100), PercentageDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/OnOffScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/OnOffScaleConverter.cpp
@@ -5,16 +5,6 @@ tDisplayValue OnOffScaleConverter::controlPositionToDisplay(const tControlPositi
   return cpValue;
 }
 
-tTcdValue OnOffScaleConverter::controlPositionToTcd(const tControlPositionValue& cpValue) const
-{
-  return cpValue;
-}
-
-tControlPositionValue OnOffScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return v;
-}
-
 bool OnOffScaleConverter::isBiPolar() const
 {
   return false;

--- a/projects/epc/playground/src/parameters/scale-converters/OnOffScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/OnOffScaleConverter.h
@@ -6,7 +6,5 @@ class OnOffScaleConverter : public LinearCountScaleConverter<2, OnOffDimension>
 {
  public:
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue& cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue& cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] bool isBiPolar() const override;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/Parabolic10HzScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Parabolic10HzScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/FrequencyDimension.h"
 
 Parabolic10HzScaleConverter::Parabolic10HzScaleConverter()
-    : ParabolicScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 10), FrequencyDimension::get())
+    : ParabolicScaleConverter(tDisplayRange(0, 10), FrequencyDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Parabolic2000MsScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Parabolic2000MsScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/TimeDimension.h"
 
 Parabolic2000MsScaleConverter::Parabolic2000MsScaleConverter()
-    : ParabolicScaleConverter(tTcdRange(0, 16000), tDisplayRange(0, 2000), TimeDimension<3>::get())
+    : ParabolicScaleConverter(tDisplayRange(0, 2000), TimeDimension<3>::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/Parabolic50MsScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/Parabolic50MsScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "dimension/TimeDimension.h"
 
 Parabolic50MsScaleConverter::Parabolic50MsScaleConverter()
-    : ParabolicScaleConverter(tTcdRange(0, 12500), tDisplayRange(0, 50), TimeDimension<3>::get())
+    : ParabolicScaleConverter(tDisplayRange(0, 50), TimeDimension<3>::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/ParabolicGainDbScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/ParabolicGainDbScaleConverter.cpp
@@ -34,16 +34,6 @@ tControlPositionValue ParabolicGainDbScaleConverter::displayToControlPosition(co
   return getControlPositionRange().clip(cp);
 }
 
-tTcdValue ParabolicGainDbScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return 16000 * cpValue;
-}
-
-tControlPositionValue ParabolicGainDbScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return v / 16000.0;
-}
-
 Glib::ustring ParabolicGainDbScaleConverter::controlPositionToDisplayJS() const
 {
   std::stringstream s;

--- a/projects/epc/playground/src/parameters/scale-converters/ParabolicGainDbScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/ParabolicGainDbScaleConverter.h
@@ -12,7 +12,5 @@ class ParabolicGainDbScaleConverter : public ScaleConverter
 
   [[nodiscard]] tControlPositionValue displayToControlPosition(const tDisplayValue &displayValue) const;
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/ParabolicScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/ParabolicScaleConverter.cpp
@@ -1,10 +1,8 @@
 #include "ParabolicScaleConverter.h"
 #include "dimension/PercentageDimension3Digits.h"
 
-ParabolicScaleConverter::ParabolicScaleConverter(tTcdRange tcdRange, tDisplayRange displayRange,
-                                                 const Dimension &dimension)
+ParabolicScaleConverter::ParabolicScaleConverter(tDisplayRange displayRange, const Dimension& dimension)
     : ScaleConverter(dimension)
-    , m_tcdRange(tcdRange)
     , m_displayRange(displayRange)
 {
 }
@@ -16,16 +14,6 @@ ParabolicScaleConverter::~ParabolicScaleConverter()
 bool ParabolicScaleConverter::isBiPolar() const
 {
   return false;
-}
-
-tTcdValue ParabolicScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), false);
-}
-
-tControlPositionValue ParabolicScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, m_tcdRange, false);
 }
 
 tDisplayValue ParabolicScaleConverter::controlPositionToDisplay(const tControlPositionValue &cpValue) const

--- a/projects/epc/playground/src/parameters/scale-converters/ParabolicScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/ParabolicScaleConverter.h
@@ -5,17 +5,13 @@
 class ParabolicScaleConverter : public ScaleConverter
 {
  public:
-  ParabolicScaleConverter(tTcdRange tcdRange, tDisplayRange displayRange, const Dimension &dimension);
+  ParabolicScaleConverter(tDisplayRange displayRange, const Dimension& dimension);
   ~ParabolicScaleConverter() override;
 
   [[nodiscard]] bool isBiPolar() const override;
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
 
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
-
  private:
-  tTcdRange m_tcdRange;
   tDisplayRange m_displayRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/PhaseBipolar180DegreeScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PhaseBipolar180DegreeScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/DegreeDimension.h"
 
 PhaseBipolar180DegreeScaleConverter::PhaseBipolar180DegreeScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-180, 180), DegreeDimension::get())
+    : LinearScaleConverter(tDisplayRange(-180, 180), DegreeDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/PhaseBipolar360DegreeScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PhaseBipolar360DegreeScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/DegreeDimensionCoarse.h"
 
 PhaseBipolar360DegreeScaleConverter::PhaseBipolar360DegreeScaleConverter()
-    : LinearScaleConverter(tTcdRange(-7200, 7200), tDisplayRange(-360, 360), DegreeDimensionCoarse::get())
+    : LinearScaleConverter(tDisplayRange(-360, 360), DegreeDimensionCoarse::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/PitchCombLinearStModulationScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PitchCombLinearStModulationScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 PitchCombLinearStModulationScaleConverter::PitchCombLinearStModulationScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(-120, 120), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-120, 120), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/PitchCombLinearStScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PitchCombLinearStScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 PitchCombLinearStScaleConverter::PitchCombLinearStScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 12000), tDisplayRange(0, 120), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 120), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/PitchOscLinearStScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PitchOscLinearStScaleConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 PitchOscLinearStScaleConverter::PitchOscLinearStScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 15000), tDisplayRange(-20, 130), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-20, 130), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/PitchOscLinearStScaleModulationConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/PitchOscLinearStScaleModulationConverter.cpp
@@ -2,7 +2,7 @@
 #include "dimension/PitchDimension.h"
 
 PitchOscLinearStScaleModulationConverter::PitchOscLinearStScaleModulationConverter()
-    : LinearScaleConverter(tTcdRange(0, 15000), tDisplayRange(-150, 150), PitchDimension::get())
+    : LinearScaleConverter(tDisplayRange(-150, 150), PitchDimension::get())
 {
 }
 

--- a/projects/epc/playground/src/parameters/scale-converters/ScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/ScaleConverter.cpp
@@ -32,12 +32,6 @@ const ScaleConverter::tControlPositionRange &ScaleConverter::getControlPositionR
   return s;
 }
 
-ScaleConverter::tTcdRange ScaleConverter::getTcdRange() const
-{
-  ScaleConverter::tControlPositionRange cpRange = getControlPositionRange();
-  return tTcdRange(controlPositionToTcd(cpRange.getMin()), controlPositionToTcd(cpRange.getMax()));
-}
-
 tControlPositionValue ScaleConverter::getCoarseDenominator(const QuantizedValue &v) const
 {
   return v.getCoarseDenominator();
@@ -48,7 +42,7 @@ tControlPositionValue ScaleConverter::getFineDenominator(const QuantizedValue &v
   return v.getFineDenominator();
 }
 
-const ScaleConverter::tControlPositionRange ScaleConverter::getControlPositionRange() const
+ScaleConverter::tControlPositionRange ScaleConverter::getControlPositionRange() const
 {
   return isBiPolar() ? getControlPositionRangeBipolar() : getControlPositionRangeUnipolar();
 }

--- a/projects/epc/playground/src/parameters/scale-converters/ScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/ScaleConverter.h
@@ -10,7 +10,6 @@ class QuantizedValue;
 class ScaleConverter
 {
  public:
-  typedef ValueRange<tTcdValue> tTcdRange;
   typedef ValueRange<tDisplayValue> tDisplayRange;
   typedef ValueRange<tControlPositionValue> tControlPositionRange;
 
@@ -20,20 +19,16 @@ class ScaleConverter
   [[nodiscard]] virtual tControlPositionValue getFineDenominator(const QuantizedValue &v) const;
 
   [[nodiscard]] virtual tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const = 0;
-  [[nodiscard]] virtual tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const = 0;
-  [[nodiscard]] virtual tControlPositionValue tcdToControlPosition(tTcdValue v) const = 0;
-
   [[nodiscard]] virtual Glib::ustring controlPositionToDisplayJS() const = 0;
 
-  [[nodiscard]] const ScaleConverter::tControlPositionRange getControlPositionRange() const;
+  [[nodiscard]] ScaleConverter::tControlPositionRange getControlPositionRange() const;
   [[nodiscard]] virtual bool isBiPolar() const = 0;
 
   [[nodiscard]] const Dimension &getDimension() const;
-  [[nodiscard]] tTcdRange getTcdRange() const;
 
   template <typename T> static const ScaleConverter *get()
   {
-    static std::map<int, std::unique_ptr<ScaleConverter>> s_converters;
+    static std::map<size_t, std::unique_ptr<ScaleConverter>> s_converters;
 
     auto key = typeid(T).hash_code();
     auto it = s_converters.find(key);

--- a/projects/epc/playground/src/parameters/scale-converters/SplitPointScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/SplitPointScaleConverter.cpp
@@ -2,6 +2,6 @@
 #include "SplitPointScaleConverter.h"
 
 SplitPointScaleConverter::SplitPointScaleConverter()
-    : LinearScaleConverter(tTcdRange(0, 60), tDisplayRange(0, 60), SplitPointDimension::get())
+    : LinearScaleConverter(tDisplayRange(0, 60), SplitPointDimension::get())
 {
 }

--- a/projects/epc/playground/src/parameters/scale-converters/TimeScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/TimeScaleConverter.cpp
@@ -2,9 +2,8 @@
 #include "dimension/TimeDimension.h"
 #include <math.h>
 
-TimeScaleConverter::TimeScaleConverter(const tTcdRange &tcdRange, const tDisplayRange &displayRange)
+TimeScaleConverter::TimeScaleConverter(const tDisplayRange& displayRange)
     : ScaleConverter(TimeDimension<3>::get())
-    , m_tcdRange(tcdRange)
     , m_displayRange(displayRange)
 {
 }
@@ -16,16 +15,6 @@ TimeScaleConverter::~TimeScaleConverter()
 bool TimeScaleConverter::isBiPolar() const
 {
   return false;
-}
-
-tTcdValue TimeScaleConverter::controlPositionToTcd(const tControlPositionValue &cpValue) const
-{
-  return m_tcdRange.scaleValueToRange(cpValue, getControlPositionRange(), false);
-}
-
-tControlPositionValue TimeScaleConverter::tcdToControlPosition(tTcdValue v) const
-{
-  return getControlPositionRange().scaleValueToRange(v, getTcdRange(), false);
 }
 
 tDisplayValue TimeScaleConverter::controlPositionToDisplay(const tControlPositionValue &cpValue) const
@@ -65,5 +54,5 @@ Glib::ustring TimeScaleConverter::controlPositionToDisplayJS() const
 
 size_t TimeScaleConverter::hash() const
 {
-  return super::hash() ^ m_tcdRange.hash() ^ m_displayRange.hash();
+  return super::hash() ^ m_displayRange.hash();
 }

--- a/projects/epc/playground/src/parameters/scale-converters/TimeScaleConverter.h
+++ b/projects/epc/playground/src/parameters/scale-converters/TimeScaleConverter.h
@@ -7,18 +7,15 @@ class TimeScaleConverter : public ScaleConverter
   typedef ScaleConverter super;
 
  public:
-  TimeScaleConverter(const tTcdRange &tcdRange, const tDisplayRange &displayRange);
+  TimeScaleConverter(const tDisplayRange& displayRange);
   ~TimeScaleConverter() override;
 
   [[nodiscard]] tDisplayValue controlPositionToDisplay(const tControlPositionValue &cpValue) const override;
   [[nodiscard]] Glib::ustring controlPositionToDisplayJS() const override;
   [[nodiscard]] bool isBiPolar() const override;
-  [[nodiscard]] tTcdValue controlPositionToTcd(const tControlPositionValue &cpValue) const override;
-  [[nodiscard]] tControlPositionValue tcdToControlPosition(tTcdValue v) const override;
 
   [[nodiscard]] size_t hash() const override;
 
  private:
-  tTcdRange m_tcdRange;
   tDisplayRange m_displayRange;
 };

--- a/projects/epc/playground/src/parameters/scale-converters/TransitionTimeMSScaleConverter.cpp
+++ b/projects/epc/playground/src/parameters/scale-converters/TransitionTimeMSScaleConverter.cpp
@@ -1,7 +1,7 @@
 #include "TransitionTimeMSScaleConverter.h"
 
 TransitionTimeMSScaleConverter::TransitionTimeMSScaleConverter()
-    : TimeScaleConverter(tTcdRange(0, 16000), tDisplayRange(0.1, 16000.0))
+    : TimeScaleConverter(tDisplayRange(0.1, 16000.0))
 {
 }
 

--- a/projects/epc/playground/src/parameters/value/QuantizedValue.cpp
+++ b/projects/epc/playground/src/parameters/value/QuantizedValue.cpp
@@ -92,17 +92,6 @@ QuantizedValue::~QuantizedValue()
 {
 }
 
-tTcdValue QuantizedValue::getTcdValue() const
-{
-  return getScaleConverter()->controlPositionToTcd(getQuantizedClipped());
-}
-
-void QuantizedValue::setTcdValue(tTcdValue v)
-{
-  auto cp = getScaleConverter()->tcdToControlPosition(v);
-  setRawValue(Initiator::INDIRECT, cp);
-}
-
 tDisplayValue QuantizedValue::getDisplayValue() const
 {
   return getScaleConverter()->controlPositionToDisplay(getQuantizedClipped());

--- a/projects/epc/playground/src/parameters/value/QuantizedValue.h
+++ b/projects/epc/playground/src/parameters/value/QuantizedValue.h
@@ -65,8 +65,6 @@ class QuantizedValue : public ClippedValue
   [[nodiscard]] tControlPositionValue getNextStepValue(tControlPositionValue value, int incs, bool fine,
                                                        bool shift) const;
 
-  [[nodiscard]] tTcdValue getTcdValue() const;
-  void setTcdValue(tTcdValue v);
   [[nodiscard]] tDisplayValue getDisplayValue() const;
   [[nodiscard]] Glib::ustring getDisplayString() const;
   [[nodiscard]] Glib::ustring getDisplayString(tControlPositionValue cp) const;

--- a/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.cpp
+++ b/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.cpp
@@ -18,6 +18,7 @@
 #include "device-settings/DebugLevel.h"
 #include "device-settings/VelocityCurve.h"
 #include "use-cases/ParameterUseCases.h"
+#include "parameters/ValueRange.h"
 #include <device-settings/ParameterEditModeRibbonBehaviour.h>
 #include <memory.h>
 #include <nltools/messaging/Message.h>
@@ -35,15 +36,15 @@ PlaycontrollerProxy::PlaycontrollerProxy()
 
   if(Application::exists())
   {
-      nltools::msg::onConnectionEstablished(nltools::msg::EndPoint::Playcontroller,
-                                            sigc::mem_fun(this, &PlaycontrollerProxy::onPlaycontrollerConnected));
+    nltools::msg::onConnectionEstablished(nltools::msg::EndPoint::Playcontroller,
+                                          sigc::mem_fun(this, &PlaycontrollerProxy::onPlaycontrollerConnected));
 
-      nltools::msg::receive<nltools::msg::PlaycontrollerMessage>(
-              nltools::msg::EndPoint::Playground, sigc::mem_fun(this, &PlaycontrollerProxy::onPlaycontrollerMessage));
+    nltools::msg::receive<nltools::msg::PlaycontrollerMessage>(
+        nltools::msg::EndPoint::Playground, sigc::mem_fun(this, &PlaycontrollerProxy::onPlaycontrollerMessage));
 
-      nltools::msg::receive<nltools::msg::Keyboard::NoteEventHappened>(
-              nltools::msg::EndPoint::Playground,
-              sigc::hide(sigc::mem_fun(this, &PlaycontrollerProxy::notifyKeyBedActionHappened)));
+    nltools::msg::receive<nltools::msg::Keyboard::NoteEventHappened>(
+        nltools::msg::EndPoint::Playground,
+        sigc::hide(sigc::mem_fun(this, &PlaycontrollerProxy::notifyKeyBedActionHappened)));
   }
 }
 
@@ -428,7 +429,7 @@ void PlaycontrollerProxy::sendRequestToPlaycontroller(MessageParser::Playcontrol
   queueToPlaycontroller(cmp);
 }
 
-sigc::connection PlaycontrollerProxy::onUHIDChanged(const sigc::slot<void, uint64_t>& s)
+sigc::connection PlaycontrollerProxy::onUHIDChanged(const sigc::slot<void, uint64_t> &s)
 {
   return m_signalUHIDChanged.connectAndInit(s, m_uhid);
 }
@@ -445,4 +446,36 @@ void PlaycontrollerProxy::setUHID(uint64_t uhid)
     m_uhid = uhid;
     m_signalUHIDChanged.send(m_uhid);
   }
+}
+
+template <typename tRet, typename tInValue>
+tRet scaleValueToRange(const ValueRange<tTcdValue> &tcdRange, const tInValue &in, const ValueRange<tInValue> &inRange,
+                       bool clip)
+{
+  tInValue inRangeWidth = inRange.getRangeWidth();
+  tRet outRangeWidth = tcdRange.getRangeWidth();
+  tInValue clippedIn = clip ? inRange.clip(in) : in;
+  auto res = (clippedIn - inRange.getMin()) * outRangeWidth / inRangeWidth + tcdRange.getMin();
+
+  if(std::numeric_limits<tRet>::is_integer)
+    return lround(res);
+
+  return res;
+}
+
+int16_t PlaycontrollerProxy::ribbonRelativeFactorToTCDValue(tControlPositionValue d)
+{
+  static ValueRange<tTcdValue> m_ribbonRelativeFactorTcdRange { 256, 2560 };
+  return scaleValueToRange<int16_t>(m_ribbonRelativeFactorTcdRange, d, ValueRange<tControlPositionValue>(0, 1), false);
+}
+
+int16_t PlaycontrollerProxy::ribbonCPValueToTCDValue(tControlPositionValue d, bool bipolar)
+{
+  static ValueRange<tTcdValue> m_ribbonValueTcdRangeBipolar { -8000, 8000 };
+  static ValueRange<tTcdValue> m_ribbonValueTcdRangeUnipolar { 0, 16000 };
+
+  if(bipolar)
+    return scaleValueToRange<int16_t>(m_ribbonValueTcdRangeBipolar, d, ValueRange<tControlPositionValue>(-1, 1), false);
+  else
+    return scaleValueToRange<int16_t>(m_ribbonValueTcdRangeUnipolar, d, ValueRange<tControlPositionValue>(0, 1), false);
 }

--- a/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.h
+++ b/projects/epc/playground/src/proxies/playcontroller/PlaycontrollerProxy.h
@@ -3,6 +3,7 @@
 #include "playground.h"
 #include "MessageParser.h"
 #include "MessageComposer.h"
+#include "parameters/ValueRange.h"
 #include <parameters/value/QuantizedValue.h>
 #include <memory>
 #include <nltools/threading/Throttler.h>
@@ -74,6 +75,8 @@ class PlaycontrollerProxy
   Parameter *findPhysicalControlParameterFromPlaycontrollerHWSourceID(uint16_t id) const;
   void notifyRibbonTouch(int ribbonsParameterID);
   void setUHID(uint64_t uhid);
+  int16_t ribbonRelativeFactorToTCDValue(tControlPositionValue d);
+  int16_t ribbonCPValueToTCDValue(tControlPositionValue d, bool bipolar);
 
  private:
   void onPlaycontrollerMessage(const nltools::msg::PlaycontrollerMessage &msg);

--- a/projects/epc/playground/src/testing/unit-tests/data/settings/RoutingSettingsTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/data/settings/RoutingSettingsTests.cpp
@@ -14,14 +14,16 @@ TEST_CASE("setAllValues will not notify if no values Changed")
 
   WHEN("All Values are initialy true")
   {
-    auto allValuesAreTrue = std::all_of(data.begin(), data.end(), [](const auto& row) {
-      return std::all_of(row.begin(), row.end(), [](auto b) { return b == true; });
-    });
+    auto allValuesAreTrue = std::all_of(
+        data.begin(), data.end(),
+        [](const auto& row) { return std::all_of(row.begin(), row.end(), [](auto b) { return b == true; }); });
 
     CHECK(allValuesAreTrue);
 
     WHEN("All elements are set to current Value again")
     {
+      setting->setAllValues(true);  //sanitize values first
+
       bool didNotifyArrive = false;
       auto connection = setting->onChange([&](auto) { didNotifyArrive = true; });
 
@@ -61,6 +63,8 @@ TEST_CASE("setAllValues will not notify if no values Changed")
 
     WHEN("on elements is set to current value again")
     {
+      setting->setAllValues(true);  //sanitize values first!
+
       bool didNotifyArrive = false;
       auto connection = setting->onChange([&](auto) { didNotifyArrive = true; });
 

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue3035/PresetRecallTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue3035/PresetRecallTests.cpp
@@ -192,7 +192,7 @@ TEST_CASE("Load Preset with differing Return Types", "[3035]")
     CHECK(pedal1->getDisplayString() == "25.0 %");
     ebUseCases.load(ped1_retzero);
     TestHelper::doMainLoopIteration();
-    CHECK(pedal1->getDisplayString() == "25.0 %");
+    CHECK(pedal1->getDisplayString() == "! 25.0 %");
   }
 
   WHEN("Non Ret Pedal Load should not set MC Pos")
@@ -217,7 +217,7 @@ TEST_CASE("Load Preset with differing Return Types", "[3035]")
     ribbonUseCase.changeFromAudioEngine(1, HWChangeSource::TCD);
     TestHelper::doMainLoopIteration();
 
-    CHECK(ribbon1->getDisplayString() == "100.0 %");
+    CHECK(ribbon1->getDisplayString() == "! 100.0 %");
     CHECK(mc1->getDisplayString() == "100.0 %");
 
     ebUseCases.load(rib1_stay);
@@ -237,13 +237,13 @@ TEST_CASE("Load Preset with differing Return Types", "[3035]")
     ribbonUseCase.changeFromAudioEngine(1, HWChangeSource::TCD);
     TestHelper::doMainLoopIteration();
 
-    CHECK(ribbon1->getDisplayString() == "100.0 %");
+    CHECK(ribbon1->getDisplayString() == "! 100.0 %");
     CHECK(mc1->getDisplayString() == "100.0 %");
 
     ebUseCases.load(rib1_retcenter_2);
     TestHelper::doMainLoopIteration();
 
-    CHECK(ribbon1->getDisplayString() == "100.0 %");
+    CHECK(ribbon1->getDisplayString() == "! 100.0 %");
     CHECK(mc1->getDisplayString() == "100.0 %");
   }
 


### PR DESCRIPTION
removed TCDRange from ScaleConverters, the only 2 TCD Ranges that were needed were the RibbonRelativeFactor (with a weird range btw) and the RibbonParameter one as these were the only values that are send to the playcontroller still. Those conversions happen inside the PlayController now and dont leak into parameters

closes #3252 