### PR TITLE
issue 2608: Stop Playback of Recorder on last WebUI close

### DIFF
--- a/projects/epc/audio-engine/src/recorder/Recorder.cpp
+++ b/projects/epc/audio-engine/src/recorder/Recorder.cpp
@@ -204,7 +204,8 @@ void Recorder::checkAndSendNoClientsStatus()
 
   if(!hasClients and m_hadClientsAtLastCheck and m_out->isPlaying())
   {
-    m_out->pause();
+    nltools::msg::Setting::NotifyNoRecorderClients msg {};
+    nltools::msg::send(nltools::msg::EndPoint::Playground, msg);
   }
 
   m_hadClientsAtLastCheck = hasClients;

--- a/projects/epc/audio-engine/src/recorder/Recorder.cpp
+++ b/projects/epc/audio-engine/src/recorder/Recorder.cpp
@@ -38,7 +38,7 @@ Recorder::Recorder(int sr)
                                                                                 m_in->setPaused(false);
                                                                             });
 
-  m_stopConnection = nltools::msg::receive<nltools::msg::Setting::FlacRecorderStop>(
+  m_stopConnection = nltools::msg::receive<nltools::msg::Setting::FlacRecorderStopPlayback>(
       nltools::msg::EndPoint::AudioEngine, [this](const auto &msg) { m_out->pause(); });
 }
 

--- a/projects/epc/audio-engine/src/recorder/Recorder.cpp
+++ b/projects/epc/audio-engine/src/recorder/Recorder.cpp
@@ -17,6 +17,8 @@ constexpr int operator""_MB(unsigned long long const x)
 
 constexpr static auto c_flacFrameBufferSize = 500_MB;
 
+using namespace std::chrono_literals;
+
 Recorder::Recorder(int sr)
     : m_storage(std::make_unique<FlacFrameStorage>(c_flacFrameBufferSize))
     , m_in(std::make_unique<RecorderInput>(m_storage.get(), sr))
@@ -25,7 +27,7 @@ Recorder::Recorder(int sr)
                                                              [this](auto, const auto &msg) { return api(msg); }))
     , m_http(std::make_unique<NetworkServer>(RECORDER_HTTPSERVER_PORT, m_storage.get()))
     , m_checkForActiveClients(Glib::MainContext::get_default(),
-                              sigc::mem_fun(this, &Recorder::checkAndSendNoClientsStatus), std::chrono::seconds(1))
+                              sigc::mem_fun(this, &Recorder::checkAndSendNoClientsStatus), 1s)
 {
   m_in->setPaused(true);
   m_settingConnection
@@ -209,5 +211,5 @@ void Recorder::checkAndSendNoClientsStatus()
   }
 
   m_hadClientsAtLastCheck = hasClients;
-  m_checkForActiveClients.refresh(Expiration::Duration(std::chrono::seconds(1)));
+  m_checkForActiveClients.refresh(1s);
 }

--- a/projects/epc/audio-engine/src/recorder/Recorder.h
+++ b/projects/epc/audio-engine/src/recorder/Recorder.h
@@ -51,7 +51,6 @@ private:
   sigc::connection m_settingConnection;
   sigc::connection m_stopConnection;
 
+  Expiration m_checkForActiveClients;
   bool m_hadClientsAtLastCheck = false;
-  Throttler m_checkClientThrottler;
-  std::future<void> m_checkForStop;
 };

--- a/projects/epc/audio-engine/src/recorder/Recorder.h
+++ b/projects/epc/audio-engine/src/recorder/Recorder.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Types.h"
-#include "nltools/threading/Throttler.h"
+#include "nltools/threading/Expiration.h"
 #include <nltools/nlohmann/json.hpp>
 #include <memory>
 #include <sigc++/connection.h>

--- a/projects/epc/audio-engine/src/recorder/Recorder.h
+++ b/projects/epc/audio-engine/src/recorder/Recorder.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "Types.h"
+#include "nltools/threading/Throttler.h"
 #include <nltools/nlohmann/json.hpp>
 #include <memory>
 #include <sigc++/connection.h>
