### PR TITLE
Individual modulation of Split-Point-Parameters

### DIFF
--- a/projects/epc/playground/src/device-settings/SyncSplitSettingUseCases.cpp
+++ b/projects/epc/playground/src/device-settings/SyncSplitSettingUseCases.cpp
@@ -23,6 +23,18 @@ void SyncSplitSettingUseCases::enableSyncSetting(UNDO::Transaction* t)
   auto cpI = m_splitI->getControlPositionValue();
   auto cpII = m_splitII->getValue().getNextStepValue(cpI, 1, false, false);
   m_splitII->updateCPFromSyncChange(t, cpII);
+
+  //TODO implement rules to copy ModAspects from I into II or vice versa
+  if(m_splitI->getModulationSource() != MacroControls::NONE)
+  {
+    m_splitII->setModulationAmount(t, m_splitI->getModulationAmount());
+    m_splitII->setModulationSource(t, m_splitI->getModulationSource());
+  }
+  else if(m_splitII->getModulationSource() != MacroControls::NONE)
+  {
+    m_splitI->setModulationAmount(t, m_splitII->getModulationAmount());
+    m_splitI->setModulationSource(t, m_splitII->getModulationSource());
+  }
 }
 
 void SyncSplitSettingUseCases::disableSyncSetting(UNDO::Transaction* t)

--- a/projects/epc/playground/src/parameters/SplitPointParameter.cpp
+++ b/projects/epc/playground/src/parameters/SplitPointParameter.cpp
@@ -37,27 +37,24 @@ Layout* SplitPointParameter::createLayout(FocusAndMode focusAndMode) const
 void SplitPointParameter::setCpValue(UNDO::Transaction* transaction, Initiator initiator, tControlPositionValue value,
                                      bool dosendToPlaycontroller)
 {
-  if(auto eb = getParentEditBuffer())
+  const auto syncActive = isSynced();
+
+  if(syncActive && isAtExtremes(value) && initiator != Initiator::INDIRECT_SPLIT_SYNC)
   {
-    const auto syncActive = isSynced();
+    clampToExtremes(transaction, dosendToPlaycontroller);
+    return;
+  }
 
-    if(syncActive && isAtExtremes(value) && initiator != Initiator::INDIRECT_SPLIT_SYNC)
+  Parameter::setCpValue(transaction, initiator, value, dosendToPlaycontroller);
+
+  if(syncActive)
+  {
+    if(initiator != Initiator::INDIRECT_SPLIT_SYNC)
     {
-      clampToExtremes(transaction, dosendToPlaycontroller);
-      return;
-    }
-
-    Parameter::setCpValue(transaction, initiator, value, dosendToPlaycontroller);
-
-    if(syncActive)
-    {
-      if(initiator != Initiator::INDIRECT_SPLIT_SYNC)
-      {
-        auto other = getSibling();
-        auto siblingValue
-            = getValue().getNextStepValue(value, other->getVoiceGroup() == VoiceGroup::I ? -1 : 1, false, false);
-        other->setCpValue(transaction, Initiator::INDIRECT_SPLIT_SYNC, siblingValue, dosendToPlaycontroller);
-      }
+      auto other = getSibling();
+      auto siblingValue
+          = getValue().getNextStepValue(value, other->getVoiceGroup() == VoiceGroup::I ? -1 : 1, false, false);
+      other->setCpValue(transaction, Initiator::INDIRECT_SPLIT_SYNC, siblingValue, dosendToPlaycontroller);
     }
   }
 }

