### PR TITLE
Make sure, the download folder is created before 'docker run' is exec…

### DIFF
--- a/os/epc3/CMakeLists.txt
+++ b/os/epc3/CMakeLists.txt
@@ -9,7 +9,17 @@ file(GLOB_RECURSE EPC3_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*)
 # pacman -S <new packages go here>
 # pacman -Q # <-- generates list to be copied into packages.txt
 
+SET(EPC3_DOWNLOAD_FOLDER ${DOWNLOAD_DIR}/os/epc3)
+SET(EPC3_DOWNLOAD_STAMP ${EPC3_DOWNLOAD_FOLDER}/.download-dir)
+
 # COMMANDS
+ADD_CUSTOM_COMMAND(
+    COMMENT "Make sure download folder exists"
+    OUTPUT ${EPC3_DOWNLOAD_STAMP}
+    COMMAND mkdir -p ${EPC3_DOWNLOAD_FOLDER}
+    COMMAND touch ${EPC3_DOWNLOAD_STAMP}
+)
+
 ADD_CUSTOM_COMMAND(
     COMMENT "Building Docker Container for epc3 OS"
     OUTPUT .arch-docker
@@ -28,11 +38,12 @@ ADD_CUSTOM_COMMAND(
     DEPENDS install/oroot
     DEPENDS packages.txt
     DEPENDS dockerized-create-epc3-base-meta-package.sh
+    DEPENDS ${EPC3_DOWNLOAD_STAMP}
     VERBATIM
     COMMAND docker run
     -ti --rm
     -v ${CMAKE_CURRENT_SOURCE_DIR}:/src
-    -v ${DOWNLOAD_DIR}/os/epc3:/packages
+    -v ${EPC3_DOWNLOAD_FOLDER}:/packages
     -v ${CMAKE_CURRENT_BINARY_DIR}:/out
     epc3-arch-docker
     /src/dockerized-create-epc3-base-meta-package.sh
@@ -44,11 +55,12 @@ ADD_CUSTOM_COMMAND(
     DEPENDS packages.txt
     DEPENDS dockerized-create-epc3-base-package-database.sh
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/epc3-base-meta-1.0.0-1-any.pkg.tar.zst
+    DEPENDS ${EPC3_DOWNLOAD_STAMP}
     VERBATIM
     COMMAND docker run
     -ti --rm
     -v ${CMAKE_CURRENT_SOURCE_DIR}:/src
-    -v ${DOWNLOAD_DIR}/os/epc3:/packages
+    -v ${EPC3_DOWNLOAD_FOLDER}:/packages
     -v ${CMAKE_CURRENT_BINARY_DIR}:/out
     epc3-arch-docker
     /src/dockerized-create-epc3-base-package-database.sh
@@ -57,6 +69,7 @@ ADD_CUSTOM_COMMAND(
 ADD_CUSTOM_COMMAND(
     OUTPUT .fetch-base-packages
     DEPENDS packages.txt
+    DEPENDS ${EPC3_DOWNLOAD_STAMP}
     VERBATIM
     COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/fetched-packages
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/fetch.sh
@@ -69,12 +82,13 @@ ADD_CUSTOM_COMMAND(
     OUTPUT epc3-base.iso
     DEPENDS ${EPC3_SOURCE_FILES}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/epc3-base.db.tar.zst
+    DEPENDS ${EPC3_DOWNLOAD_STAMP}
     VERBATIM
     COMMAND docker run
     -ti --rm
     --privileged
     -v ${CMAKE_CURRENT_SOURCE_DIR}:/src
-    -v ${DOWNLOAD_DIR}/os/epc3:/packages
+    -v ${EPC3_DOWNLOAD_FOLDER}:/packages
     -v ${CMAKE_CURRENT_BINARY_DIR}:/out
     epc3-arch-docker
     /src/dockerized-create-iso.sh
@@ -82,10 +96,10 @@ ADD_CUSTOM_COMMAND(
 
 ADD_CUSTOM_COMMAND(
     OUTPUT .download-base-packages
-    COMMAND mkdir -p ${DOWNLOAD_DIR}/os/epc3
+    DEPENDS ${EPC3_DOWNLOAD_STAMP}
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/fetch.sh
     http://${NL_SERVER}/os/epc3
-    ${DOWNLOAD_DIR}/os/epc3
+    ${EPC3_DOWNLOAD_FOLDER}
     ${CMAKE_CURRENT_SOURCE_DIR}/packages.txt
 )
 


### PR DESCRIPTION
…uted,

otherwise docker will create the folder with root permissions

Also, I had to remove the default index.html from nl server. Otherwise, the logic in fetch.sh fails, as it relies on 404 when trying possible file types and platform suffixes.