+#include <future>
 
 class FlacFrameStorage;
 class RecorderInput;
@@ -35,6 +37,8 @@ class Recorder
   void notifyStateChange();
   
 private:
+ void checkAndSendNoClientsStatus();
+
   nlohmann::json generateInfo() const;
   nlohmann::json prepareDownload(FrameId begin, FrameId end) const;
   nlohmann::json queryFrames(FrameId begin, FrameId end) const;
@@ -45,4 +49,9 @@ private:
   std::unique_ptr<nltools::msg::WebSocketJsonAPI> m_api;
   std::unique_ptr<NetworkServer> m_http;
   sigc::connection m_settingConnection;
+  sigc::connection m_stopConnection;
+
+  bool m_hadClientsAtLastCheck = false;
+  Throttler m_checkClientThrottler;
+  std::future<void> m_checkForStop;
 };

--- a/projects/epc/audio-engine/src/recorder/Recorder.h
+++ b/projects/epc/audio-engine/src/recorder/Recorder.h
@@ -5,7 +5,6 @@
 #include <nltools/nlohmann/json.hpp>
 #include <memory>
 #include <sigc++/connection.h>
-#include <future>
 
 class FlacFrameStorage;
 class RecorderInput;

--- a/projects/epc/audio-engine/src/recorder/RecorderOutput.cpp
+++ b/projects/epc/audio-engine/src/recorder/RecorderOutput.cpp
@@ -123,3 +123,8 @@ void RecorderOutput::background()
     }
   }
 }
+
+bool RecorderOutput::isPlaying() const
+{
+  return !m_paused;
+}

--- a/projects/epc/audio-engine/src/recorder/RecorderOutput.h
+++ b/projects/epc/audio-engine/src/recorder/RecorderOutput.h
@@ -18,6 +18,7 @@ class RecorderOutput
   ~RecorderOutput();
 
   void process(SampleFrame *frames, size_t numFrames);
+  bool isPlaying() const;
   void pause();
   void start();
   void setPlayPos(FrameId id);

--- a/projects/epc/playground/src/Application.cpp
+++ b/projects/epc/playground/src/Application.cpp
@@ -91,11 +91,12 @@ Application::Application(int numArgs, char **argv)
     : m_theMainContext(createMainContext())
     , m_options(initStatic(this, std::make_unique<Options>(numArgs, argv)))
     , m_theMainLoop(Glib::MainLoop::create(m_theMainContext))
+    , m_recorderManager(std::make_unique<RecorderManager>())
     , m_http(new HTTPServer())
     , m_settings(new Settings(m_options->getSettingsFile(), m_http->getUpdateDocumentMaster()))
     , m_presetManager(
           new PresetManager(m_http->getUpdateDocumentMaster(), false, *m_options, *m_settings, m_audioEngineProxy))
-    , m_hwui(new HWUI(*m_settings))
+    , m_hwui(new HWUI(*m_settings, *m_recorderManager.get()))
     , m_undoScope(new UndoScope(m_http->getUpdateDocumentMaster()))
     , m_playcontrollerProxy(new PlaycontrollerProxy())
     , m_audioEngineProxy(new AudioEngineProxy(*m_presetManager, *m_settings, *m_playcontrollerProxy))
@@ -106,7 +107,8 @@ Application::Application(int numArgs, char **argv)
     , m_clipboard(new Clipboard(m_http->getUpdateDocumentMaster()))
     , m_usbChangeListener(std::make_unique<USBChangeListener>())
     , m_webUISupport(std::make_unique<WebUISupport>(m_http->getUpdateDocumentMaster()))