--- a/projects/epc/playground/src/parameters/SplitPointParameter.cpp
+++ b/projects/epc/playground/src/parameters/SplitPointParameter.cpp
@@ -39,8 +39,7 @@ void SplitPointParameter::setCpValue(UNDO::Transaction* transaction, Initiator i
 {
   if(auto eb = getParentEditBuffer())
   {
-    auto& settings = eb->getSettings();
-    const auto syncActive = settings.getSetting<SplitPointSyncParameters>()->get();
+    const auto syncActive = isSynced();
 
     if(syncActive && isAtExtremes(value) && initiator != Initiator::INDIRECT_SPLIT_SYNC)
     {
@@ -59,10 +58,6 @@ void SplitPointParameter::setCpValue(UNDO::Transaction* transaction, Initiator i
             = getValue().getNextStepValue(value, other->getVoiceGroup() == VoiceGroup::I ? -1 : 1, false, false);
         other->setCpValue(transaction, Initiator::INDIRECT_SPLIT_SYNC, siblingValue, dosendToPlaycontroller);
       }
-    }
-    else
-    {
-      preventNegativeOverlap(transaction, value, dosendToPlaycontroller);
     }
   }
 }
@@ -86,42 +81,22 @@ void SplitPointParameter::clampToExtremes(UNDO::Transaction* transaction, bool d
   }
 }
 
-void SplitPointParameter::preventNegativeOverlap(UNDO::Transaction* transaction, tControlPositionValue value,
-                                                 bool dosendToPlaycontroller)
-{
-  auto sibling = getSibling();
-  auto siblingValue = sibling->getControlPositionValue();
-  auto inc = sibling->getVoiceGroup() == VoiceGroup::I ? 1 : -1;
-
-  auto siblingThreshold = getValue().getNextStepValue(siblingValue, inc, false, false);
-  siblingValue = getValue().getNextStepValue(value, -inc, false, false);
-
-  if(getVoiceGroup() == VoiceGroup::I)
-  {
-    if(value < siblingThreshold)
-    {
-      sibling->setCpValue(transaction, Initiator::INDIRECT_SPLIT_SYNC, siblingValue, dosendToPlaycontroller);
-    }
-  }
-  else
-  {
-    if(value > siblingThreshold)
-    {
-      sibling->setCpValue(transaction, Initiator::INDIRECT_SPLIT_SYNC, siblingValue, dosendToPlaycontroller);
-    }
-  }
-}
-
 void SplitPointParameter::setModulationAmount(UNDO::Transaction* transaction, const tDisplayValue& amount)
 {
   ModulateableParameter::setModulationAmount(transaction, amount);
-  getSibling()->setModulationAmountFromSibling(transaction, amount);
+  if(isSynced())
+  {
+    getSibling()->setModulationAmountFromSibling(transaction, amount);
+  }
 }
 
 void SplitPointParameter::setModulationSource(UNDO::Transaction* transaction, MacroControls src)
 {
   ModulateableParameter::setModulationSource(transaction, src);
-  getSibling()->setModulationSourceFromSibling(transaction, src);
+  if(isSynced())
+  {
+    getSibling()->setModulationSourceFromSibling(transaction, src);
+  }
 }
 
 Glib::ustring SplitPointParameter::stringizeModulationAmount(tControlPositionValue amount) const
@@ -204,4 +179,14 @@ void SplitPointParameter::loadDefault(UNDO::Transaction* transaction, Defaults m
     else
       loadFromPreset(transaction, getDefaultValue());
   }
+}
+
+bool SplitPointParameter::isSynced() const
+{
+  if(auto eb = getParentEditBuffer())
+  {
+    auto& settings = eb->getSettings();
+    return settings.getSetting<SplitPointSyncParameters>()->get();
+  }
+  return false;
 }

--- a/projects/epc/playground/src/parameters/SplitPointParameter.h
+++ b/projects/epc/playground/src/parameters/SplitPointParameter.h
@@ -48,6 +48,7 @@ class SplitPointParameter : public ModulateableParameterWithUnusualModUnit
   bool inDefaultSplitBehaviour() const;
   void updateCPFromSyncChange(UNDO::Transaction* transaction, double cp);
   void loadDefault(UNDO::Transaction* transaction, Defaults mode) override;
