### PR TITLE
issue 2045 - undo part selection

### DIFF
--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -433,6 +433,8 @@ Glib::ustring Parameter::getMiniParameterEditorName() const
 
 Glib::ustring Parameter::getGroupAndParameterName() const
 {
+  if(getParentEditBuffer()->isDual() && getVoiceGroup() != VoiceGroup::Global)
+    return UNDO::StringTools::buildString(getParentGroup()->getShortName(), " - ", getLongName(), " - ", toString(getVoiceGroup()));
   return UNDO::StringTools::buildString(getParentGroup()->getShortName(), " - ", getLongName());
 }
 

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -1583,7 +1583,7 @@ void EditBuffer::cleanupParameterSelectionOnSoundTypeChange(UNDO::Transaction *t
           vg = VoiceGroup::I;
 
         undoableSelectParameter(transaction, { itConv->second, vg }, false);
-        vgManager->setCurrentVoiceGroup(vg);
+        vgManager->setCurrentVoiceGroup(transaction, vg);
       }
     }
 
@@ -1593,7 +1593,7 @@ void EditBuffer::cleanupParameterSelectionOnSoundTypeChange(UNDO::Transaction *t
       if(!ParameterId::isGlobal(selNum))
         undoableSelectParameter(transaction, { selNum, VoiceGroup::I }, false);
 
-      vgManager->setCurrentVoiceGroup(VoiceGroup::I);
+      vgManager->setCurrentVoiceGroup(transaction, VoiceGroup::I);
     }
   }
 }

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSinkBroker.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSinkBroker.cpp
@@ -19,6 +19,7 @@
 #include "use-cases/MacroControlParameterUseCases.h"
 #include "use-cases/ModParameterUseCases.h"
 #include "use-cases/EditBufferUseCases.h"
+#include "use-cases/VoiceGroupUseCases.h"
 #include <proxies/hwui/descriptive-layouts/GenericLayout.h>
 #include <proxies/hwui/panel-unit/boled/parameter-screens/ModulateableDualVoiceGroupMasterAndSplitPointLayout.h>
 #include <proxies/hwui/controls/SwitchVoiceGroupButton.h>
@@ -116,9 +117,15 @@ namespace DescriptiveLayouts
       }
     });
 
-    registerEvent(EventSinks::ToggleVoiceGroupWithParameterSelection, [vgManager]() { vgManager->toggleCurrentVoiceGroup(); });
+    registerEvent(EventSinks::ToggleVoiceGroupWithParameterSelection, [vgManager, eb]() {
+                    VoiceGroupUseCases vgUseCases(vgManager, eb);
+                    vgUseCases.toggleVoiceGroupSelection();
+                  });
 
