### PR TITLE
issue-3392: Downgrade wpa_supplicant

### DIFF
--- a/build-tools/pacman/c15/CMakeLists.txt
+++ b/build-tools/pacman/c15/CMakeLists.txt
@@ -5,15 +5,18 @@ string(STRIP ${USER_ID} USER_ID)
 
 file(GLOB_RECURSE SOURCE_FILES ${CMAKE_SOURCE_DIR}/projects/epc/*)
 
-SET(ARCH_VERSION 20220424.0.54084)
-SET(C15_PACKAGES_VERSION "2022-09-13")
+SET(ARCH_VERSION_YEAR 2022)
+SET(ARCH_VERSION_MONTH 04)
+SET(ARCH_VERSION_DAY 24)
+SET(ARCH_VERSION ${ARCH_VERSION_YEAR}${ARCH_VERSION_MONTH}${ARCH_VERSION_DAY}.0.54084)
+SET(C15_PACKAGES_VERSION "2022-11-17")
 SET(BUILD_SETUP_VERSION "arch-${ARCH_VERSION}-packages-${C15_PACKAGES_VERSION}")
 SET(DOCKERNAME pacman-c15-fetch-${BUILD_SETUP_VERSION}-docker)
 SET(NL_DOWNLOAD_PATH /build-tools/pacman/c15) # used with http
 SET(NL_UPLOAD_PATH /var/www/html/${NL_DOWNLOAD_PATH}) # used with rsync
 SET(DOCKER_TAR c15-build-docker-${BUILD_SETUP_VERSION}.tar)
 
-SET(HOST_REQUIREMENTS binutils ccache cmake fakeroot gcc git linux make nano ninja pacman pacman-contrib pkgconfig sudo squashfs-tools xz npm nodejs)
+SET(HOST_REQUIREMENTS binutils ccache cmake fakeroot gcc git linux make nano ninja pacman pacman-contrib pkgconfig sudo squashfs-tools xz npm nodejs npm rsync)
 STRING(REPLACE ";" " " HOST_REQUIREMENTS "${HOST_REQUIREMENTS}")
 
 SET(C15_REQUIREMENTS alsa alsa-tools alsa-utils arch-install-scripts base boost cpupower dnsmasq flac freetype2 glibmm linux-firmware libpng libsoup lm_sensors mc nano networkmanager png++ shared-mime-info sudo sshfs lsof systemd-sysvcompat vi)

--- a/build-tools/pacman/c15/Dockerfile.in
+++ b/build-tools/pacman/c15/Dockerfile.in
@@ -1,10 +1,7 @@
 FROM archlinux:base-@ARCH_VERSION@
 
-RUN pacman-key --init
+RUN echo "Server=https://archive.archlinux.org/repos/@ARCH_VERSION_YEAR@/@ARCH_VERSION_MONTH@/@ARCH_VERSION_DAY@/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist
 RUN pacman --noconfirm -Sy
-RUN pacman --noconfirm -S archlinux-keyring
-RUN pacman-key --populate
-RUN pacman --noconfirm -Syyuu
 RUN pacman --noconfirm -S @HOST_REQUIREMENTS@ @C15_REQUIREMENTS@
 
 RUN mkdir -p /packages
@@ -12,5 +9,11 @@ RUN mkdir -p /tmp/blankdb
 WORKDIR /packages
 RUN pacman --noconfirm -Syw --cachedir . --dbpath /tmp/blankdb @C15_REQUIREMENTS@
 
-RUN pacman --noconfirm -S npm nodejs rsync
+# downgrade wpa_supplicant
+RUN pacman --noconfirm -S wget
+RUN rm /packages/wpa_supplicant*
+RUN wget https://archive.archlinux.org/packages/w/wpa_supplicant/wpa_supplicant-2%3A2.9-8-x86_64.pkg.tar.zst
+RUN wget https://archive.archlinux.org/packages/w/wpa_supplicant/wpa_supplicant-2%3A2.9-8-x86_64.pkg.tar.zst.sig
+RUN pacman --noconfirm -Uw --cachedir . --dbpath /tmp/blankdb /packages/wpa_supplicant-2:2.9-8-x86_64.pkg.tar.zst
+
 RUN npm install -g typescript js-yaml @types/node @types/js-yaml


### PR DESCRIPTION
Mac os devices (>= Monterey) cannot connect to C15 running wpa_supplicant >= 2.10. So we have to downgrade to 2.9 which seems to work fine.
While working on this, I found that I have to pin arch updates to a dedicated version (2022-04-24) as otherwise due to the rolling distribution nature of arch linux each rebuilding of the docker container will fetch the newest version of everything.

Probably, this pinning will introduce the known 'signature' errors in the future, which I will solve then. (It is hard to fix/test it now, as currently the errors do not yet exist)