-    , m_actionManagers(m_http->getUpdateDocumentMaster(), *m_presetManager, *m_audioEngineProxy, *m_hwui, *m_settings, *m_voiceGroupManager)
+    , m_actionManagers(m_http->getUpdateDocumentMaster(), *m_presetManager, *m_audioEngineProxy, *m_hwui, *m_settings,
+                       *m_voiceGroupManager)
     , m_heartbeatState(false)
     , m_isQuit(false)
 {
@@ -347,4 +349,9 @@ ActionManagers *Application::getActionManagers()
 VoiceGroupAndLoadToPartManager *Application::getVGManager()
 {
   return m_voiceGroupManager.get();
+}
+
+RecorderManager *Application::getRecorderManager()
+{
+  return m_recorderManager.get();
 }

--- a/projects/epc/playground/src/Application.h
+++ b/projects/epc/playground/src/Application.h
@@ -2,6 +2,7 @@
 
 #include "playground.h"
 #include "use-cases/VoiceGroupAndLoadToPartManager.h"
+#include "use-cases/RecorderManager.h"
 #include <memory>
 #include <glibmm/refptr.h>
 #include <proxies/usb/USBChangeListener.h>
@@ -53,6 +54,7 @@ class Application
   Clipboard *getClipboard();
   WebUISupport *getWebUISupport();
   VoiceGroupAndLoadToPartManager* getVGManager();
+  RecorderManager* getRecorderManager();
 
   void quit();
   [[nodiscard]] bool isQuit() const;
@@ -70,6 +72,8 @@ class Application
   Glib::RefPtr<Glib::MainContext> m_theMainContext;
   std::unique_ptr<Options> m_options;
   Glib::RefPtr<Glib::MainLoop> m_theMainLoop;
+
+  std::unique_ptr<RecorderManager> m_recorderManager;
 
   std::unique_ptr<HTTPServer> m_http;
   std::unique_ptr<Settings> m_settings;

--- a/projects/epc/playground/src/device-settings/SettingsActions.cpp
+++ b/projects/epc/playground/src/device-settings/SettingsActions.cpp
@@ -92,6 +92,7 @@ SettingsActions::SettingsActions(UpdateDocumentContributor* parent, Settings& se
   });
 
   addAction("panic-audio-engine", [](auto request) { SettingsUseCases::panicAudioEngine(); });
+  addAction("stop-recorder-playback", [](auto) { RecorderManager::stopRecorder(); });
 
   addAction("set-all-routings-to-value", [&](auto request) {
     auto requestedState = request->get("state") == "1";

--- a/projects/epc/playground/src/device-settings/SettingsActions.cpp
+++ b/projects/epc/playground/src/device-settings/SettingsActions.cpp
@@ -92,7 +92,7 @@ SettingsActions::SettingsActions(UpdateDocumentContributor* parent, Settings& se
   });
 
   addAction("panic-audio-engine", [](auto request) { SettingsUseCases::panicAudioEngine(); });
-  addAction("stop-recorder-playback", [](auto) { RecorderManager::stopRecorder(); });
+  addAction("stop-recorder-playback", [](auto) { RecorderManager::stopRecorderPlayback(); });
 
   addAction("set-all-routings-to-value", [&](auto request) {
     auto requestedState = request->get("state") == "1";

--- a/projects/epc/playground/src/proxies/hwui/HWUI.cpp
+++ b/projects/epc/playground/src/proxies/hwui/HWUI.cpp
@@ -35,10 +35,11 @@
 #include "use-cases/SettingsUseCases.h"
 #include "use-cases/EditBufferUseCases.h"
 #include "device-settings/ScreenSaverTimeoutSetting.h"
+#include "proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.h"
 #include <Options.h>
 #include <proxies/hwui/panel-unit/boled/SplashLayout.h>
 
-HWUI::HWUI(Settings &settings)
+HWUI::HWUI(Settings &settings, RecorderManager &recorderManager)
     : m_layoutFolderMonitor(std::make_unique<LayoutFolderMonitor>())
     , m_panelUnit { settings, m_oleds, m_layoutFolderMonitor.get() }
     , m_baseUnit { settings, m_oleds }
@@ -57,6 +58,9 @@ HWUI::HWUI(Settings &settings)
 
   nltools::msg::receive<nltools::msg::ButtonChangedMessage>(nltools::msg::EndPoint::Playground,
                                                             sigc::mem_fun(this, &HWUI::onButtonMessage));
+
+  recorderManager.subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(
+      [this] { getPanelUnit().getEditPanel().getBoled().setOverlay(new DoYouWantToStopRecorderLayout()); });
 }
 
 HWUI::~HWUI()

--- a/projects/epc/playground/src/proxies/hwui/HWUI.cpp
+++ b/projects/epc/playground/src/proxies/hwui/HWUI.cpp
@@ -35,7 +35,7 @@
 #include "use-cases/SettingsUseCases.h"
 #include "use-cases/EditBufferUseCases.h"
 #include "device-settings/ScreenSaverTimeoutSetting.h"
-#include "proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.h"
+#include "proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderPlaybackLayout.h"
 #include <Options.h>
 #include <proxies/hwui/panel-unit/boled/SplashLayout.h>
 
@@ -60,7 +60,7 @@ HWUI::HWUI(Settings &settings, RecorderManager &recorderManager)
                                                             sigc::mem_fun(this, &HWUI::onButtonMessage));
 
   recorderManager.subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(
-      [this] { getPanelUnit().getEditPanel().getBoled().setOverlay(new DoYouWantToStopRecorderLayout()); });
+      [this] { getPanelUnit().getEditPanel().getBoled().setOverlay(new DoYouWantToStopRecorderPlaybackLayout()); });
 }
 
 HWUI::~HWUI()

