### PR TITLE
implement fill Preset-Messages from Playground and send new Parameter-Messages 

### DIFF
--- a/projects/epc/playground/src/groups/ParameterGroup.cpp
+++ b/projects/epc/playground/src/groups/ParameterGroup.cpp
@@ -231,6 +231,8 @@ void ParameterGroup::validateParameterTypes() const
   bool hasAny = false;
   bool isPoly = false;
   bool isMono = false;
+  bool isGlobal = false;
+  bool isLocal = false;
 
   C15::Descriptors::ParameterType firstFoundType = C15::Descriptors::ParameterType::None;
   for(const auto& p: getParameters())
@@ -238,15 +240,31 @@ void ParameterGroup::validateParameterTypes() const
     auto foundType = p->getType();
     auto isPolyParam = foundType == C15::Descriptors::ParameterType::Polyphonic_Unmodulateable || foundType == C15::Descriptors::ParameterType::Polyphonic_Modulateable;
     auto isMonoParam = foundType == C15::Descriptors::ParameterType::Monophonic_Unmodulateable || foundType == C15::Descriptors::ParameterType::Monophonic_Modulateable;
+    auto isGlobalParam = foundType == C15::Descriptors::ParameterType::Global_Modulateable || foundType == C15::Descriptors::ParameterType::Global_Unmodulateable;
+    auto isLocalParam = foundType == C15::Descriptors::ParameterType::Local_Modulateable || foundType == C15::Descriptors::ParameterType::Local_Unmodulateable;
 
     if(!hasAny)
     {
       isPoly = isPolyParam;
       isMono = isMonoParam;
+      isGlobal = isGlobalParam;
+      isLocal = isLocalParam;
     }
-    else if(isPoly != isPolyParam || isMono != isMonoParam)
+    else if(isPoly != isPolyParam)
     {
-      nltools_assertAlways(false);
+      nltools_detailedAssertAlways(false, "poly not consistent");
+    }
+    else if(isMono != isMonoParam)
+    {
+      nltools_detailedAssertAlways(false, "mono not consistent");
+    }
+    else if(isGlobal != isGlobalParam)
+    {
+      nltools_detailedAssertAlways(false, "global not consistent");
+    }
+    else if(isLocal != isLocalParam)
+    {
+      nltools_detailedAssertAlways(false, "local not consistent");
     }
   }
 }

--- a/projects/epc/playground/src/groups/ParameterGroup.cpp
+++ b/projects/epc/playground/src/groups/ParameterGroup.cpp
@@ -234,7 +234,11 @@ void ParameterGroup::validateParameterTypes() const
   bool isGlobal = false;
   bool isLocal = false;
 
-  C15::Descriptors::ParameterType firstFoundType = C15::Descriptors::ParameterType::None;
+  int polyCount = 0;
+  int monoCount = 0;
+  int globalCount = 0;
+  int localCount = 0;
+
   for(const auto& p: getParameters())
   {
     auto foundType = p->getType();
@@ -243,28 +247,27 @@ void ParameterGroup::validateParameterTypes() const
     auto isGlobalParam = foundType == C15::Descriptors::ParameterType::Global_Modulateable || foundType == C15::Descriptors::ParameterType::Global_Unmodulateable;
     auto isLocalParam = foundType == C15::Descriptors::ParameterType::Local_Modulateable || foundType == C15::Descriptors::ParameterType::Local_Unmodulateable;
 
+    polyCount += isPolyParam;
+    monoCount += isMonoParam;
+    globalCount += isGlobalParam;
+    localCount += isLocalParam;
+
     if(!hasAny)
     {
+      hasAny = true;
       isPoly = isPolyParam;
       isMono = isMonoParam;
       isGlobal = isGlobalParam;
       isLocal = isLocalParam;
     }
-    else if(isPoly != isPolyParam)
+    else
     {
-      nltools_detailedAssertAlways(false, "poly not consistent");
-    }
-    else if(isMono != isMonoParam)
-    {
-      nltools_detailedAssertAlways(false, "mono not consistent");
-    }
-    else if(isGlobal != isGlobalParam)
-    {
-      nltools_detailedAssertAlways(false, "global not consistent");
-    }
-    else if(isLocal != isLocalParam)
-    {
-      nltools_detailedAssertAlways(false, "local not consistent");
+      nltools::Log::error("polyCount:", polyCount, "monoCount:", monoCount, "globalCount:", globalCount, "localCount:", localCount);
+
+      nltools_detailedAssertAlways(isPoly == isPolyParam, "poly not consistent");
+      nltools_detailedAssertAlways(isMono == isMonoParam, "mono not consistent");
+      nltools_detailedAssertAlways(isGlobal == isGlobalParam, "global not consistent");
+      nltools_detailedAssertAlways(isLocal == isLocalParam, "local not consistent");
     }
   }
 }

--- a/projects/epc/playground/src/groups/ParameterGroup.cpp
+++ b/projects/epc/playground/src/groups/ParameterGroup.cpp
@@ -225,3 +225,28 @@ nlohmann::json ParameterGroup::serialize() const
 {
   return { { "id", getID() }, { "name", getLongName() }, { "parameters", m_parameters } };
 }
+
+void ParameterGroup::validateParameterTypes() const
+{
+  bool hasAny = false;
+  bool isPoly = false;
+  bool isMono = false;
+
+  C15::Descriptors::ParameterType firstFoundType = C15::Descriptors::ParameterType::None;
+  for(const auto& p: getParameters())
+  {
+    auto foundType = p->getType();
+    auto isPolyParam = foundType == C15::Descriptors::ParameterType::Polyphonic_Unmodulateable || foundType == C15::Descriptors::ParameterType::Polyphonic_Modulateable;
+    auto isMonoParam = foundType == C15::Descriptors::ParameterType::Monophonic_Unmodulateable || foundType == C15::Descriptors::ParameterType::Monophonic_Modulateable;
+
+    if(!hasAny)
+    {
+      isPoly = isPolyParam;
+      isMono = isMonoParam;
+    }
+    else if(isPoly != isPolyParam || isMono != isMonoParam)
+    {
+      nltools_assertAlways(false);
+    }
+  }
+}

--- a/projects/epc/playground/src/groups/ParameterGroup.h
+++ b/projects/epc/playground/src/groups/ParameterGroup.h
@@ -82,6 +82,7 @@ class ParameterGroup : public UpdateDocumentContributor, public IntrusiveListIte
   VoiceGroup getVoiceGroup() const;
 
   void undoableLoadDefault(UNDO::Transaction *transaction, Defaults mode);
+  void validateParameterTypes() const;
 
  protected:
   template<typename T>

--- a/projects/epc/playground/src/parameters/HardwareSourceSendParameter.cpp
+++ b/projects/epc/playground/src/parameters/HardwareSourceSendParameter.cpp
@@ -98,12 +98,6 @@ void HardwareSourceSendParameter::onSiblingChanged(const Parameter* sibling)
   }
 }
 
