### PR TITLE
fix installation of c15 packages

### DIFF
--- a/build-tools/pacman/c15/dockerized-create-c15-rootfs.sh
+++ b/build-tools/pacman/c15/dockerized-create-c15-rootfs.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -x
+
 ### Installs c15 package and all its dependencies into a folder and packs the result into a tar.gz
 ### This results in a rootfs that can be booted and run the full NL software stack.
 
@@ -11,6 +14,7 @@ setup_package_database() { # Create a database containing c15 package and all it
   cp /out/c15-1.0.0-1-any.pkg.tar.zst /nl/
   echo "[nl]" > /etc/pacman.conf
   echo "Server = file:///nl/" >> /etc/pacman.conf
+  echo "SigLevel = Optional TrustAll" >> /etc/pacman.conf
   set +e
 }
 

--- a/projects/shared/version.h
+++ b/projects/shared/version.h
@@ -27,7 +27,7 @@
 //
 //  Final Versions         "YY-WW"   YY-WW : release date (tbd).
 //  Everything else        whatever seems appropriate
-#define C15_VERSION_STRING "22-48"
+#define C15_VERSION_STRING "22-49"
 #pragma message("make sure version string '" C15_VERSION_STRING "' is up-to date when building a release or beta")
 
 // do not change these two strings:


### PR DESCRIPTION
there were revoked certificates that could not be approved, so installation of packages turned into a noop.
We don't need to approve package maintainers keys, so lets configure pacman accordingly.