+  bool isSynced() const;
 
  protected:
   void setCpValue(UNDO::Transaction* transaction, Initiator initiator, tControlPositionValue value,
@@ -55,7 +56,6 @@ class SplitPointParameter : public ModulateableParameterWithUnusualModUnit
 
   bool inModAmountSet = false;
   bool inModSrcSet = false;
-  void preventNegativeOverlap(UNDO::Transaction* transaction, tControlPositionValue value, bool dosendToPlaycontroller);
   bool isAtExtremes(tControlPositionValue value);
 
   void clampToExtremes(UNDO::Transaction* transaction, bool dosendToPlaycontroller);

--- a/projects/epc/playground/src/use-cases/EditBufferUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/EditBufferUseCases.cpp
@@ -181,7 +181,10 @@ void EditBufferUseCases::setSplits(const ParameterId& id, tControlPositionValue 
     auto name = s->getGroupAndParameterNameWithVoiceGroup();
     auto scope = s->getUndoScope().startContinuousTransaction(s, "Set '%0'", name);
     s->setCPFromWebUI(scope->getTransaction(), cp);
-    other->setCPFromWebUI(scope->getTransaction(), otherCp);
+    if(s->isSynced())
+    {
+      other->setCPFromWebUI(scope->getTransaction(), otherCp);
+    }
   }
 }
 

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/useCases/EditBufferUseCases.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/useCases/EditBufferUseCases.java
@@ -96,23 +96,15 @@ public class EditBufferUseCases {
 		if (SetupModel.get().systemSettings.syncSplit.getBool()) {
 			handleSplitSync(p, newValue);
 		} else {
-			preventUnassignedKeyrange(p, newValue, oracle);
+			if (p.id.getVoiceGroup() == VoiceGroup.I) {
+				newValue = Math.min(59 / 60.0, newValue);
+				p.value.value.setValue(newValue);
+			} else {
+				newValue = Math.max(1 / 60.0, newValue);
+				p.value.value.setValue(newValue);
+			}
+			NonMaps.get().getServerProxy().setSplitPoints(p.id, newValue, 0.0, oracle);
 		}
-	}
-
-	private void preventUnassignedKeyrange(BasicParameterModel p, double newValue, boolean oracle) {
-		BasicParameterModel other = getSibling(p);
-		p.value.value.setValue(newValue);
-		double otherValue = other.value.getQuantizedAndClipped(true);
-
-		if (p.id.getVoiceGroup() == VoiceGroup.I) {
-			otherValue = Math.min(otherValue, p.value.getQuantizedAndClipped(true) + 1 / 60.0);
-		} else {
-			otherValue = Math.max(otherValue, p.value.getQuantizedAndClipped(true) - 1 / 60.0);
-		}
-
-		other.value.value.setValue(otherValue);
-		NonMaps.get().getServerProxy().setSplitPoints(p.id, newValue, other.value.value.getValue(), oracle);
 	}
 
 	private void startReturningAnimation(PhysicalControlParameterModel m) {

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/parameters/BeltParameterLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/parameters/BeltParameterLayout.java
@@ -354,10 +354,10 @@ public class BeltParameterLayout extends OverlayLayout {
 				Mode.paramValue, Mode.modulateableParameter, Mode.unmodulateableParameter) && isEnabled;
 
 		boolean dualSplitPointDisplay = isSplitPoint && isSyncDisabled();
-
+		boolean isInModAspect = isOneOf(Mode.mcValue, Mode.mcAmount, Mode.mcSource, Mode.mcUpper, Mode.mcLower);
 		syncSplitParameter.setVisible(isSplitPoint);
-		splitValueDisplay.setVisible(dualSplitPointDisplay && valueDisplayEnabled);
-		valueDisplay.setVisible(!dualSplitPointDisplay && valueDisplayEnabled);
+		splitValueDisplay.setVisible(dualSplitPointDisplay && valueDisplayEnabled && !isInModAspect);
+		valueDisplay.setVisible((!dualSplitPointDisplay && valueDisplayEnabled) || (dualSplitPointDisplay && isInModAspect));
 
 		dottedLine.setVisible(isOneOf(Mode.modulateableParameter) && isEnabled);
 		infoButton.setVisible(isOneOf(Mode.modulateableParameter, Mode.unmodulateableParameter));


### PR DESCRIPTION
removed safety-guards for modulateable split-point, can now be modulated freely if the points are not synced. upon resyncing them, if SplitI was modulated the aspects are copied to SPII and vice versa. Also fixes Value Display bugs in ParameterBelt Modulation Aspects Focus, for unlinked splitpoints, closes #3268