--- a/projects/epc/playground/src/proxies/hwui/HWUI.h
+++ b/projects/epc/playground/src/proxies/hwui/HWUI.h
@@ -20,6 +20,7 @@ class Application;
 class UsageMode;
 class Settings;
 class LayoutFolderMonitor;
+class RecorderManager;
 
 namespace UNDO
 {
@@ -34,10 +35,10 @@ namespace nltools::msg
 class PresetPartSelection;
 class SplashLayout;
 
-class HWUI
+class HWUI : public sigc::trackable
 {
  public:
-  HWUI(Settings &settings);
+  HWUI(Settings &settings, RecorderManager &recorderManager);
   virtual ~HWUI();
   void init();
   void indicateBlockingMainThread();

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.cpp
@@ -1,0 +1,41 @@
+#include "DoYouWantToStopRecorderLayout.h"
+#include "proxies/hwui/controls/labels/LabelStyleable.h"
+#include "proxies/hwui/controls/Button.h"
+#include <Application.h>
+#include <proxies/hwui/HWUI.h>
+#include <proxies/hwui/panel-unit/PanelUnit.h>
+#include <proxies/hwui/panel-unit/boled/BOLED.h>
+#include "use-cases/RecorderManager.h"
+#include "proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.h"
+
+DoYouWantToStopRecorderLayout::DoYouWantToStopRecorderLayout()
+    : Layout(Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled())
+{
+  LabelStyle headlineStyle{};
+  headlineStyle.size = FontSize::Size9;
+  headlineStyle.decoration = FontDecoration::Bold;
+
+  auto headline = addControl(new LabelStyleable("Recorder still in playback!", {0, 0, 256, 16}, headlineStyle));
+  auto content = addControl(new MultiLineLabel({8, 16, 248, 48}, "All recorder tabs have been closed. Do you want to stop the playback?\n"
+                                                                   "It can also be stopped anytime in the Setup menu."));
+  auto nope = addControl(new Button("No", Buttons::BUTTON_A));
+  auto okay = addControl(new Button("Yes", Buttons::BUTTON_D));
+}
+
+bool DoYouWantToStopRecorderLayout::onButton(Buttons i, bool down, ::ButtonModifiers modifiers)
+{
+  if(down && i == Buttons::BUTTON_A)
+  {
+    Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled().resetOverlay();
+    return true;
+  }
+
+  if(down && i == Buttons::BUTTON_D)
+  {
+    RecorderManager::stopRecorder();
+    Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled().resetOverlay();
+    return true;
+  }
+
+  return Layout::onButton(i, down, modifiers);
+}

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderLayout.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "proxies/hwui/Layout.h"
+
+class DoYouWantToStopRecorderLayout : public Layout
+{
+ public:
+  DoYouWantToStopRecorderLayout();
+  bool onButton(Buttons i, bool down, ::ButtonModifiers modifiers) override;
+};

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderPlaybackLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderPlaybackLayout.cpp
@@ -1,4 +1,4 @@
-#include "DoYouWantToStopRecorderLayout.h"
+#include "DoYouWantToStopRecorderPlaybackLayout.h"
 #include "proxies/hwui/controls/labels/LabelStyleable.h"
 #include "proxies/hwui/controls/Button.h"
 #include <Application.h>
@@ -8,7 +8,7 @@
 #include "use-cases/RecorderManager.h"
 #include "proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.h"
 
-DoYouWantToStopRecorderLayout::DoYouWantToStopRecorderLayout()
+DoYouWantToStopRecorderPlaybackLayout::DoYouWantToStopRecorderPlaybackLayout()
     : Layout(Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled())
 {
   LabelStyle headlineStyle{};
@@ -22,7 +22,7 @@ DoYouWantToStopRecorderLayout::DoYouWantToStopRecorderLayout()
   auto okay = addControl(new Button("Yes", Buttons::BUTTON_D));
 }
 
-bool DoYouWantToStopRecorderLayout::onButton(Buttons i, bool down, ::ButtonModifiers modifiers)
+bool DoYouWantToStopRecorderPlaybackLayout::onButton(Buttons i, bool down, ::ButtonModifiers modifiers)
 {
   if(down && i == Buttons::BUTTON_A)
   {
@@ -32,7 +32,7 @@ bool DoYouWantToStopRecorderLayout::onButton(Buttons i, bool down, ::ButtonModif
 
   if(down && i == Buttons::BUTTON_D)
   {
-    RecorderManager::stopRecorder();
+    RecorderManager::stopRecorderPlayback();
     Application::get().getHWUI()->getPanelUnit().getEditPanel().getBoled().resetOverlay();
     return true;
   }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderPlaybackLayout.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/recorder/DoYouWantToStopRecorderPlaybackLayout.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "proxies/hwui/Layout.h"
 
-class DoYouWantToStopRecorderLayout : public Layout
+class DoYouWantToStopRecorderPlaybackLayout : public Layout
 {
  public:
-  DoYouWantToStopRecorderLayout();
+  DoYouWantToStopRecorderPlaybackLayout();
   bool onButton(Buttons i, bool down, ::ButtonModifiers modifiers) override;
 };

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/SetupLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/SetupLayout.cpp
@@ -1049,7 +1049,7 @@ namespace NavTree
   struct RecorderStopButton : OneShotEntry
   {
     explicit RecorderStopButton(InnerNode* p)
-    : OneShotEntry(p, "Stop Playback", OneShotTypes::StartCB([]{ RecorderManager::stopRecorder(); }))
+    : OneShotEntry(p, "Stop Playback", OneShotTypes::StartCB([]{ RecorderManager::stopRecorderPlayback(); }))
     {
     }
   };

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/SetupLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/SetupLayout.cpp
@@ -644,7 +644,7 @@ namespace NavTree
     };
 
     explicit RamUsage(InnerNode *parent)
-        : Leaf(parent, "RAM usage:")
+        : Leaf(parent, "RAM Usage:")
     {
     }
 
@@ -1046,6 +1046,14 @@ namespace NavTree
     }
   };
 
+  struct RecorderStopButton : OneShotEntry
+  {
+    explicit RecorderStopButton(InnerNode* p)
+    : OneShotEntry(p, "Stop Playback", OneShotTypes::StartCB([]{ RecorderManager::stopRecorder(); }))
+    {
+    }
+  };
+
   struct RoutingsEntry : public EditableLeaf
   {
    public:
@@ -1175,7 +1183,8 @@ namespace NavTree
     explicit FlacSettings(InnerNode *parent)
         : InnerNode(parent, "Recorder Settings")
     {
-      children.emplace_back(new EnumSettingItem<AutoStartRecorderSetting>(this, "Auto-Start Recorder"));
+      children.emplace_back(new EnumSettingItem<AutoStartRecorderSetting>(this, "Auto-Start Recording"));
+      children.emplace_back(new RecorderStopButton(this));
     }
   };
 

--- a/projects/epc/playground/src/use-cases/RecorderManager.cpp
+++ b/projects/epc/playground/src/use-cases/RecorderManager.cpp
@@ -1,0 +1,22 @@
+#include "RecorderManager.h"
+#include <nltools/messaging/Messaging.h>
+#include <nltools/messaging/Message.h>
+
+RecorderManager::RecorderManager()
+{
+  using tMsg = nltools::msg::Setting::NotifyNoRecorderClients;
+  nltools::msg::receive<tMsg>(nltools::msg::EndPoint::Playground, [this](tMsg msg){
+    m_signal.deferedSend();
+  });
+}
+
+sigc::connection RecorderManager::subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(sigc::slot<void(void)> s)
+{
+  return m_signal.connect(s);
+}
+
+void RecorderManager::stopRecorder()
+{
+  nltools::msg::Setting::FlacRecorderStop msg{};
+  nltools::msg::send(nltools::msg::EndPoint::AudioEngine, msg);
+}

--- a/projects/epc/playground/src/use-cases/RecorderManager.cpp
+++ b/projects/epc/playground/src/use-cases/RecorderManager.cpp
@@ -8,7 +8,6 @@ RecorderManager::RecorderManager()
   nltools::msg::receive<tMsg>(nltools::msg::EndPoint::Playground,
                               [this](tMsg msg)
                               {
-                                nltools::Log::error("received stop playback message!");
                                 m_signal.deferedSend();
                               });
 }
@@ -20,6 +19,6 @@ sigc::connection RecorderManager::subscribeToNotifyNoRecorderUIsLeftAndStillPlay
 
 void RecorderManager::stopRecorderPlayback()
 {
-  nltools::msg::Setting::FlacRecorderStop msg {};
+  nltools::msg::Setting::FlacRecorderStopPlayback msg {};
   nltools::msg::send(nltools::msg::EndPoint::AudioEngine, msg);
 }

--- a/projects/epc/playground/src/use-cases/RecorderManager.cpp
+++ b/projects/epc/playground/src/use-cases/RecorderManager.cpp
@@ -18,7 +18,7 @@ sigc::connection RecorderManager::subscribeToNotifyNoRecorderUIsLeftAndStillPlay
   return m_signal.connect(s);
 }
 
