### PR TITLE
finished Split Point rounding

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/parameter_types.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/parameter_types.h
@@ -2,6 +2,7 @@
 
 #include <Parameters.h>
 #include <parameter_group.h>
+#include <SplitPointRounding.h>
 
 namespace Engine
 {
@@ -221,25 +222,41 @@ namespace Engine
       }
       inline bool modulate(const float &_mod)
       {
-        m_unclipped = m_base + (m_amount * _mod);
+        if(m_splitpoint)
+        {
+          m_unclipped = m_base + SplitPointRounding::getModulation(_mod, m_amount);
+        }
+        else
+        {
+          m_unclipped = m_base + (m_amount * _mod);
+        }
         return m_position != m_unclipped;  // basic change detection (position needs to be updated from outside)
       }
       inline void update_modulation_aspects(const float &_mod)
       {
-        m_base = m_position - (m_amount * _mod);
+        if(m_splitpoint)
+        {
+          m_base = m_position - SplitPointRounding::getModulation(_mod, m_amount);
+        }
+        else
+        {
+          m_base = m_position - (m_amount * _mod);
+        }
         m_ceil = m_base + m_amount;
       }
       inline void log(const char *const _msg, const C15::ParameterDescriptor &_descriptor)
       {
         nltools::Log::info(_msg, "(label:", C15::ParameterGroups[(unsigned) _descriptor.m_group].m_label_short,
                            _descriptor.m_pg.m_param_label_long, ", index:", _descriptor.m_param.m_index,
-                           ", position:", m_position, ", mc:", (int) m_source, ", amt:", m_amount, ", scaled:", m_scaled, ")");
+                           ", position:", m_position, ", mc:", (int) m_source, ", amt:", m_amount,
+                           ", scaled:", m_scaled, ")");
       }
       inline void log(const uint32_t &_layer, const char *const _msg, const C15::ParameterDescriptor &_descriptor)
       {
-        nltools::Log::info(_msg, "(layer: ", _layer, ", label:", C15::ParameterGroups[(unsigned) _descriptor.m_group].m_label_short,
-                           _descriptor.m_pg.m_param_label_long, ", index:", _descriptor.m_param.m_index,
-                           ", position:", m_position, ", mc:", (int) m_source, ", amt:", m_amount, ", scaled:", m_scaled, ")");
+        nltools::Log::info(
+            _msg, "(layer: ", _layer, ", label:", C15::ParameterGroups[(unsigned) _descriptor.m_group].m_label_short,
+            _descriptor.m_pg.m_param_label_long, ", index:", _descriptor.m_param.m_index, ", position:", m_position,
+            ", mc:", (int) m_source, ", amt:", m_amount, ", scaled:", m_scaled, ")");
       }
     };
 
@@ -259,7 +276,8 @@ namespace Engine
       }
       inline void log(const uint32_t &_layer, const char *const _msg, const C15::ParameterDescriptor &_descriptor)
       {
-        nltools::Log::info(_msg, "(layer: ", _layer, ", label:", C15::ParameterGroups[(unsigned) _descriptor.m_group].m_label_short,
+        nltools::Log::info(_msg, "(layer: ", _layer,
+                           ", label:", C15::ParameterGroups[(unsigned) _descriptor.m_group].m_label_short,
                            _descriptor.m_pg.m_param_label_long, ", index:", _descriptor.m_param.m_index,
                            ", position:", m_position, ", scaled:", m_scaled, ")");
       }

--- a/projects/epc/playground/src/parameters/SplitPointParameter.cpp
+++ b/projects/epc/playground/src/parameters/SplitPointParameter.cpp
@@ -12,6 +12,7 @@
 #include <device-settings/SplitPointSyncParameters.h>
 #include <parameter_declarations.h>
 #include <libundo/undo/Scope.h>
+#include <SplitPointRounding.h>
 
 SplitPointParameter::SplitPointParameter(ParameterGroup* group, const ParameterId& id)
     : ModulateableParameter(group, id)
@@ -186,40 +187,22 @@ bool SplitPointParameter::isSynced() const
   return false;
 }
 
-// copy of the algorithm used in audio-engine
-auto ae_round(const float _value)
-{
-  return (signed) std::ceil(_value * (signed) 60);
-}
-
-auto ae_quantize(const float _value, const unsigned _steps)
-{
-  if(_steps == 0)
-    return _value;
-
-  return std::clamp(std::floor(_value * (1 + _steps)) / _steps, 0.0f, 1.0f);
-}
-
-auto ae_getModulation(const float _mod, const float modAmount)
-{
-  return (float) modAmount * ae_quantize(_mod, ae_round(std::abs(modAmount)));
-};
-
 void SplitPointParameter::applyMacroControl(tDisplayValue mcValue, Initiator initiator)
 {
-  auto newValue = getModulationBase() + (double) ae_getModulation(mcValue, getModulationAmount());
+  auto newValue
+      = getModulationBase() + (double) SplitPointRounding::getModulation(mcValue, (float) getModulationAmount());
   getValue().setRawValue(initiator, newValue);
 }
 
 void SplitPointParameter::updateModulationBase()
 {
-  auto calcModulationBase = [this] {
+  auto calcModulationBase = [this]
+  {
     if(auto macroParam = getMacroControl())
     {
       auto _mod = (float) macroParam->getControlPositionValue();
-      auto modAmount = getModulationAmount();
       auto curValue = getValue().getQuantizedClipped();
-      return curValue - (double) ae_getModulation(_mod, getModulationAmount());
+      return curValue - (double) SplitPointRounding::getModulation(_mod, (float) getModulationAmount());
     }
     return 0.0;
   };

--- a/projects/shared/nltools-2/include/SplitPointRounding.h
+++ b/projects/shared/nltools-2/include/SplitPointRounding.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <parameter_list.h>
+#include <cmath>
+#include <algorithm>
+
+namespace SplitPointRounding
+{
+
+  static constexpr float range = (float) C15::ParameterList[C15::PID::Split_Split_Point].m_pg.m_coarse_cp;
+
+  static signed round(const float &_value)
+  {
+    return (signed) std::ceil(range * _value);
+  }
+
+  static float quantize(const float &_value, const unsigned &_steps)
+  {
+    if(_steps == 0)
+      return _value;
+    const float normal = 1.0f / (float) _steps;
+    return std::clamp(std::floor(_value * (float) (1 + _steps)) / (float) _steps, 0.0f, 1.0f);
+  }
+
+  static float getModulation(const float &_mod, const float &_modAmount)
+  {
+    return (float) _modAmount * quantize(_mod, round(std::abs(_modAmount)));
+  }
+
+}


### PR DESCRIPTION
closes #2394

- [x] provided shared (nltools-2) and generic (no hand-coded resolution) split point rounding algorithm for playground and audio-engine
- [x] testing: playground- and acceptance- tests are ok, tested successfully and sporadically with linked and unlinked split points