### PR TITLE
fixes for 2920, 2921 and 2995

### DIFF
--- a/projects/epc/playground/src/parameters/ParameterImportConversions.cpp
+++ b/projects/epc/playground/src/parameters/ParameterImportConversions.cpp
@@ -78,7 +78,6 @@ ParameterImportConversions::ParameterImportConversions(bool registerDefaults)
     registerConverter(C15::PID::MC_Time_E, 5, [=](auto v, auto, auto) { return 0.442; });
     registerConverter(C15::PID::MC_Time_F, 5, [=](auto v, auto, auto) { return 0.442; });
 
-    registerConverter(C15::PID::Out_Mix_Key_Pan, 11, [=](auto v, auto, auto) { return v * 0.5; });
     registerConverter(C15::PID::Osc_A_Pitch_KT, 11, [=](auto v, auto, auto) { return pitchKTV11ToV12(v); });
     registerConverter(C15::PID::Osc_B_Pitch_KT, 11, [=](auto v, auto, auto) { return pitchKTV11ToV12(v); });
     registerConverter(C15::PID::Comb_Flt_Pitch_KT, 11, [=](auto v, auto, auto) { return pitchKTV11ToV12(v); });
@@ -88,38 +87,31 @@ ParameterImportConversions::ParameterImportConversions(bool registerDefaults)
     registerConverter(C15::PID::Unison_Detune, 11, [=](auto v, auto, auto) { return v * 0.5; });
     registerMCAmountConverter(C15::PID::Unison_Detune, 11, [=](auto v, auto, auto) { return v * 0.5; });
 
-    registerConverter(C15::PID::Env_A_Att_Vel, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Env_B_Att_Vel, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Env_C_Att_Vel, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Env_A_Time_KT, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Env_B_Time_KT, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Env_C_Time_KT, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Shp_A_FB_Env_C, 11, [=](auto v, auto, auto) { return v * 0.5; });
-    registerConverter(C15::PID::Shp_B_FB_Env_C, 11, [=](auto v, auto, auto) { return v * 0.5; });
-
     for(auto offset :
         { C15::PID::Scale_Offset_0, C15::PID::Scale_Offset_1, C15::PID::Scale_Offset_2, C15::PID::Scale_Offset_3,
           C15::PID::Scale_Offset_4, C15::PID::Scale_Offset_5, C15::PID::Scale_Offset_6, C15::PID::Scale_Offset_7,
           C15::PID::Scale_Offset_8, C15::PID::Scale_Offset_9, C15::PID::Scale_Offset_10, C15::PID::Scale_Offset_11 })
     {
       registerConverter(offset, 11, [=](auto v, auto, auto) { return (2. / 3.) * v; });
-      registerConverter(offset, 14, [=](auto v, auto, auto) {
-        const auto oldLim = 1./12.;
-        const auto newLim = 10./21.;
+      registerConverter(offset, 14,
+                        [=](auto v, auto, auto)
+                        {
+                          const auto oldLim = 1. / 12.;
+                          const auto newLim = 10. / 21.;
 
-        if ( (v > -oldLim) && (v < oldLim) )
-        {
-          return v * newLim / oldLim;
-        }
-        else if (v >= oldLim)
-        {
-          return newLim + (v - oldLim) * (1.0 - newLim) / (1.0 - oldLim);
-        }
-        else
-        {
-          return -newLim + (v + oldLim) * (1.0 - newLim) / (1.0 - oldLim);
-        }
-      });
+                          if((v > -oldLim) && (v < oldLim))
+                          {
+                            return v * newLim / oldLim;
+                          }
+                          else if(v >= oldLim)
+                          {
+                            return newLim + (v - oldLim) * (1.0 - newLim) / (1.0 - oldLim);
+                          }
+                          else
+                          {
+                            return -newLim + (v + oldLim) * (1.0 - newLim) / (1.0 - oldLim);
+                          }
+                        });
     }
 
     registerConverter(C15::PID::Env_A_Att_Vel, 12, [=](auto v, auto, auto) { return -v; });

--- a/projects/shared/nltools-2/include/PresetMessages.h
+++ b/projects/shared/nltools-2/include/PresetMessages.h
@@ -203,8 +203,8 @@ namespace nltools
         {
           const auto index = (uint32_t) id;
           // copy data from Part I to Part II (assuming already correct id)
-          auto& lhs = m_polyphonicModulateables[0][index];
-          const auto& rhs = m_polyphonicModulateables[1][index];
+          const auto& rhs = m_polyphonicModulateables[0][index];
+          auto& lhs = m_polyphonicModulateables[1][index];
           lhs.m_controlPosition = rhs.m_controlPosition;
           lhs.m_macro = rhs.m_macro;
           lhs.m_modulationAmount = rhs.m_modulationAmount;


### PR DESCRIPTION
### Import Conversions for Bank Version 11

- [x] fixes #2921 (and #2920)

Some Parameters just were refactored from being unipolar into being bipolar, their range was otherwise not affected. Those Parameters had wrong Import Conversions (0.5 * cp) which were removed. 

[Playground-Test](https://github.com/nonlinear-labs-dev/C15/files/10166461/2995-ae-playground-test.txt) and [Acceptance-Tests](https://github.com/nonlinear-labs-dev/C15/files/10166467/2995-ae-acceptance-tests.txt) yielded no fails related to this.

### BugFix Recall Layer Unison/Mono

Unison Detune/Phase/Pan and Mono Glide were recalled with initial values due to bug in `nltools-2/PresetMessages.h::guaranteeEqualVoicesParameters` _(copied II --> I instead of I --> II)_

- [x] Sound Check was successful