### PR TITLE
closes #3386

### DIFF
--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
@@ -61,6 +61,9 @@ class AudioEngineProxy : public sigc::trackable
 
   void sendEditBuffer();
 
+  void freezePresetMessages();
+  void thawPresetMessages(bool send);
+
   void freezeParameterMessages();
   void thawParameterMessages(bool send);
 
@@ -81,6 +84,7 @@ class AudioEngineProxy : public sigc::trackable
 
   uint8_t m_lastMIDIKnownProgramNumber = std::numeric_limits<uint8_t>::max();
   uint m_suppressParamChanges = 0;
+  uint m_suppressPresetChanges = 0;
 
   sigc::connection m_midiBankChangedConnection;
   sigc::connection m_midiBankConnection;

--- a/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
+++ b/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
@@ -1,12 +1,15 @@
 #include "EditBufferStorePreparation.h"
 #include <presets/EditBuffer.h>
 #include <libundo/undo/Scope.h>
+#include <proxies/audio-engine/AudioEngineProxy.h>
 
 EditBufferStorePreparation::EditBufferStorePreparation(EditBuffer& eb) : m_eb{eb}
 {
   auto scope = UNDO::Scope::startTrashTransaction();
   auto transaction = scope->getTransaction();
   m_oldPositions = m_eb.setHWSourcesToDefaultValues(transaction);
+  eb.getAudioEngineProxy().freezeParameterMessages();
+  eb.getAudioEngineProxy().freezePresetMessages();
 }
 
 EditBufferStorePreparation::~EditBufferStorePreparation()
@@ -14,4 +17,6 @@ EditBufferStorePreparation::~EditBufferStorePreparation()
   auto scope = UNDO::Scope::startTrashTransaction();
   auto transaction = scope->getTransaction();
   m_eb.setHWSourcesToOldPositions(transaction, m_oldPositions);
+  m_eb.getAudioEngineProxy().thawParameterMessages(false);
+  m_eb.getAudioEngineProxy().thawPresetMessages(false);
 }

--- a/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
+++ b/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
@@ -7,9 +7,9 @@ EditBufferStorePreparation::EditBufferStorePreparation(EditBuffer& eb) : m_eb{eb
 {
   auto scope = UNDO::Scope::startTrashTransaction();
   auto transaction = scope->getTransaction();
+  m_eb.getAudioEngineProxy().freezeParameterMessages();
+  m_eb.getAudioEngineProxy().freezePresetMessages();
   m_oldPositions = m_eb.setHWSourcesToDefaultValues(transaction);
-  eb.getAudioEngineProxy().freezeParameterMessages();
-  eb.getAudioEngineProxy().freezePresetMessages();
 }
 
 EditBufferStorePreparation::~EditBufferStorePreparation()


### PR DESCRIPTION
, introduced freeze/thaw-PresetMessage to prevent the intermittent EditBuffer that is modified while storing to not be send to the AE, to prevent glitches and possible stolen notes (through modulation ending envelopes for example)

- [x] to test on device