-void RecorderManager::stopRecorder()
+void RecorderManager::stopRecorderPlayback()
 {
   nltools::msg::Setting::FlacRecorderStop msg {};
   nltools::msg::send(nltools::msg::EndPoint::AudioEngine, msg);

--- a/projects/epc/playground/src/use-cases/RecorderManager.cpp
+++ b/projects/epc/playground/src/use-cases/RecorderManager.cpp
@@ -5,9 +5,12 @@
 RecorderManager::RecorderManager()
 {
   using tMsg = nltools::msg::Setting::NotifyNoRecorderClients;
-  nltools::msg::receive<tMsg>(nltools::msg::EndPoint::Playground, [this](tMsg msg){
-    m_signal.deferedSend();
-  });
+  nltools::msg::receive<tMsg>(nltools::msg::EndPoint::Playground,
+                              [this](tMsg msg)
+                              {
+                                nltools::Log::error("received stop playback message!");
+                                m_signal.deferedSend();
+                              });
 }
 
 sigc::connection RecorderManager::subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(sigc::slot<void(void)> s)
@@ -17,6 +20,6 @@ sigc::connection RecorderManager::subscribeToNotifyNoRecorderUIsLeftAndStillPlay
 
 void RecorderManager::stopRecorder()
 {
-  nltools::msg::Setting::FlacRecorderStop msg{};
+  nltools::msg::Setting::FlacRecorderStop msg {};
   nltools::msg::send(nltools::msg::EndPoint::AudioEngine, msg);
 }

--- a/projects/epc/playground/src/use-cases/RecorderManager.h
+++ b/projects/epc/playground/src/use-cases/RecorderManager.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <sigc++/trackable.h>
+#include <sigc++/connection.h>
+#include <sigc++/slot.h>
+#include <tools/Signal.h>
+
+class RecorderManager : public sigc::trackable
+{
+ public:
+  RecorderManager();
+  sigc::connection subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(sigc::slot<void(void)> s);
+  static void stopRecorder();
+
+ private:
+  Signal<void> m_signal;
+};
+

--- a/projects/epc/playground/src/use-cases/RecorderManager.h
+++ b/projects/epc/playground/src/use-cases/RecorderManager.h
@@ -9,7 +9,7 @@ class RecorderManager : public sigc::trackable
  public:
   RecorderManager();
   sigc::connection subscribeToNotifyNoRecorderUIsLeftAndStillPlaying(sigc::slot<void(void)> s);
-  static void stopRecorder();
+  static void stopRecorderPlayback();
 
  private:
   Signal<void> m_signal;

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -273,6 +273,22 @@ namespace nltools
         bool enabled;
       };
 