-void HardwareSourceSendParameter::sendParameterMessage() const
-{
-  if(auto eb = getParentEditBuffer())
-    eb->getAudioEngineProxy().createAndSendParameterMessage<HardwareSourceSendParameter>(this);
-}
-
 void HardwareSourceSendParameter::onLocalChanged(const Setting* setting)
 {
   if(auto localSetting = dynamic_cast<const GlobalLocalEnableSetting*>(setting))

--- a/projects/epc/playground/src/parameters/HardwareSourceSendParameter.h
+++ b/projects/epc/playground/src/parameters/HardwareSourceSendParameter.h
@@ -32,8 +32,6 @@ class HardwareSourceSendParameter : public Parameter
   bool shouldWriteDocProperties(tUpdateID knownRevision) const override;
 
  private:
-  void sendParameterMessage() const override;
-
   void onLocalChanged(const Setting* setting);
   void onRoutingsChanged(const Setting* setting);
   void onSiblingChanged(const Parameter* sibling);

--- a/projects/epc/playground/src/parameters/MacroControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/MacroControlParameter.cpp
@@ -412,11 +412,6 @@ void MacroControlParameter::setCPFromMCView(UNDO::Transaction *transaction, cons
   setCpValue(transaction, Initiator::EXPLICIT_MCVIEW, cpValue, true);
 }
 
-void MacroControlParameter::sendParameterMessage() const
-{
-  Application::get().getAudioEngineProxy()->createAndSendParameterMessage<MacroControlParameter>(this);
-}
-
 bool MacroControlParameter::hasRelativeRibbonAsSource() const
 {
   auto group = getParentEditBuffer()->getParameterGroupByID({ "MCM", VoiceGroup::Global });

--- a/projects/epc/playground/src/parameters/MacroControlParameter.h
+++ b/projects/epc/playground/src/parameters/MacroControlParameter.h
@@ -82,7 +82,6 @@ class MacroControlParameter : public Parameter
   Glib::ustring m_lastMCViewUuid;
 
   void propagateMCChangeToMCViews(const Initiator &initiatior);
-  void sendParameterMessage() const override;
 
  private:
   tControlPositionValue lastBroadcastedControlPosition = std::numeric_limits<tControlPositionValue>::max();

--- a/projects/epc/playground/src/parameters/ModulateableParameter.cpp
+++ b/projects/epc/playground/src/parameters/ModulateableParameter.cpp
@@ -90,12 +90,6 @@ void ModulateableParameter::setModulationAmount(UNDO::Transaction *transaction, 
   }
 }
 
-void ModulateableParameter::sendParameterMessage() const
-{
-  if(Application::exists())
-    Application::get().getAudioEngineProxy()->createAndSendParameterMessage<ModulateableParameter>(this);
-}
-
 MacroControls ModulateableParameter::getModulationSource() const
 {
   return m_modSource;

--- a/projects/epc/playground/src/parameters/ModulateableParameter.h
+++ b/projects/epc/playground/src/parameters/ModulateableParameter.h
@@ -64,8 +64,6 @@ class ModulateableParameter : public Parameter
  private:
   int getModAmountDenominator(const ButtonModifiers &modifiers) const;
 
-  void sendParameterMessage() const override;
-
   tDisplayValue m_modulationAmount;
   MacroControls m_modSource;
   const ScaleConverter* m_modulationAmountScaleConverter = nullptr;

--- a/projects/epc/playground/src/parameters/ModulationRoutingParameter.cpp
+++ b/projects/epc/playground/src/parameters/ModulationRoutingParameter.cpp
@@ -149,11 +149,3 @@ Layout *ModulationRoutingParameter::createLayout(FocusAndMode focusAndMode) cons
 void ModulationRoutingParameter::undoableRandomize(UNDO::Transaction *transaction, Initiator initiator, double amount)
 {
 }
-
-void ModulationRoutingParameter::sendParameterMessage() const
-{
-  if(Application::exists())
-  {
-    Application::get().getAudioEngineProxy()->createAndSendParameterMessage<ModulationRoutingParameter>(this);
-  }
-}

--- a/projects/epc/playground/src/parameters/ModulationRoutingParameter.h
+++ b/projects/epc/playground/src/parameters/ModulationRoutingParameter.h
@@ -35,7 +35,4 @@ class ModulationRoutingParameter : public Parameter, public IntrusiveListItem<Mo
   Layout *createLayout(FocusAndMode focusAndMode) const override;
 
   void onExclusiveRoutingLost();
-
- private:
-  void sendParameterMessage() const override;
 };

--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -11,6 +11,7 @@
 #include "proxies/playcontroller/PlaycontrollerProxy.h"
 #include "proxies/audio-engine/AudioEngineProxy.h"
 #include "parameter_list.h"
+#include "MacroControlSmoothingParameter.h"
 #include <proxies/hwui/panel-unit/boled/parameter-screens/ParameterInfoLayout.h>
 #include <proxies/hwui/panel-unit/boled/parameter-screens/UnmodulatebaleParameterLayouts.h>
 #include <presets/EditBuffer.h>
@@ -27,6 +28,7 @@
 #include <proxies/hwui/HWUI.h>
 #include <parameter_declarations.h>
 #include <sync/JsonAdlSerializers.h>
+#include <parameters/ModulateableParameter.h>
 
 static const auto c_invalidSnapshotValue = std::numeric_limits<tControlPositionValue>::max();
 
@@ -630,7 +632,89 @@ void Parameter::copyFrom(UNDO::Transaction *transaction, const Parameter *other)
 void Parameter::sendParameterMessage() const
 {
   if(auto eb = getParentEditBuffer())
-    eb->getAudioEngineProxy().createAndSendParameterMessage<Parameter>(this);
+    switch(getType())
+    {
+      case C15::Descriptors::ParameterType::Hardware_Source:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Hardware_Source>(dynamic_cast<const PhysicalControlParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Display_Parameter:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Display_Parameter>(dynamic_cast<const HardwareSourceSendParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Hardware_Amount:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Hardware_Amount>(dynamic_cast<const ModulationRoutingParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Macro_Control:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Macro_Control>(dynamic_cast<const MacroControlParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Macro_Time:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Macro_Time>(this);
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Global_Modulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Global_Modulateable>(dynamic_cast<const ModulateableParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Global_Unmodulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Global_Unmodulateable>(this);
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Local_Modulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Local_Modulateable>(dynamic_cast<const ModulateableParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Local_Unmodulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Local_Unmodulateable>(this);
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Polyphonic_Modulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Polyphonic_Modulateable>(dynamic_cast<const ModulateableParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Polyphonic_Unmodulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Polyphonic_Unmodulateable>(this);
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Monophonic_Modulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Monophonic_Modulateable>(dynamic_cast<const ModulateableParameter*>(this));
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::Monophonic_Unmodulateable:
+      {
+        auto ret = ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Monophonic_Unmodulateable>(this);
+        eb->getAudioEngineProxy().sendParameterMessage(ret);
+        break;
+      }
+      case C15::Descriptors::ParameterType::None:
+        break;
+    }
 }
 
 bool Parameter::isValueDifferentFrom(double d) const

--- a/projects/epc/playground/src/parameters/Parameter.cpp
+++ b/projects/epc/playground/src/parameters/Parameter.cpp
@@ -666,3 +666,9 @@ void Parameter::onSoundTypeChanged(SoundType t)
 {
   invalidate();
 }
+
+C15::Descriptors::ParameterType Parameter::getType() const
+{
+  auto& desc = C15::ParameterList[getID().getNumber()];
+  return desc.m_param.m_type;
+}

--- a/projects/epc/playground/src/parameters/Parameter.h
+++ b/projects/epc/playground/src/parameters/Parameter.h
@@ -8,6 +8,7 @@
 #include <ParameterId.h>
 #include <tools/Signal.h>
 #include <sync/SyncedItem.h>
+#include <parameter_declarations.h>
 
 class Layout;
 class EditBuffer;
@@ -147,6 +148,8 @@ class Parameter : public UpdateDocumentContributor,
 
   bool isDisabledForType(SoundType type) const;
   bool isDisabled() const;
+
+  [[nodiscard]] C15::Descriptors::ParameterType getType() const;
 
  protected:
   virtual void sendToAudioEngine() const;

--- a/projects/epc/playground/src/parameters/Parameter.h
+++ b/projects/epc/playground/src/parameters/Parameter.h
@@ -151,6 +151,8 @@ class Parameter : public UpdateDocumentContributor,
 
   [[nodiscard]] C15::Descriptors::ParameterType getType() const;
 
+  void sendParameterMessage() const;
+
  protected:
   virtual void sendToAudioEngine() const;
   virtual void setCpValue(UNDO::Transaction *transaction, Initiator initiator, tControlPositionValue value,
@@ -183,6 +185,4 @@ class Parameter : public UpdateDocumentContributor,
 
   tControlPositionValue m_lastSnapshotedValue;
   bool m_isLocked = false;
-
-  virtual void sendParameterMessage() const;
 };

--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
@@ -278,12 +278,6 @@ void PhysicalControlParameter::undoableRandomize(UNDO::Transaction *transaction,
 {
 }
 
-void PhysicalControlParameter::sendParameterMessage() const
-{
-  if(auto eb = getParentEditBuffer())
-    eb->getAudioEngineProxy().createAndSendParameterMessage<PhysicalControlParameter>(this);
-}
-
 bool PhysicalControlParameter::lockingEnabled() const
 {
   return false;

--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.h
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.h
@@ -61,8 +61,6 @@ class PhysicalControlParameter : public Parameter
   void onValueChanged(Initiator initiator, tControlPositionValue oldValue, tControlPositionValue newValue) override;
 
  private:
-  void sendParameterMessage() const override;
-
   IntrusiveList<ModulationRoutingParameter *> m_targets;
 
   tControlPositionValue m_valueBeforeLastLoad = 0;

--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -43,7 +43,7 @@ EditBuffer::EditBuffer(PresetManager *parent, Settings &settings, std::unique_pt
     : ParameterGroupSet(parent)
     , SyncedItem(parent->getRoot()->getSyncMaster(), "/editbuffer")
     , m_parameterDB(*this)
-    , m_deferredJobs(100, std::bind(&EditBuffer::doDeferedJobs, this))
+    , m_deferredJobs(100, [this]() { doDeferedJobs(); })
     , m_isModified(false)
     , m_recallSet(this)
     , m_type(SoundType::Single)
@@ -60,6 +60,14 @@ void EditBuffer::init(Settings *settings)
 {
   ParameterGroupSet::init(settings);
   m_recallSet.init();
+
+  for(auto vg : { VoiceGroup::I, VoiceGroup::II, VoiceGroup::Global })
+  {
+    for(auto &g : getParameterGroups(vg))
+    {
+      g->validateParameterTypes();
+    }
+  }
 }
 
 EditBuffer::~EditBuffer()
@@ -1739,8 +1747,8 @@ void EditBuffer::setHWSourcesToLoadRulePostionsAndModulate(UNDO::Transaction *tr
   {
     if(auto hw = dynamic_cast<PhysicalControlParameter *>(p))
     {
-      if(hw->getID().getNumber() == C15::PID::Ribbon_1 || hw->getID().getNumber() == C15::PID::Ribbon_2 ||
-         hw->getID().getNumber() == C15::PID::Ribbon_3 || hw->getID().getNumber() == C15::PID::Ribbon_4)
+      if(hw->getID().getNumber() == C15::PID::Ribbon_1 || hw->getID().getNumber() == C15::PID::Ribbon_2
+         || hw->getID().getNumber() == C15::PID::Ribbon_3 || hw->getID().getNumber() == C15::PID::Ribbon_4)
       {
         auto oldMode = hw->getLastReturnModeBeforePresetLoad();
         auto newMode = hw->getReturnMode();

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.cpp
@@ -137,11 +137,10 @@ void fillMessageWithMacroControlsAndMacroTimes(nltools::msg::detail::PresetMessa
 }
 
 template <nltools::msg::MessageType tMsgType>
-void fillMessageWithHardwareSourceAndSends(nltools::msg::detail::PresetMessage<tMsgType> &msg,
+void fillMessageWithHardwareSources(nltools::msg::detail::PresetMessage<tMsgType> &msg,
                                            const EditBuffer &editBuffer)
 {
   size_t hw = 0;
-  size_t hw_send = 0;
 
   for(auto &param : editBuffer.getParameterGroupByID({ "CS", VoiceGroup::Global })->getParameters())
   {
@@ -152,16 +151,8 @@ void fillMessageWithHardwareSourceAndSends(nltools::msg::detail::PresetMessage<t
       e.m_controlPosition = hwParam->getControlPositionValue();
       e.m_returnMode = hwParam->getReturnMode();
     }
-    else if(auto send = dynamic_cast<const HardwareSourceSendParameter *>(param))
-    {
-      auto &e = msg.m_hardwareSourceSends[hw_send++];
-      e.m_id = static_cast<C15::PID::ParameterID>(send->getID().getNumber());
-      e.m_controlPosition = send->getControlPositionValue();
-      e.m_returnMode = send->getReturnMode();
-    }
   }
 
-  nltools_assertAlways(msg.m_hardwareSourceSends.size() == hw_send);
   nltools_assertAlways(msg.m_hardwareSources.size() == hw);
 }
 
@@ -271,7 +262,7 @@ template <nltools::msg::MessageType tMsgType>
 void fillMessageWithSharedParameters(nltools::msg::detail::PresetMessage<tMsgType> &msg, const EditBuffer &editBuffer)
 {
   fillMessageWithMacroControlsAndMacroTimes(msg, editBuffer);
-  fillMessageWithHardwareSourceAndSends(msg, editBuffer);
+  fillMessageWithHardwareSources(msg, editBuffer);
   fillMessageWithHWAmounts(msg, editBuffer);
   fillMessageWithGlobalNotHandledGroups(msg, editBuffer);
   fillMessageWithMonophonicParameters(msg, editBuffer);

--- a/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
+++ b/projects/epc/playground/src/proxies/audio-engine/AudioEngineProxy.h
@@ -71,9 +71,6 @@ class AudioEngineProxy : public sigc::trackable
   static nltools::msg::SinglePresetMessage createSingleEditBufferMessage(const EditBuffer& eb);
 
  private:
-  static void fillMonoPart(nltools::msg::ParameterGroups::MonoGroup& monoGroup, ParameterGroup* const& g);
-  static void fillUnisonPart(nltools::msg::ParameterGroups::UnisonGroup& unisonGroup, ParameterGroup* const& g);
-
   void onMidiBankSelectionChanged(const Uuid& newMidiBankUuid);
   void setLastKnownMIDIProgramChangeNumber(int pc);
   void sendSelectedMidiPresetAsProgramChange();

--- a/projects/epc/playground/src/testing/unit-tests/PresetMessageTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/PresetMessageTests.cpp
@@ -24,22 +24,6 @@ template <typename T> void collectIDs(const T &range, std::unordered_map<int, in
   }
 }
 
-void collectIDs(const nltools::msg::ParameterGroups::MonoGroup &group, std::unordered_map<int, int> &counts)
-{
-  collectID(group.legato, counts);
-  collectID(group.priority, counts);
-  collectID(group.monoEnable, counts);
-  collectID(group.glide, counts);
-}
-
-void collectIDs(const nltools::msg::ParameterGroups::UnisonGroup &group, std::unordered_map<int, int> &counts)
-{
-  collectID(group.phase, counts);
-  collectID(group.pan, counts);
-  collectID(group.detune, counts);
-  collectID(group.unisonVoices, counts);
-}
-
 template <typename T> void assertMap(const T &t)
 {
   for(auto &idCount : t)
@@ -51,43 +35,34 @@ template <typename T> void assertMap(const T &t)
 void assertNoIDTwice(const nltools::msg::SinglePresetMessage &msg)
 {
   std::unordered_map<int, int> count;
-  collectIDs(msg.unison, count);
-  collectIDs(msg.mono, count);
-  collectIDs(msg.unmodulateables, count);
-  collectIDs(msg.modulateables, count);
-  collectIDs(msg.hwamounts, count);
-  collectIDs(msg.hwsources, count);
-  collectIDs(msg.macros, count);
-  collectIDs(msg.scaleOffsets, count);
+  collectIDs(msg.m_polyphonicUnmodulateables, count);
+  collectIDs(msg.m_polyphonicModulateables, count);
+  collectIDs(msg.m_monophonicUnmodulateables[0], count);
+  collectIDs(msg.m_monophonicModulateables[0], count);
+  collectIDs(msg.m_globalUnmodulateables, count);
+  collectIDs(msg.m_globalModulateables, count);
+  collectIDs(msg.m_hardwareAmounts, count);
+  collectIDs(msg.m_hardwareSourceSends, count);
+  collectIDs(msg.m_hardwareSources, count);
+  collectIDs(msg.m_macroControls, count);
+  collectIDs(msg.m_macroTimes, count);
   assertMap(count);
 }
 
 template <int vg, typename tMsg> void collectDual(const tMsg &msg)
 {
   std::unordered_map<int, int> count;
-  collectIDs(msg.unison[vg], count);
-  collectIDs(msg.mono[vg], count);
-  collectIDs(msg.unmodulateables[vg], count);
-  collectIDs(msg.modulateables[vg], count);
-  collectID(msg.splitpoint[vg], count);
-  collectIDs(msg.hwamounts, count);
-  collectIDs(msg.hwsources, count);
-  collectIDs(msg.macros, count);
-  collectIDs(msg.scaleOffsets, count);
-  assertMap(count);
-}
-
-template <int vg> void collectDual(const nltools::msg::LayerPresetMessage &msg)
-{
-  std::unordered_map<int, int> count;
-  collectIDs(msg.unison, count);
-  collectIDs(msg.mono, count);
-  collectIDs(msg.unmodulateables[vg], count);
-  collectIDs(msg.modulateables[vg], count);
-  collectIDs(msg.hwamounts, count);
-  collectIDs(msg.hwsources, count);
-  collectIDs(msg.macros, count);
-  collectIDs(msg.scaleOffsets, count);
+  collectIDs(msg.m_polyphonicUnmodulateables[vg], count);
+  collectIDs(msg.m_polyphonicModulateables[vg], count);
+  collectIDs(msg.m_monophonicUnmodulateables[vg], count);
+  collectIDs(msg.m_monophonicModulateables[vg], count);
+  collectIDs(msg.m_globalUnmodulateables, count);
+  collectIDs(msg.m_globalModulateables, count);
+  collectIDs(msg.m_hardwareAmounts, count);
+  collectIDs(msg.m_hardwareSourceSends, count);
+  collectIDs(msg.m_hardwareSources, count);
+  collectIDs(msg.m_macroControls, count);
+  collectIDs(msg.m_macroTimes, count);
   assertMap(count);
 }
 

--- a/projects/epc/playground/src/testing/unit-tests/PresetMessageTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/PresetMessageTests.cpp
@@ -42,7 +42,6 @@ void assertNoIDTwice(const nltools::msg::SinglePresetMessage &msg)
   collectIDs(msg.m_globalUnmodulateables, count);
   collectIDs(msg.m_globalModulateables, count);
   collectIDs(msg.m_hardwareAmounts, count);
-  collectIDs(msg.m_hardwareSourceSends, count);
   collectIDs(msg.m_hardwareSources, count);
   collectIDs(msg.m_macroControls, count);
   collectIDs(msg.m_macroTimes, count);
@@ -59,7 +58,6 @@ template <int vg, typename tMsg> void collectDual(const tMsg &msg)
   collectIDs(msg.m_globalUnmodulateables, count);
   collectIDs(msg.m_globalModulateables, count);
   collectIDs(msg.m_hardwareAmounts, count);
-  collectIDs(msg.m_hardwareSourceSends, count);
   collectIDs(msg.m_hardwareSources, count);
   collectIDs(msg.m_macroControls, count);
   collectIDs(msg.m_macroTimes, count);

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
@@ -220,10 +220,21 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Layer
     const auto oldVoicesIHash = EBL::createValueHash(EBL::getVoices<VoiceGroup::I>());
     const auto oldCrossFBIIHash = EBL::createValueHash(EBL::getCrossFB<VoiceGroup::II>());
 
+    const auto oldAEMessage = AudioEngineProxy::createLayerEditBufferMessage(*eb);
+    const auto oldHash = eb->getHash();
+
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
 
     eb->undoableLoadToPart(transaction, preset, VoiceGroup::I, VoiceGroup::II);
+
+    THEN("AudioEngine Message is different")
+    {
+      auto newHash = eb->getHash();
+      auto newAEMessage = AudioEngineProxy::createLayerEditBufferMessage(*eb);
+      CHECK_FALSE(newHash == oldHash);
+      CHECK_FALSE(newAEMessage == oldAEMessage);
+    }
 
     THEN("Type is Same")
     {

--- a/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/dual-mode-acceptance/Loading/LoadDualPresetPartIntoLayerSoundTests.cpp
@@ -71,14 +71,17 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Load Part I of Split into Layer
     auto scope = TestHelper::createTestScope();
     auto transaction = scope->getTransaction();
 
+    auto oldHash = eb->getHash();
     auto oldAEMessage = AudioEngineProxy::createLayerEditBufferMessage(*eb);
 
     eb->undoableLoadToPart(transaction, preset, VoiceGroup::I, VoiceGroup::I);
 
     THEN("AudioEngine Message is different")
     {
+      auto newHash = eb->getHash();
       auto newAEMessage = AudioEngineProxy::createLayerEditBufferMessage(*eb);
       CHECK_FALSE(newAEMessage == oldAEMessage);
+      CHECK_FALSE(newHash == oldHash);
     }
 
     THEN("Type is Same")

--- a/projects/epc/playground/src/testing/unit-tests/messaging/MessagingTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/messaging/MessagingTests.cpp
@@ -101,3 +101,21 @@ TEST_CASE("ContextBoundMessageQueue - no send after destruction")
   CHECK(firstCBReached);
   CHECK(!secondCBReached);
 }
+
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "Send all Parameter Messages")
+{
+  int testedParams = 0;
+  for(auto vg: {VoiceGroup::Global, VoiceGroup::I, VoiceGroup::II})
+  {
+    for(auto g: app->getPresetManager()->getEditBuffer()->getParameterGroups(vg))
+    {
+      for(auto& p: g->getParameters())
+      {
+        testedParams++;
+        REQUIRE_NOTHROW(p->sendParameterMessage());
+      }
+    }
+  }
+
+  REQUIRE(testedParams > 0);
+}

--- a/projects/shared/nltools-2/include/PresetMessages.h
+++ b/projects/shared/nltools-2/include/PresetMessages.h
@@ -157,8 +157,6 @@ namespace nltools
         SingularParameterArray<ParameterType::Macro_Time, Parameters::UnmodulateableParameter> macrotimes;
         // ... into:
         SingularParameterArray<ParameterType::Hardware_Source, controls::HardwareSourceParameter> m_hardwareSources;
-        SingularParameterArray<ParameterType::Display_Parameter, controls::HardwareSourceSendParameter>
-            m_hardwareSourceSends;
         SingularParameterArray<ParameterType::Hardware_Amount, controls::HardwareAmountParameter> m_hardwareAmounts;
         SingularParameterArray<ParameterType::Macro_Control, controls::MacroControlParameter> m_macroControls;
         SingularParameterArray<ParameterType::Macro_Time, controls::MacroTimeParameter> m_macroTimes;

--- a/projects/shared/nltools-2/include/PresetMessages.h
+++ b/projects/shared/nltools-2/include/PresetMessages.h
@@ -175,6 +175,8 @@ namespace nltools
         SingularParameterArray<ParameterType::Macro_Time, Parameters::UnmodulateableParameter> macrotimes;
         // ... into:
         SingularParameterArray<ParameterType::Hardware_Source, controls::HardwareSourceParameter> m_hardwareSources;
+        SingularParameterArray<ParameterType::Display_Parameter, controls::HardwareSourceSendParameter>
+            m_hardwareSourceSends;
         SingularParameterArray<ParameterType::Hardware_Amount, controls::HardwareAmountParameter> m_hardwareAmounts;
         SingularParameterArray<ParameterType::Macro_Control, controls::MacroControlParameter> m_macroControls;
         SingularParameterArray<ParameterType::Macro_Time, controls::MacroTimeParameter> m_macroTimes;
@@ -219,25 +221,33 @@ namespace nltools
         // validation
         static inline bool validateCommon(const PresetMessage<M>& _msg)
         {
-            for(const auto &element : _msg.m_hardwareSources)
-                if(!element.validateParameterType()) return false;
-            for(const auto &element : _msg.m_hardwareAmounts)
-                if(!element.validateParameterType()) return false;
-            for(const auto &element : _msg.m_macroControls)
-                if(!element.validateParameterType()) return false;
-            for(const auto &element : _msg.m_macroTimes)
-                if(!element.validateParameterType()) return false;
-            for(const auto &element : _msg.m_globalModulateables)
-                if(!element.validateParameterType()) return false;
-            for(const auto &element : _msg.m_globalUnmodulateables)
-                if(!element.validateParameterType()) return false;
-            for(const auto &layer : _msg.m_monophonicModulateables)
-                for(const auto &element : layer)
-                    if(!element.validateParameterType()) return false;
-            for(const auto &layer : _msg.m_monophonicUnmodulateables)
-                for(const auto &element : layer)
-                    if(!element.validateParameterType()) return false;
-            return true;
+          for(const auto& element : _msg.m_hardwareSources)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& element : _msg.m_hardwareAmounts)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& element : _msg.m_macroControls)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& element : _msg.m_macroTimes)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& element : _msg.m_globalModulateables)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& element : _msg.m_globalUnmodulateables)
+            if(!element.validateParameterType())
+              return false;
+          for(const auto& layer : _msg.m_monophonicModulateables)
+            for(const auto& element : layer)
+              if(!element.validateParameterType())
+                return false;
+          for(const auto& layer : _msg.m_monophonicUnmodulateables)
+            for(const auto& element : layer)
+              if(!element.validateParameterType())
+                return false;
+          return true;
         }
       };
 
@@ -262,12 +272,14 @@ namespace nltools
       // validation
       static inline bool validate(const SinglePresetMessage& _msg)
       {
-          if(!SinglePresetMessage::validateCommon(_msg)) return false;
-          for(const auto &element : _msg.m_polyphonicModulateables)
-              if(!element.validateParameterType()) return false;
-          for(const auto &element : _msg.m_polyphonicUnmodulateables)
-              if(!element.validateParameterType()) return false;
-          return true;
+        if(!SinglePresetMessage::validateCommon(_msg))
+          return false;
+
+        auto modulateablesValid = std::all_of(_msg.m_polyphonicModulateables.begin(), _msg.m_polyphonicModulateables.end(),
+                           [](auto e) { return e.validateParameterType(); });
+        auto unmodulateablesValid = std::all_of(_msg.m_polyphonicUnmodulateables.begin(), _msg.m_polyphonicUnmodulateables.end(),
+                           [](auto e) { return e.validateParameterType(); });
+        return modulateablesValid && unmodulateablesValid;
       }
     };
 
@@ -309,14 +321,17 @@ namespace nltools
       // validation
       static inline bool validate(const SplitPresetMessage& _msg)
       {
-          if(!SplitPresetMessage::validateCommon(_msg)) return false;
-          for(const auto &layer : _msg.m_polyphonicModulateables)
-              for(const auto &element : layer)
-                  if(!element.validateParameterType()) return false;
-          for(const auto &layer : _msg.m_polyphonicUnmodulateables)
-              for(const auto &element : layer)
-                  if(!element.validateParameterType()) return false;
-          return true;
+        if(!SplitPresetMessage::validateCommon(_msg))
+          return false;
+        for(const auto& layer : _msg.m_polyphonicModulateables)
+          for(const auto& element : layer)
+            if(!element.validateParameterType())
+              return false;
+        for(const auto& layer : _msg.m_polyphonicUnmodulateables)
+          for(const auto& element : layer)
+            if(!element.validateParameterType())
+              return false;
+        return true;
       }
     };
 
@@ -360,14 +375,17 @@ namespace nltools
       // validation
       static inline bool validate(const LayerPresetMessage& _msg)
       {
-          if(!LayerPresetMessage::validateCommon(_msg)) return false;
-          for(const auto &layer : _msg.m_polyphonicModulateables)
-              for(const auto &element : layer)
-                  if(!element.validateParameterType()) return false;
-          for(const auto &layer : _msg.m_polyphonicUnmodulateables)
-              for(const auto &element : layer)
-                  if(!element.validateParameterType()) return false;
-          return true;
+        if(!LayerPresetMessage::validateCommon(_msg))
+          return false;
+        for(const auto& layer : _msg.m_polyphonicModulateables)
+          for(const auto& element : layer)
+            if(!element.validateParameterType())
+              return false;
+        for(const auto& layer : _msg.m_polyphonicUnmodulateables)
+          for(const auto& element : layer)
+            if(!element.validateParameterType())
+              return false;
+        return true;
       }
     };
 

--- a/projects/shared/nltools-2/include/PresetMessages.h
+++ b/projects/shared/nltools-2/include/PresetMessages.h
@@ -7,7 +7,7 @@ namespace nltools
   namespace msg
   {
 
-    // todo: deprecate
+    // todo: remove
     namespace Parameters
     {
       // note: hard-coded counts should only be temporary
@@ -21,20 +21,6 @@ namespace nltools
         uint16_t m_id {};
         double m_controlPosition = 0;
       };
-
-      // todo: remove (unused)
-      //      struct RibbonParameter : Parameter
-      //      {
-      //        RibbonTouchBehaviour ribbonTouchBehaviour {};
-      //        RibbonReturnMode ribbonReturnMode {};
-      //      };
-
-      // todo: remove (unused)
-      //      struct PedalParameter : Parameter
-      //      {
-      //        PedalModes pedalMode {};
-      //        ReturnMode returnMode {};
-      //      };
 
       struct MacroParameter : Parameter
       {
@@ -50,7 +36,6 @@ namespace nltools
       {
       };
 
-      // todo: remove (unnecessary)
       struct GlobalParameter : Parameter
       {
       };
@@ -64,7 +49,6 @@ namespace nltools
       {
       };
 
-      // todo: remove (unnecessary)
       struct SplitPoint : ModulateableParameter
       {
       };
@@ -86,63 +70,6 @@ namespace nltools
       }
 
     }  // namespace nltools::msg::Parameters
-
-    // todo: refactor (into Global or Polyphonic/Monophonic Modulateables/Unmodulateables, deprecating ParameterGroups)
-    namespace ParameterGroups
-    {
-
-      struct UnisonGroup
-      {
-        Parameters::UnmodulateableParameter unisonVoices;
-        Parameters::ModulateableParameter detune;
-        Parameters::UnmodulateableParameter phase;
-        Parameters::UnmodulateableParameter pan;
-      };
-
-      struct MonoGroup
-      {
-        Parameters::UnmodulateableParameter monoEnable;
-        Parameters::UnmodulateableParameter legato;
-        Parameters::UnmodulateableParameter priority;
-        Parameters::ModulateableParameter glide;
-      };
-
-      struct MasterGroup
-      {
-        Parameters::ModulateableParameter volume;
-        Parameters::ModulateableParameter tune;
-        Parameters::ModulateableParameter pan;
-        Parameters::ModulateableParameter serialFX;
-      };
-
-      inline bool operator==(const MonoGroup& lhs, const MonoGroup& rhs)
-      {
-        auto ret = lhs.glide == rhs.glide;
-        ret &= lhs.monoEnable == rhs.monoEnable;
-        ret &= lhs.priority == rhs.priority;
-        ret &= lhs.legato == rhs.legato;
-        return ret;
-      }
-
-      inline bool operator==(const UnisonGroup& lhs, const UnisonGroup& rhs)
-      {
-        auto ret = lhs.unisonVoices == rhs.unisonVoices;
-        ret &= lhs.detune == rhs.detune;
-        ret &= lhs.pan == rhs.pan;
-        ret &= lhs.phase == rhs.phase;
-        return ret;
-      }
-
-      inline bool operator==(const MasterGroup& lhs, const MasterGroup& rhs)
-      {
-        auto ret = lhs.volume == rhs.volume;
-        ret &= lhs.tune == rhs.tune;
-        ret &= lhs.pan == rhs.pan;
-        ret &= lhs.serialFX == rhs.serialFX;
-        return ret;
-      }
-
-    }  // namespace nltools::msg::ParameterGroups
 
     namespace detail
     {
@@ -168,11 +95,6 @@ namespace nltools
         }
 
         // shared data (present in any sound type)
-        // todo: refactor ...
-        SingularParameterArray<ParameterType::Hardware_Source, Parameters::HardwareSourceParameter> hwsources;
-        SingularParameterArray<ParameterType::Hardware_Amount, Parameters::HardwareAmountParameter> hwamounts;
-        SingularParameterArray<ParameterType::Macro_Control, Parameters::MacroParameter> macros;
-        SingularParameterArray<ParameterType::Macro_Time, Parameters::UnmodulateableParameter> macrotimes;
         // ... into:
         SingularParameterArray<ParameterType::Hardware_Source, controls::HardwareSourceParameter> m_hardwareSources;
         SingularParameterArray<ParameterType::Display_Parameter, controls::HardwareSourceSendParameter>
@@ -181,11 +103,6 @@ namespace nltools
         SingularParameterArray<ParameterType::Macro_Control, controls::MacroControlParameter> m_macroControls;
         SingularParameterArray<ParameterType::Macro_Time, controls::MacroTimeParameter> m_macroTimes;
 
-        // todo: refactor (into Global Modulateables/Unmodulateables, deprecating ParameterGroups)
-        ParameterGroups::MasterGroup master;
-        Parameters::GlobalParameter scaleBaseKey;
-        std::array<Parameters::ModulateableParameter, 12> scaleOffsets;
-        // todo: use
         SingularParameterArray<ParameterType::Global_Modulateable, controls::GlobalModulateableParameter>
             m_globalModulateables;
         SingularParameterArray<ParameterType::Global_Unmodulateable, controls::GlobalUnmodulateableParameter>
@@ -206,15 +123,6 @@ namespace nltools
           ret &= _lhs.m_globalUnmodulateables == _rhs.m_globalUnmodulateables;
           ret &= _lhs.m_monophonicModulateables == _rhs.m_monophonicModulateables;
           ret &= _lhs.m_monophonicUnmodulateables == _rhs.m_monophonicUnmodulateables;
-          // todo: remove
-          ret = _lhs.hwsources == _rhs.hwsources;
-          ret &= _lhs.hwamounts == _rhs.hwamounts;
-          ret &= _lhs.macros == _rhs.macros;
-          ret &= _lhs.macrotimes == _rhs.macrotimes;
-          // todo: remove (when refactored into Global Modulateables/Unmodulateables)
-          ret &= _lhs.master == _rhs.master;
-          ret &= _lhs.scaleBaseKey == _rhs.scaleBaseKey;
-          ret &= _lhs.scaleOffsets == _rhs.scaleOffsets;
           return ret;
         }
 
@@ -255,15 +163,6 @@ namespace nltools
 
     struct SinglePresetMessage : public detail::PresetMessage<nltools::msg::MessageType::SinglePreset>
     {
-      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      std::array<Parameters::ModulateableParameter, 169> modulateables;
-      std::array<Parameters::UnmodulateableParameter, 29> unmodulateables;
-
-      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
-      ParameterGroups::UnisonGroup unison;
-      ParameterGroups::MonoGroup mono;
-
-      // todo: use
       SingularParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       SingularParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>
@@ -275,10 +174,12 @@ namespace nltools
         if(!SinglePresetMessage::validateCommon(_msg))
           return false;
 
-        auto modulateablesValid = std::all_of(_msg.m_polyphonicModulateables.begin(), _msg.m_polyphonicModulateables.end(),
-                           [](auto e) { return e.validateParameterType(); });
-        auto unmodulateablesValid = std::all_of(_msg.m_polyphonicUnmodulateables.begin(), _msg.m_polyphonicUnmodulateables.end(),
-                           [](auto e) { return e.validateParameterType(); });
+        auto modulateablesValid
+            = std::all_of(_msg.m_polyphonicModulateables.begin(), _msg.m_polyphonicModulateables.end(),
+                          [](auto e) { return e.validateParameterType(); });
+        auto unmodulateablesValid
+            = std::all_of(_msg.m_polyphonicUnmodulateables.begin(), _msg.m_polyphonicUnmodulateables.end(),
+                          [](auto e) { return e.validateParameterType(); });
         return modulateablesValid && unmodulateablesValid;
       }
     };
@@ -288,11 +189,6 @@ namespace nltools
       auto ret = SinglePresetMessage::compareCommon(_lhs, _rhs);
       ret &= _lhs.m_polyphonicModulateables == _rhs.m_polyphonicModulateables;
       ret &= _lhs.m_polyphonicUnmodulateables == _rhs.m_polyphonicUnmodulateables;
-      // todo: remove (when refactored into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      ret &= _lhs.unmodulateables == _rhs.unmodulateables;
-      ret &= _lhs.modulateables == _rhs.modulateables;
-      ret &= _lhs.mono == _rhs.mono;
-      ret &= _lhs.unison == _rhs.unison;
       return ret;
     }
 
@@ -303,16 +199,6 @@ namespace nltools
 
     struct SplitPresetMessage : public detail::PresetMessage<nltools::msg::MessageType::SplitPreset>
     {
-      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      std::array<std::array<Parameters::ModulateableParameter, 169>, 2> modulateables;
-      std::array<std::array<Parameters::UnmodulateableParameter, 29>, 2> unmodulateables;
-
-      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
-      std::array<ParameterGroups::UnisonGroup, 2> unison;
-      std::array<ParameterGroups::MonoGroup, 2> mono;
-      std::array<Parameters::SplitPoint, 2> splitpoint;
-
-      // todo: use
       DualParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       DualParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>
@@ -340,12 +226,6 @@ namespace nltools
       auto ret = SplitPresetMessage::compareCommon(_lhs, _rhs);
       ret &= _lhs.m_polyphonicModulateables == _rhs.m_polyphonicModulateables;
       ret &= _lhs.m_polyphonicUnmodulateables == _rhs.m_polyphonicUnmodulateables;
-      // todo: remove (when refactored into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      ret &= _lhs.unmodulateables == _rhs.unmodulateables;
-      ret &= _lhs.modulateables == _rhs.modulateables;
-      ret &= _lhs.mono == _rhs.mono;
-      ret &= _lhs.unison == _rhs.unison;
-      ret &= _lhs.splitpoint == _rhs.splitpoint;
       return ret;
     }
 
@@ -356,17 +236,9 @@ namespace nltools
 
     struct LayerPresetMessage : public detail::PresetMessage<nltools::msg::MessageType::LayerPreset>
     {
-      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      std::array<std::array<Parameters::ModulateableParameter, 169>, 2> modulateables;
-      std::array<std::array<Parameters::UnmodulateableParameter, 29>, 2> unmodulateables;
-
-      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
       // note: yes, Unison and Mono will be present twice in a LayerPresetMsg (although only one VoiceGroup is relevant)
       //       (for comparisons to work properly, Unison/Mono should be identical in both VoiceGroups)
-      ParameterGroups::UnisonGroup unison;
-      ParameterGroups::MonoGroup mono;
 
-      // todo: use
       DualParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       DualParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>
@@ -394,11 +266,6 @@ namespace nltools
       auto ret = LayerPresetMessage::compareCommon(_lhs, _rhs);
       ret &= _lhs.m_polyphonicModulateables == _rhs.m_polyphonicModulateables;
       ret &= _lhs.m_polyphonicUnmodulateables == _rhs.m_polyphonicUnmodulateables;
-      // todo: remove (when refactored into Polyphonic/Monophonic Modulateables/Unmodulateables)
-      ret &= _lhs.unmodulateables == _rhs.unmodulateables;
-      ret &= _lhs.modulateables == _rhs.modulateables;
-      ret &= _lhs.mono == _rhs.mono;
-      ret &= _lhs.unison == _rhs.unison;
       return ret;
     }
 

--- a/projects/shared/nltools-2/include/PresetMessages.h
+++ b/projects/shared/nltools-2/include/PresetMessages.h
@@ -71,6 +71,62 @@ namespace nltools
 
     }  // namespace nltools::msg::Parameters
 
+    namespace ParameterGroups
+    {
+
+      struct UnisonGroup
+      {
+        Parameters::UnmodulateableParameter unisonVoices;
+        Parameters::ModulateableParameter detune;
+        Parameters::UnmodulateableParameter phase;
+        Parameters::UnmodulateableParameter pan;
+      };
+
+      struct MonoGroup
+      {
+        Parameters::UnmodulateableParameter monoEnable;
+        Parameters::UnmodulateableParameter legato;
+        Parameters::UnmodulateableParameter priority;
+        Parameters::ModulateableParameter glide;
+      };
+
+      struct MasterGroup
+      {
+        Parameters::ModulateableParameter volume;
+        Parameters::ModulateableParameter tune;
+        Parameters::ModulateableParameter pan;
+        Parameters::ModulateableParameter serialFX;
+      };
+
+      inline bool operator==(const MonoGroup& lhs, const MonoGroup& rhs)
+      {
+        auto ret = lhs.glide == rhs.glide;
+        ret &= lhs.monoEnable == rhs.monoEnable;
+        ret &= lhs.priority == rhs.priority;
+        ret &= lhs.legato == rhs.legato;
+        return ret;
+      }
+
+      inline bool operator==(const UnisonGroup& lhs, const UnisonGroup& rhs)
+      {
+        auto ret = lhs.unisonVoices == rhs.unisonVoices;
+        ret &= lhs.detune == rhs.detune;
+        ret &= lhs.pan == rhs.pan;
+        ret &= lhs.phase == rhs.phase;
+        return ret;
+      }
+
+      inline bool operator==(const MasterGroup& lhs, const MasterGroup& rhs)
+      {
+        auto ret = lhs.volume == rhs.volume;
+        ret &= lhs.tune == rhs.tune;
+        ret &= lhs.pan == rhs.pan;
+        ret &= lhs.serialFX == rhs.serialFX;
+        return ret;
+      }
+
+    }  // namespace nltools::msg::ParameterGroups
+
     namespace detail
     {
 
@@ -95,6 +151,10 @@ namespace nltools
         }
 
         // shared data (present in any sound type)
+        SingularParameterArray<ParameterType::Hardware_Source, Parameters::HardwareSourceParameter> hwsources;
+        SingularParameterArray<ParameterType::Hardware_Amount, Parameters::HardwareAmountParameter> hwamounts;
+        SingularParameterArray<ParameterType::Macro_Control, Parameters::MacroParameter> macros;
+        SingularParameterArray<ParameterType::Macro_Time, Parameters::UnmodulateableParameter> macrotimes;
         // ... into:
         SingularParameterArray<ParameterType::Hardware_Source, controls::HardwareSourceParameter> m_hardwareSources;
         SingularParameterArray<ParameterType::Display_Parameter, controls::HardwareSourceSendParameter>
@@ -103,6 +163,12 @@ namespace nltools
         SingularParameterArray<ParameterType::Macro_Control, controls::MacroControlParameter> m_macroControls;
         SingularParameterArray<ParameterType::Macro_Time, controls::MacroTimeParameter> m_macroTimes;
 
+        //todo: remove:
+        ParameterGroups::MasterGroup master;
+        Parameters::GlobalParameter scaleBaseKey;
+        std::array<Parameters::ModulateableParameter, 12> scaleOffsets;
+
+        // done: use
         SingularParameterArray<ParameterType::Global_Modulateable, controls::GlobalModulateableParameter>
             m_globalModulateables;
         SingularParameterArray<ParameterType::Global_Unmodulateable, controls::GlobalUnmodulateableParameter>
@@ -163,6 +229,15 @@ namespace nltools
 
     struct SinglePresetMessage : public detail::PresetMessage<nltools::msg::MessageType::SinglePreset>
     {
+      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
+      std::array<Parameters::ModulateableParameter, 169> modulateables;
+      std::array<Parameters::UnmodulateableParameter, 29> unmodulateables;
+
+      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
+      ParameterGroups::UnisonGroup unison;
+      ParameterGroups::MonoGroup mono;
+
+      // todo: use
       SingularParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       SingularParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>
@@ -199,6 +274,16 @@ namespace nltools
 
     struct SplitPresetMessage : public detail::PresetMessage<nltools::msg::MessageType::SplitPreset>
     {
+      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
+      std::array<std::array<Parameters::ModulateableParameter, 169>, 2> modulateables;
+      std::array<std::array<Parameters::UnmodulateableParameter, 29>, 2> unmodulateables;
+
+      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
+      std::array<ParameterGroups::UnisonGroup, 2> unison;
+      std::array<ParameterGroups::MonoGroup, 2> mono;
+      std::array<Parameters::SplitPoint, 2> splitpoint;
+
+      // todo: use
       DualParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       DualParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>
@@ -236,9 +321,17 @@ namespace nltools
 
     struct LayerPresetMessage : public detail::PresetMessage<nltools::msg::MessageType::LayerPreset>
     {
+      // todo: refactor (into Polyphonic/Monophonic Modulateables/Unmodulateables)
+      std::array<std::array<Parameters::ModulateableParameter, 169>, 2> modulateables;
+      std::array<std::array<Parameters::UnmodulateableParameter, 29>, 2> unmodulateables;
+
+      // todo: refactor (into Polyphonic Modulateables/Unmodulateables, deprecating ParameterGroups)
       // note: yes, Unison and Mono will be present twice in a LayerPresetMsg (although only one VoiceGroup is relevant)
       //       (for comparisons to work properly, Unison/Mono should be identical in both VoiceGroups)
+      ParameterGroups::UnisonGroup unison;
+      ParameterGroups::MonoGroup mono;
 
+      // todo: use
       DualParameterArray<ParameterType::Polyphonic_Modulateable, controls::PolyphonicModulateableParameter>
           m_polyphonicModulateables;
       DualParameterArray<ParameterType::Polyphonic_Unmodulateable, controls::PolyphonicUnmodulateableParameter>


### PR DESCRIPTION
- [ ] some new tests are failing as the parameters are not yet declared as Monophonic_Mod/Unmod and Polyphonic_Mod/Unmod that's why the check for different messages fail (as the array has a length of 0)
- [x] implement sending of new parameter-changed-messages
- [x] implement filling of new preset-messages
- [x] deleted unused/deprecated members and classes, which are no longer needed (see below)
- [x] the Playground would compile without the members marked `todo: depricate and todo: remove` but I let them live for now to support compilation of the AE