### PR TITLE
remove service re-added by pi4-merge

### DIFF
--- a/projects/bbb/bridge/systemd/install-update-from-epc.service.in
+++ b/projects/bbb/bridge/systemd/install-update-from-epc.service.in
@@ -1,6 +1,0 @@
-[Unit]
-Description=Copy Update From EPC and Execute
-
-[Service]
-Type=simple
-ExecStart=@C15_INSTALL_PATH@/scripts/install-update-from-epc.sh


### PR DESCRIPTION
https://github.com/nonlinear-labs-dev/C15/blob/42944b91c3bdcd5198797745eda55ba92ebcaa35/projects/bbb/bridge/systemd/install-update-from-epc.service.in

this file does not exists on the current 'main' but it was re-added with the merge of pi4 into milestone-maintance