+      struct FlacRecorderStop
+      {
+        constexpr static MessageType getType()
+        {
+          return MessageType::StopRecorderMessage;
+        }
+      };
+
+      struct NotifyNoRecorderClients
+      {
+        constexpr static MessageType getType()
+        {
+          return MessageType::NotifyNoRecorderClients;
+        }
+      };
+
       struct PresetGlitchMessage
       {
         constexpr static MessageType getType()

--- a/projects/shared/nltools/include/nltools/messaging/Message.h
+++ b/projects/shared/nltools/include/nltools/messaging/Message.h
@@ -273,11 +273,11 @@ namespace nltools
         bool enabled;
       };
 
-      struct FlacRecorderStop
+      struct FlacRecorderStopPlayback
       {
         constexpr static MessageType getType()
         {
-          return MessageType::StopRecorderMessage;
+          return MessageType::StopRecorderPlaybackMessage;
         }
       };
 

--- a/projects/shared/nltools/include/nltools/messaging/Messaging.h
+++ b/projects/shared/nltools/include/nltools/messaging/Messaging.h
@@ -46,7 +46,8 @@ namespace nltools
          MidiSimpleMessage, MidiAck, MidiProgramChange, MidiBridgeSettings, MidiSettings, MidiHardwareChange,
 
          SyncFS, UpdateUploaded, AutoStartRecorderMessage, AEPanic, GlobalLocalSetting, WifiDevBBBEnable,