-    registerEvent(EventSinks::ToggleVoiceGroup, [vgManager]() { vgManager->toggleCurrentVoiceGroup(); });
+    registerEvent(EventSinks::ToggleVoiceGroup, [vgManager, eb]() {
+                    VoiceGroupUseCases vgUseCases(vgManager, eb);
+                    vgUseCases.toggleVoiceGroupSelection();
+    });
 
     /*
        * UIFocus

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/MacroControlParameterLayouts.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/MacroControlParameterLayouts.cpp
@@ -31,6 +31,7 @@
 #include <sigc++/adaptors/hide.h>
 #include <proxies/hwui/panel-unit/boled/parameter-screens/controls/MCAssignedIndicator.h>
 #include "use-cases/EditBufferUseCases.h"
+#include "use-cases/VoiceGroupUseCases.h"
 
 MacroControlParameterLayout2::MacroControlParameterLayout2()
     : super()
@@ -136,7 +137,8 @@ bool MacroControlParameterLayout2::onButton(Buttons i, bool down, ButtonModifier
         }
         else if(buttonText == "I / II")
         {
-          Application::get().getVGManager()->toggleCurrentVoiceGroup();
+          VoiceGroupUseCases vgUseCases(Application::get().getVGManager(), getCurrentEditParameter()->getParentEditBuffer());
+          vgUseCases.toggleVoiceGroupSelection();
         }
       }
         return true;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ModulateableParameterLayouts.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ModulateableParameterLayouts.cpp
@@ -47,6 +47,7 @@
 #include "groups/MasterGroup.h"
 #include "parameter_declarations.h"
 #include "use-cases/SettingsUseCases.h"
+#include "use-cases/VoiceGroupUseCases.h"
 
 ModulateableParameterLayout2::ModulateableParameterLayout2()
 {
@@ -241,7 +242,8 @@ bool ModulateableParameterSelectLayout2::onButton(Buttons i, bool down, ButtonMo
           }
           else
           {
-            Application::get().getVGManager()->toggleCurrentVoiceGroup();
+            VoiceGroupUseCases vgUseCases(Application::get().getVGManager(), getCurrentEditParameter()->getParentEditBuffer());
+            vgUseCases.toggleVoiceGroupSelection();
           }
           return true;
         }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.cpp
@@ -221,3 +221,8 @@ void VoiceGroupIndicator::onLoadModeChanged(bool loadModeActive)
   m_inLoadToPart = m_allowLoadToPart && loadModeActive;
   setDirty();
 }
+
+VoiceGroup VoiceGroupIndicator::getCurrentDisplayedVoiceGroup() const
+{
+  return m_selectedVoiceGroup;
+}

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.h
@@ -7,6 +7,7 @@ class VoiceGroupIndicator : public Control
   explicit VoiceGroupIndicator(const Rect& r, bool allowLoadToPart);
   ~VoiceGroupIndicator() override;
   bool redraw(FrameBuffer& fb) override;
+  VoiceGroup getCurrentDisplayedVoiceGroup() const;
 
  private:
   void onSoundTypeChanged(SoundType type);

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankButton.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/BankButton.cpp
@@ -6,6 +6,7 @@
 #include <sigc++/adaptors/hide.h>
 #include "BankButton.h"
 #include "use-cases/SettingsUseCases.h"
+#include "use-cases/VoiceGroupUseCases.h"
 #include <device-settings/Settings.h>
 #include <device-settings/FocusAndModeSetting.h>
 
@@ -99,5 +100,11 @@ void BankButton::installDual()
   };
 
   m_buttonAHandler = std::make_unique<ShortVsLongPress>(
-      [this] { Application::get().getVGManager()->toggleCurrentVoiceGroup(); }, toggleBankFocus);
+      []
+      {
+        VoiceGroupUseCases vgUseCases(Application::get().getVGManager(),
+                                      Application::get().getPresetManager()->getEditBuffer());
+        vgUseCases.toggleVoiceGroupSelection();
+      },
+      toggleBankFocus);
 }

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Conversion/ConvertDualToDualSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Conversion/ConvertDualToDualSoundTests.cpp
@@ -31,7 +31,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Convert Split (II) to Layer")
     monoII->setCPFromHwui(scope->getTransaction(), 1);
     CHECK(monoII->getDisplayString() == "On");
 
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(scope->getTransaction(), VoiceGroup::II);
 
     for(auto p : EBL::getLocalNormal<VoiceGroup::I>())
       TestHelper::forceParameterChange(scope->getTransaction(), p);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
@@ -27,7 +27,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Layer
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::I);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::I);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -174,7 +174,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Layer
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -321,7 +321,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Layer into Layer
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::I);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::I);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -477,7 +477,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Layer into Layer
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoSplitSoundTests.cpp
@@ -24,7 +24,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Split
     TestHelper::initDualEditBuffer<SoundType::Split>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::I);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::I);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -187,7 +187,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Split
     TestHelper::initDualEditBuffer<SoundType::Split>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -352,7 +352,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Layer into Split
     TestHelper::initDualEditBuffer<SoundType::Split>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToLayerSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToLayerSoundTests.cpp
@@ -25,7 +25,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Single into Layer Part I")
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::I);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::I);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -147,7 +147,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Single into Layer Part II"
     TestHelper::initDualEditBuffer<SoundType::Layer>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadSingleToSplitSoundTests.cpp
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Single into Split Part I")
     TestHelper::initDualEditBuffer<SoundType::Split>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::I);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::I);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);
@@ -176,7 +176,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Single into Split Part II"
     TestHelper::initDualEditBuffer<SoundType::Split>(VoiceGroup::I);
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
-    Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+    Application::get().getVGManager()->setCurrentVoiceGroup(transaction, VoiceGroup::II);
 
     auto envAAttack = preset->findParameterByID({ 0, VoiceGroup::I }, true);
     envAAttack->setValue(transaction, 0.666);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/PartOriginAttributeTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/PartOriginAttributeTests.cpp
@@ -129,7 +129,10 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Step Direct Load and Load to Pa
   auto settings = TestHelper::getSettings();
   auto pm = Application::get().getPresetManager();
   auto vgManager = Application::get().getVGManager();
-  vgManager->setCurrentVoiceGroup(VoiceGroup::I);
+  {
+    auto scope = TestHelper::createTestScope();
+    vgManager->setCurrentVoiceGroup(scope->getTransaction(), VoiceGroup::I);
+  }
   auto currentVG = vgManager->getCurrentVoiceGroup();
 
   CHECK(currentVG == VoiceGroup::I);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/UnselectDiabledParameterOnSoundTypeChange.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/UnselectDiabledParameterOnSoundTypeChange.cpp
@@ -12,7 +12,10 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"FROM Layer")
   EditBufferUseCases ebUseCases(*eb);
   ebUseCases.load(presets.getLayerPreset());
 
-  Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+  {
+    auto scope = TestHelper::createTestScope();
+    Application::get().getVGManager()->setCurrentVoiceGroup(scope->getTransaction(), VoiceGroup::II);
+  }
 
   CHECK(eb->getType() == SoundType::Layer);
 
@@ -281,7 +284,11 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Split Loaded")
 
   ebUseCases.load(presets.getSplitPreset());
 
-  Application::get().getVGManager()->setCurrentVoiceGroup(VoiceGroup::II);
+  {
+    auto scope = TestHelper::createTestScope();
+    Application::get().getVGManager()->setCurrentVoiceGroup(scope->getTransaction(), VoiceGroup::II);
+  }
+
   CHECK(eb->getType() == SoundType::Split);
 
   WHEN("OUT: To FX x selected")

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue2045.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue2045.cpp
@@ -1,0 +1,66 @@
+#include <testing/TestHelper.h>
+#include <proxies/hwui/HWUI.h>
+#include "proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.h"
+#include "proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.h"
+#include "use-cases/VoiceGroupUseCases.h"
+#include <http/UndoScope.h>
+
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "HWUI - Part Selection not visible after UNDO")
+{
+  using namespace std::chrono_literals;
+
+  auto hwui = app->getHWUI();
+  auto vgManager = app->getVGManager();
+
+  auto eb = app->getPresetManager()->getEditBuffer();
+  EditBufferUseCases ebUseCases(*eb);
+  auto parameterToSelect = GENERATE(C15::PID::Env_A_Att_Vel, C15::PID::FB_Mix_Asym, C15::PID::Osc_A_Chirp);
+
+  TestHelper::initDualEditBuffer<SoundType::Split>(vgManager->getCurrentVoiceGroup());
+
+  INFO("Selecting Parameter " << parameterToSelect);
+  ebUseCases.selectParameter({parameterToSelect, VoiceGroup::I});
+
+  auto isInParameterLayout = [hwui](){
+    auto layout = hwui->getPanelUnit().getEditPanel().getBoled().getLayout().get();
+    return dynamic_cast<ParameterLayout2*>(layout) != nullptr;
+  };
+
+  auto getVoiceGroupIndicator = [hwui](){
+    auto layout = hwui->getPanelUnit().getEditPanel().getBoled().getLayout().get();
+    return layout->findControlOfType<VoiceGroupIndicator>();
+  };
+
+  WHEN("WHEN part I is selected")
+  {
+    REQUIRE(vgManager->getCurrentVoiceGroup() == VoiceGroup::I);
+    REQUIRE(isInParameterLayout());
+    REQUIRE(getVoiceGroupIndicator() != nullptr);
+    REQUIRE(getVoiceGroupIndicator()->getCurrentDisplayedVoiceGroup() == VoiceGroup::I);
+
+    THEN("Switch VoiceGroup")
+    {
+      VoiceGroupUseCases vgUseCases(vgManager, eb);
+      vgUseCases.toggleVoiceGroupSelection();
+
+      TestHelper::doMainLoopFor(10ms);
+
+      REQUIRE(vgManager->getCurrentVoiceGroup() == VoiceGroup::II);
+      REQUIRE(isInParameterLayout());
+      REQUIRE(getVoiceGroupIndicator() != nullptr);
+      REQUIRE(getVoiceGroupIndicator()->getCurrentDisplayedVoiceGroup() == VoiceGroup::II);
+
+      WHEN("Undo Pressed!")
+      {
+        app->getUndoScope()->undo();
+
+        TestHelper::doMainLoopFor(10ms);
+
+        REQUIRE(vgManager->getCurrentVoiceGroup() == VoiceGroup::I);
+        REQUIRE(isInParameterLayout());
+        REQUIRE(getVoiceGroupIndicator() != nullptr);
+        REQUIRE(getVoiceGroupIndicator()->getCurrentDisplayedVoiceGroup() == VoiceGroup::I);
+      }
+    }
+  }
+}

--- a/projects/epc/playground/src/testing/unit-tests/mock/EditBufferNamedLogicalParts.h
+++ b/projects/epc/playground/src/testing/unit-tests/mock/EditBufferNamedLogicalParts.h
@@ -1,32 +1,6 @@
 #pragma once
 #include <testing/TestHelper.h>
 
-namespace detail
-{
-  constexpr static auto MONO_ENABLE = 364;
-
-  constexpr static auto MASTER_VOLUME = 247;
-  constexpr static auto MASTER_TUNE = 248;
-
-  constexpr static auto PART_VOLUME = 358;
-  constexpr static auto PART_TUNE = 360;
-
-  constexpr static auto FADE_FROM = 396;
-  constexpr static auto FADE_RANGE = 397;
-
-  constexpr static auto SPLIT_POINT = 356;
-
-  constexpr static auto UNISON_VOICES = 249;
-
-  constexpr static auto FB_OSC = 346;
-  constexpr static auto FB_OSC_SRC = 348;
-  constexpr static auto FB_COMB_FROM = 350;
-  constexpr static auto FB_SVF_FROM = 352;
-  constexpr static auto FB_FX_FROM = 354;
-
-  constexpr static auto OUT_TO_FX = 362;
-}
-
 class EditBufferLogicalParts
 {
  private:
@@ -36,10 +10,10 @@ class EditBufferLogicalParts
   }
 
  public:
-  static std::vector<Parameter*> removeElements(std::vector<Parameter*> p, std::vector<int> ids)
+  static std::vector<Parameter*> removeElements(const std::vector<Parameter*>& p, std::vector<int> ids)
   {
-    std::vector<Parameter*> ret{};
-    for(auto& param: p)
+    std::vector<Parameter*> ret {};
+    for(auto& param : p)
     {
       if(std::find(ids.begin(), ids.end(), param->getID().getNumber()) == ids.end())
       {
@@ -51,12 +25,12 @@ class EditBufferLogicalParts
 
   template <VoiceGroup vg> static std::vector<Parameter*> getLocalNormal()
   {
-    using namespace detail;
     auto eb = TestHelper::getEditBuffer();
     std::vector<Parameter*> ret {};
 
     auto ignore = std::vector { "Unison", "Mono", "Part", "Split" };
-    auto ignoreParams = std::vector { FB_OSC, FB_OSC_SRC, FB_COMB_FROM, FB_SVF_FROM, FB_FX_FROM, OUT_TO_FX };
+    auto ignoreParams = std::vector { C15::PID::FB_Mix_Osc,     C15::PID::FB_Mix_Osc_Src, C15::PID::FB_Mix_Comb_Src,
+                                      C15::PID::FB_Mix_SVF_Src, C15::PID::FB_Mix_FX_Src,  C15::PID::Out_Mix_To_FX };
 
     for(auto& g : eb->getParameterGroups(vg))
     {
@@ -78,16 +52,17 @@ class EditBufferLogicalParts
   std::vector<Parameter*> filter(const std::vector<Parameter*>& in, const std::vector<ParameterId>& exclude)
   {
     std::vector<Parameter*> ret;
-    std::copy_if(in.begin(), in.end(), std::back_inserter(ret), [&](Parameter* p) {
-      auto it = std::find(exclude.begin(), exclude.end(), p->getID());
-      return it == exclude.end();
-    });
+    std::copy_if(in.begin(), in.end(), std::back_inserter(ret),
+                 [&](Parameter* p)
+                 {
+                   auto it = std::find(exclude.begin(), exclude.end(), p->getID());
+                   return it == exclude.end();
+                 });
     return ret;
   }
 
   template <VoiceGroup vg> static std::vector<Parameter*> getAllNonGlobalParameters()
   {
-    using namespace detail;
     auto eb = TestHelper::getEditBuffer();
     std::vector<Parameter*> ret {};
     eb->forEachParameter<vg>([&](Parameter* p) { ret.emplace_back(p); });
@@ -96,34 +71,32 @@ class EditBufferLogicalParts
 
   template <VoiceGroup vg> static std::vector<Parameter*> getCrossFB()
   {
-    using namespace detail;
     auto eb = TestHelper::getEditBuffer();
     std::vector<Parameter*> ret;
-    ret.emplace_back(eb->findParameterByID({ FB_COMB_FROM, vg }));
-    ret.emplace_back(eb->findParameterByID({ FB_FX_FROM, vg }));
-    ret.emplace_back(eb->findParameterByID({ FB_OSC, vg }));
-    ret.emplace_back(eb->findParameterByID({ FB_OSC_SRC, vg }));
-    ret.emplace_back(eb->findParameterByID({ FB_SVF_FROM, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::FB_Mix_Comb_Src, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::FB_Mix_FX_Src, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::FB_Mix_Osc, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::FB_Mix_Osc_Src, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::FB_Mix_SVF_Src, vg }));
     return ret;
   }
 
   template <VoiceGroup vg> static std::vector<Parameter*> getToFX()
   {
-    using namespace detail;
     auto eb = TestHelper::getEditBuffer();
     std::vector<Parameter*> ret;
-    ret.emplace_back(eb->findParameterByID({ OUT_TO_FX, vg }));
+    ret.emplace_back(eb->findParameterByID({ C15::PID::Out_Mix_To_FX, vg }));
     return ret;
   }
 
   template <VoiceGroup vg> static Parameter* getUnisonVoice()
   {
-    return TestHelper::getEditBuffer()->findParameterByID({ detail::UNISON_VOICES, vg });
+    return TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Unison_Voices, vg });
   };
 
   template <VoiceGroup vg> static Parameter* getMonoEnable()
   {
-    return TestHelper::getEditBuffer()->findParameterByID({ detail::MONO_ENABLE, vg });
+    return TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Mono_Grp_Enable, vg });
   }
 
   static std::vector<Parameter*> getMaster()
@@ -164,13 +137,13 @@ class EditBufferLogicalParts
   template <VoiceGroup vg> static ModulateableParameter* getPartVolume()
   {
     return dynamic_cast<ModulateableParameter*>(
-        TestHelper::getEditBuffer()->findParameterByID({ detail::PART_VOLUME, vg }));
+        TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Voice_Grp_Volume, vg }));
   }
 
   template <VoiceGroup vg> static ModulateableParameter* getPartTune()
   {
     return dynamic_cast<ModulateableParameter*>(
-        TestHelper::getEditBuffer()->findParameterByID({ detail::PART_TUNE, vg }));
+        TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Voice_Grp_Tune, vg }));
   }
 
   template <VoiceGroup vg> static std::vector<Parameter*> getPartMaster()
@@ -188,29 +161,29 @@ class EditBufferLogicalParts
 
   template <VoiceGroup vg> static Parameter* getFadeFrom()
   {
-    return TestHelper::getEditBuffer()->findParameterByID({ detail::FADE_FROM, vg });
+    return TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Voice_Grp_Fade_From, vg });
   }
 
   template <VoiceGroup vg> static Parameter* getFadeRange()
   {
-    return TestHelper::getEditBuffer()->findParameterByID({ detail::FADE_RANGE, vg });
+    return TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Voice_Grp_Fade_Range, vg });
   }
 
   template <VoiceGroup vg> static Parameter* getSplitPoint()
   {
-    return TestHelper::getEditBuffer()->findParameterByID({ detail::SPLIT_POINT, vg });
+    return TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Split_Split_Point, vg });
   }
 
   static ModulateableParameter* getMasterVolume()
   {
     return dynamic_cast<ModulateableParameter*>(
-        TestHelper::getEditBuffer()->findParameterByID({ detail::MASTER_VOLUME, VoiceGroup::Global }));
+        TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Master_Volume, VoiceGroup::Global }));
   }
 
   static ModulateableParameter* getMasterTune()
   {
     return dynamic_cast<ModulateableParameter*>(
-        TestHelper::getEditBuffer()->findParameterByID({ detail::MASTER_TUNE, VoiceGroup::Global }));
+        TestHelper::getEditBuffer()->findParameterByID({ C15::PID::Master_Tune, VoiceGroup::Global }));
   }
 
   static std::vector<Parameter*> getModMatrix()

--- a/projects/epc/playground/src/use-cases/ParameterUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/ParameterUseCases.cpp
@@ -30,7 +30,7 @@ void ParameterUseCases::toggleLoadDefault()
 void ParameterUseCases::undoRecallParameterFromPreset(tControlPositionValue cp)
 {
   auto& scope = m_parameter->getUndoScope();
-  auto transactionScope = scope.startTransaction("Recall %0 value from Editbuffer", m_parameter->getLongName());
+  auto transactionScope = scope.startTransaction("Recall %0 value from Editbuffer", m_parameter->getGroupAndParameterName());
   auto transaction = transactionScope->getTransaction();
   m_parameter->setCPFromHwui(transaction, cp);
 }

--- a/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.cpp
+++ b/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.cpp
@@ -34,14 +34,8 @@ void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroup(UNDO::Transaction *t, 
 
 void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroup(VoiceGroup v)
 {
-  auto oldGroup = m_currentVoiceGroup;
-  if(v == VoiceGroup::I || v == VoiceGroup::II)
-    if(std::exchange(m_currentVoiceGroup, v) != v)
-    {
-      m_voiceGoupSignal.send(m_currentVoiceGroup);
-      m_editBuffer.fakeParameterSelectionSignal(oldGroup, m_currentVoiceGroup);
-      m_editBuffer.onChange(UpdateDocumentContributor::ChangeFlags::Generic);
-    }
+  auto scope = m_editBuffer.getParent()->getUndoScope().startTransaction("Select Part " + toString(v));
+  setCurrentVoiceGroup(scope->getTransaction(), v);
 }
 
 void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction,

--- a/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.cpp
+++ b/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.cpp
@@ -32,12 +32,6 @@ void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroup(UNDO::Transaction *t, 
                                 });
 }
 
-void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroup(VoiceGroup v)
-{
-  auto scope = m_editBuffer.getParent()->getUndoScope().startTransaction("Select Part " + toString(v));
-  setCurrentVoiceGroup(scope->getTransaction(), v);
-}
-
 void VoiceGroupAndLoadToPartManager::setCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction,
                                                                                      VoiceGroup v)
 {

--- a/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.h
+++ b/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.h
@@ -17,7 +17,6 @@ class VoiceGroupAndLoadToPartManager : public sigc::trackable
   void setLoadToPart(bool state);
   bool isInLoadToPart() const;
   void setCurrentVoiceGroup(UNDO::Transaction* t, VoiceGroup v);
-  void setCurrentVoiceGroup(VoiceGroup v);
   void setCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction, VoiceGroup v);
 
   VoiceGroup getCurrentVoiceGroup() const;

--- a/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.h
+++ b/projects/epc/playground/src/use-cases/VoiceGroupAndLoadToPartManager.h
@@ -16,6 +16,7 @@ class VoiceGroupAndLoadToPartManager : public sigc::trackable
   void toggleLoadToPart();
   void setLoadToPart(bool state);
   bool isInLoadToPart() const;
+  void setCurrentVoiceGroup(UNDO::Transaction* t, VoiceGroup v);
   void setCurrentVoiceGroup(VoiceGroup v);
   void setCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction, VoiceGroup v);
 
@@ -23,7 +24,6 @@ class VoiceGroupAndLoadToPartManager : public sigc::trackable
 
   void toggleCurrentVoiceGroupAndUpdateParameterSelection();
   void toggleCurrentVoiceGroupAndUpdateParameterSelection(UNDO::Transaction *transaction);
-  void toggleCurrentVoiceGroup();
 
   sigc::connection onCurrentVoiceGroupChanged(const sigc::slot<void, VoiceGroup> &cb);
   sigc::connection onLoadToPartModeChanged(const sigc::slot<void, bool> &cb);

--- a/projects/epc/playground/src/use-cases/VoiceGroupUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/VoiceGroupUseCases.cpp
@@ -1,0 +1,33 @@
+#include "VoiceGroupUseCases.h"
+#include <presets/EditBuffer.h>
+#include <presets/PresetManager.h>
+#include <use-cases/VoiceGroupAndLoadToPartManager.h>
+
+VoiceGroupUseCases::VoiceGroupUseCases(VoiceGroupAndLoadToPartManager *manager, EditBuffer *eb)
+    : m_manager { manager }
+    , m_editBuffer { eb }
+{
+}
+
+void VoiceGroupUseCases::setVoiceGroup(VoiceGroup vg)
+{
+  auto str = toString(vg);
+  auto scope = m_editBuffer->getParent()->getUndoScope().startTransaction("Select Part " + str);
+  m_manager->setCurrentVoiceGroupAndUpdateParameterSelection(scope->getTransaction(), vg);
+}
+
+namespace detail
+{
+  VoiceGroup invert(VoiceGroup vg)
+  {
+    if(vg == VoiceGroup::I)
+      return VoiceGroup::II;
+    else
+      return VoiceGroup::I;
+  }
+}
+
+void VoiceGroupUseCases::toggleVoiceGroupSelection()
+{
+  setVoiceGroup(detail::invert(m_manager->getCurrentVoiceGroup()));
+}

--- a/projects/epc/playground/src/use-cases/VoiceGroupUseCases.h
+++ b/projects/epc/playground/src/use-cases/VoiceGroupUseCases.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "nltools/Types.h"
+
+class EditBuffer;
+class VoiceGroupAndLoadToPartManager;
+
+class VoiceGroupUseCases
+{
+ public:
+  VoiceGroupUseCases(VoiceGroupAndLoadToPartManager* manager, EditBuffer* eb);
+  void setVoiceGroup(VoiceGroup vg);
+  void toggleVoiceGroupSelection();
+ private:
+  VoiceGroupAndLoadToPartManager* m_manager;
+  EditBuffer* m_editBuffer;
+};


### PR DESCRIPTION
added VoiceGroupUseCases, which make VoiceGroup undoable, change ParameterUseCases to include VoiceGroup in parameter-transactions, if applicable (when we are dual and the parameter is not global)

closes #2045 