-         BufferUnderrunsChanged, SetFramesPerPeriod, FlacRecorderStateChanged, HardwarePollEnded);
+         BufferUnderrunsChanged, SetFramesPerPeriod, FlacRecorderStateChanged, HardwarePollEnded, StopRecorderMessage,
+         NotifyNoRecorderClients);
 
     namespace detail
     {

--- a/projects/shared/nltools/include/nltools/messaging/Messaging.h
+++ b/projects/shared/nltools/include/nltools/messaging/Messaging.h
@@ -46,8 +46,8 @@ namespace nltools
          MidiSimpleMessage, MidiAck, MidiProgramChange, MidiBridgeSettings, MidiSettings, MidiHardwareChange,
 
          SyncFS, UpdateUploaded, AutoStartRecorderMessage, AEPanic, GlobalLocalSetting, WifiDevBBBEnable,
-         BufferUnderrunsChanged, SetFramesPerPeriod, FlacRecorderStateChanged, HardwarePollEnded, StopRecorderMessage,
-         NotifyNoRecorderClients);
+         BufferUnderrunsChanged, SetFramesPerPeriod, FlacRecorderStateChanged, HardwarePollEnded,
+         StopRecorderPlaybackMessage, NotifyNoRecorderClients);
 
     namespace detail
     {
@@ -77,10 +77,12 @@ namespace nltools
       template <typename Msg>
       sigc::connection receive(MessageType type, EndPoint receivingEndPoint, std::function<void(const Msg &)> cb)
       {
-        return receiveSerialized(type, receivingEndPoint, [=](const SerializedMessage &s) {
-          auto msg = detail::deserialize<Msg>(s);
-          cb(msg);
-        });
+        return receiveSerialized(type, receivingEndPoint,
+                                 [=](const SerializedMessage &s)
+                                 {
+                                   auto msg = detail::deserialize<Msg>(s);
+                                   cb(msg);
+                                 });
       }
 
       sigc::connection receiveSerialized(MessageType type, EndPoint receivingEndPoint,

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
@@ -1267,6 +1267,12 @@ public class ServerProxy {
 		queueJob(uri, false);
 	}
 
+	public void stopRecorderPlayback() {
+		StaticURI.Path path = new StaticURI.Path("settings", "stop-recorder-playback");
+		StaticURI uri = new StaticURI(path);
+		queueJob(uri, false);
+	}
+
     public void resetRoutings(boolean b) {
 		StaticURI.Path path = new StaticURI.Path("settings", "set-all-routings-to-value");
 		StaticURI.KeyValue state = new StaticURI.KeyValue("state", b ? "1" : "0");

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/useCases/SystemSettings.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/useCases/SystemSettings.java
@@ -241,6 +241,10 @@ public class SystemSettings {
 		NonMaps.theMaps.getServerProxy().triggerPanic();
 	}
 
+	public void stopRecorderPlayback() {
+		NonMaps.theMaps.getServerProxy().stopRecorderPlayback();
+	}
+
     public void resetRoutings(boolean b) {
 		NonMaps.theMaps.getServerProxy().resetRoutings(b);
 	}

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/setup/Setup.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/setup/Setup.java
@@ -112,7 +112,7 @@ public class Setup extends Composite {
 	TextArea deviceName, passphrase;
 
 	@UiField
-	Button saveDeviceName, storeInitSound, resetInitSound, classicMidi, highResMidi, panicAE, routingsOn, routingsOff, savePassphrase, dicePassphrase, defaultPassphrase;
+	Button saveDeviceName, storeInitSound, resetInitSound, classicMidi, highResMidi, panicAE, stopRecorderPlayback, routingsOn, routingsOff, savePassphrase, dicePassphrase, defaultPassphrase;
 
 	Range editSmoothingTimeRange;
 	Range pedal1Range, pedal2Range, pedal3Range, pedal4Range;
@@ -414,6 +414,7 @@ public class Setup extends Composite {
 		disable14Bit.addValueChangeHandler(e -> settings.set14BitSupport(BooleanValues.off));	
 		
 		panicAE.addClickHandler(e -> settings.panic());
+		stopRecorderPlayback.addClickHandler(e -> settings.stopRecorderPlayback());
 
 		classicMidi.addClickHandler(e -> settings.resetToClassicMidi());
 		highResMidi.addClickHandler(e -> settings.resetToHighResMidi());

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/setup/Setup.ui.xml
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/setup/Setup.ui.xml
@@ -809,11 +809,21 @@
 					</div>
 					<div class="eins-he">
 						<div class="w60p">
-							<p>Auto-Start Recorder</p>
+							<p>Auto-Start Recording</p>
 						</div>
 						<div class="w40p mw-fit-content">
 							<g:RadioButton ui:field="autoStartRecordOn" name="rad_autoStartRecord" value="true"></g:RadioButton>
 							<g:RadioButton ui:field="autoStartRecordOff" name="rad_autoStartRecord" value="false"></g:RadioButton>
+						</div>
+					</div>
+					<div class="eins-he">
+						<div class="w60p">
+							<p>Stop Playback</p>
+						</div>
+						<div class="w20p">
+							<g:Button ui:field="stopRecorderPlayback">Stop</g:Button>
+						</div>
+						<div class="w20p">
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
added overlay which will be prompted to the user under following conditions: the last recorder connection has been closed (closing the lid on an Laptop or exiting the browser or tab) and the recorder is replaying some audio. The prompt will ask the user whether or not he wants to stop the playback of the recorder, alternatively you can now stop the playback via the HWUI and WebUI Settings, closes #2608