### PR TITLE
add new layout for init as sound-type conversion (3417)

### DIFF
--- a/projects/epc/playground/resources/templates/init-screen/init-screen.json
+++ b/projects/epc/playground/resources/templates/init-screen/init-screen.json
@@ -1,0 +1,52 @@
+{
+  "layouts": {
+    "Sound-Init-Layout": {
+      "Selector": {
+        "UIFocus": "Any",
+        "UIMode": "Select",
+        "UIDetail": "InitSound"
+      },
+      "Controls": {
+        "Header": {
+          "Class": "InvertedLabel",
+          "Position": "96, 18",
+          "Init": {
+            "Text[Text]": "Initialize"
+          }
+        },
+        "Init_As_Single": {
+          "Class": "Button",
+          "Position": "BUTTON_A",
+          "Init": {
+            "Text[Text]": "as Single"
+          }
+        },
+        "Init_As_Split": {
+          "Class": "Button",
+          "Position": "BUTTON_B",
+          "Init": {
+            "Text[Text]": "as Split"
+          }
+        },
+        "Init_As_Layer": {
+          "Class": "Button",
+          "Position": "BUTTON_C",
+          "Init": {
+            "Text[Text]": "as Layer"
+          }
+        },
+        "Init_Part": {
+          "Class": "Button",
+          "Position": "BUTTON_D",
+          "Events": "InitCurrentVoiceText => Text[Text]"
+        }
+      },
+      "EventSinks": {
+        "BUTTON_A": "InitAsSingle",
+        "BUTTON_B": "InitAsSplit",
+        "BUTTON_C": "InitAsLayer",
+        "BUTTON_D": "InitPart"
+      }
+    }
+  }
+}

--- a/projects/epc/playground/src/proxies/hwui/HWUIEnums.h
+++ b/projects/epc/playground/src/proxies/hwui/HWUIEnums.h
@@ -7,7 +7,7 @@
 ENUM(UIFocus, uint8_t, Any, Sound, Parameters, Presets, Banks, Setup, Unchanged);
 ENUM(UIMode, uint8_t, Any, Select, Store, Edit, Info, Unchanged);
 ENUM(UIDetail, uint8_t, Any, Unchanged, Init, ButtonA, ButtonB, ButtonC, ButtonD, MCSelect, MCAmount, MCPosition,
-     MCModRange, Voices, SoundParameters);
+     MCModRange, Voices, SoundParameters, InitSound);
 ENUM(LayoutVersionMode, uint8_t, Old, Mixed, New);
 
 enum ButtonModifier

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/TemplateEnums.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/TemplateEnums.h
@@ -57,7 +57,8 @@ namespace DescriptiveLayouts
        LayerFBState, LayerFXState, LayerFXOffset, FX_I_Imagestate, FX_II_Imagestate, LayerToFXPath,
        Serial_FX_Imagestate, Layer_FX_TO_OUT_Imagestate, Split_FX_TO_OUT_Imagestate, Split_FX_TO_OUT_Imagestate_flipped,
        Split_Arrows_To_FX_L_TO_R_I, Split_Arrows_To_FX_L_TO_R_II, Split_Arrows_To_FX_R_TO_L_I,
-       Split_Arrows_To_FX_R_TO_L_II, Split_Arrows_FX_To_I, Split_Arrows_FX_To_II);
+       Split_Arrows_To_FX_R_TO_L_II, Split_Arrows_FX_To_I, Split_Arrows_FX_To_II,
+       InitCurrentVoiceText);
 
   ENUM(EventSinks, uint8_t, Swallow, SwitchToInitDetail, SwitchToEditMode, SwitchToSelectMode, SwitchToSetupFocus,
        SwitchToParameterFocus, SwitchToBankFocus, SwitchToPresetFocus, SwitchToSoundFocus, SwitchToMCSelectDetail,
@@ -68,7 +69,7 @@ namespace DescriptiveLayouts
        IncPresetSelectionPresetList, DecPresetSelectionPresetList, IncBankSelectionPresetList,
        DecBankSelectionPresetList, DoPresetListAction, OpenUnisonParameter, OpenMasterParameter, SwitchToVoicesDetail,
        OpenMonoParameterScreen, OpenPartScreen, InitSound, IncSplitPoint, DecSplitPoint, LayerMuteInc, LayerMuteDec,
-       OpenFXMixParameter,
+       OpenFXMixParameter, InitAsSingle, InitAsSplit, InitAsLayer, InitPart,
        // try to use more generic names, the specific meaning is implemented in the EventProvider
        Left, Right, Up, Down, IncParam, DecParam, Commit);
 

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSinkBroker.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSinkBroker.cpp
@@ -36,6 +36,7 @@ namespace DescriptiveLayouts
     auto eb = Application::get().getPresetManager()->getEditBuffer();
     auto hwui = Application::get().getHWUI();
     auto vgManager = Application::get().getVGManager();
+    auto settings = &eb->getSettings();
 
     registerEvent(EventSinks::Swallow, []() { return; });
 
@@ -414,8 +415,8 @@ namespace DescriptiveLayouts
     registerEvent(EventSinks::OpenFXMixParameter,
                   [eb]
                   {
-                    EditBufferUseCases ebUseCases{*eb};
-                    ebUseCases.selectParameter({C15::PID::Master_FX_Mix, VoiceGroup::Global}, true);
+                    EditBufferUseCases ebUseCases { *eb };
+                    ebUseCases.selectParameter({ C15::PID::Master_FX_Mix, VoiceGroup::Global }, true);
                   });
 
     registerEvent(EventSinks::InitSound,
@@ -460,8 +461,8 @@ namespace DescriptiveLayouts
     registerEvent(EventSinks::LayerMuteInc,
                   [eb]()
                   {
-                    auto muteI = eb->findParameterByID({ 395, VoiceGroup::I });
-                    auto muteII = eb->findParameterByID({ 395, VoiceGroup::II });
+                    auto muteI = eb->findParameterByID({ C15::PID::Voice_Grp_Mute, VoiceGroup::I });
+                    auto muteII = eb->findParameterByID({ C15::PID::Voice_Grp_Mute, VoiceGroup::II });
                     const auto vgIMuted = muteI->getControlPositionValue() > 0.5;
                     const auto vgIIMuted = muteII->getControlPositionValue() > 0.5;
                     EditBufferUseCases useCases(*eb);
@@ -479,8 +480,8 @@ namespace DescriptiveLayouts
     registerEvent(EventSinks::LayerMuteDec,
                   [eb]()
                   {
-                    auto muteI = eb->findParameterByID({ 395, VoiceGroup::I });
-                    auto muteII = eb->findParameterByID({ 395, VoiceGroup::II });
+                    auto muteI = eb->findParameterByID({ C15::PID::Voice_Grp_Mute, VoiceGroup::I });
+                    auto muteII = eb->findParameterByID({ C15::PID::Voice_Grp_Mute, VoiceGroup::II });
                     const auto vgIMuted = muteI->getControlPositionValue() > 0.5;
                     const auto vgIIMuted = muteII->getControlPositionValue() > 0.5;
                     EditBufferUseCases useCases(*eb);
@@ -493,6 +494,50 @@ namespace DescriptiveLayouts
                     {
                       useCases.unmuteBothPartsWithTransactionNameForPart(VoiceGroup::I);
                     }
+                  });
+
+    registerEvent(EventSinks::InitAsSingle,
+                  [eb, settings]()
+                  {
+                    EditBufferUseCases ebUseCases(*eb);
+                    SettingsUseCases uc(*settings);
+
+                    ebUseCases.initSoundAs(SoundType::Single, Defaults::UserDefault);
+                    auto famSetting = settings->getSetting<FocusAndModeSetting>();
+                    uc.setFocusAndMode(famSetting->getOldState());
+                  });
+
+    registerEvent(EventSinks::InitAsSplit,
+                  [eb, settings]()
+                  {
+                    EditBufferUseCases ebUseCases(*eb);
+                    SettingsUseCases uc(*settings);
+
+                    ebUseCases.initSoundAs(SoundType::Split, Defaults::UserDefault);
+                    auto famSetting = settings->getSetting<FocusAndModeSetting>();
+                    uc.setFocusAndMode(famSetting->getOldState());
+                  });
+
+    registerEvent(EventSinks::InitAsLayer,
+                  [eb, settings]()
+                  {
+                    EditBufferUseCases ebUseCases(*eb);
+                    SettingsUseCases uc(*settings);
+
+                    ebUseCases.initSoundAs(SoundType::Layer, Defaults::UserDefault);
+                    auto famSetting = settings->getSetting<FocusAndModeSetting>();
+                    uc.setFocusAndMode(famSetting->getOldState());
+                  });
+
+    registerEvent(EventSinks::InitPart,
+                  [eb, vgManager, settings]()
+                  {
+                    EditBufferUseCases ebUseCases(*eb);
+                    ebUseCases.initPart(vgManager->getCurrentVoiceGroup(), Defaults::UserDefault);
+
+                    SettingsUseCases uc(*settings);
+                    auto famSetting = settings->getSetting<FocusAndModeSetting>();
+                    uc.setFocusAndMode(famSetting->getOldState());
                   });
   }
 

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSourceBroker.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/GlobalEventSourceBroker.cpp
@@ -72,6 +72,7 @@ namespace DescriptiveLayouts
     m_map[EventSources::VGIIsMuted] = std::make_unique<VGIIIsMuted>();
 
     m_map[EventSources::CurrentVoiceGroupText] = std::make_unique<CurrentVoiceGroupText>();
+    m_map[EventSources::InitCurrentVoiceText] = std::make_unique<InitCurrentVoiceText>();
 
     m_map[EventSources::SplitPointValue] = std::make_unique<SplitPointValueText>();
     m_map[EventSources::SplitPointIValue] = std::make_unique<SplitPointPartValueText<VoiceGroup::I>>();

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.cpp
@@ -773,3 +773,9 @@ void DescriptiveLayouts::Split_Arrows_To_FX_R_TO_L_II::onChange(const EditBuffer
     setResult("empty");
   }
 }
+
+void DescriptiveLayouts::InitCurrentVoiceText::onChange(VoiceGroup newSelection)
+{
+  auto str = nltools::string::concat("Part ", toString(newSelection));
+  setValue({str, 0});
+}

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.h
@@ -91,6 +91,12 @@ namespace DescriptiveLayouts
     void onChange(VoiceGroup newSelection) override;
   };
 
+  class InitCurrentVoiceText : public VoiceGroupSelectedEvent<DisplayString>
+  {
+   public:
+    void onChange(VoiceGroup newSelection) override;
+  };
+
   class SoundParamsButtonText : public EditBufferEvent<DisplayString>
   {
    public:

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.cpp
@@ -90,10 +90,10 @@ void PanelUnitPresetMode::letChangedButtonsBlink(Buttons buttonId, const std::li
     {
       if(parameter->isPolyphonic())
       {
-        parameter = editBuffer->findParameterByID({paramID, VoiceGroup::I });
+        parameter = editBuffer->findParameterByID({ paramID, VoiceGroup::I });
         if(!parameter)
         {
-          parameter = editBuffer->findParameterByID({paramID, VoiceGroup::Global});
+          parameter = editBuffer->findParameterByID({ paramID, VoiceGroup::Global });
         }
       }
     }
@@ -121,15 +121,14 @@ void PanelUnitPresetMode::setStateForButton(Buttons buttonId, const std::list<in
     if(!parameter)
       parameter = editBuffer->findParameterByID({ i, VoiceGroup::Global });
 
-
     if(editBuffer->getType() == SoundType::Single)
     {
       if(parameter->isPolyphonic())
       {
-        parameter = editBuffer->findParameterByID({i, VoiceGroup::I });
+        parameter = editBuffer->findParameterByID({ i, VoiceGroup::I });
         if(!parameter)
         {
-          parameter = editBuffer->findParameterByID({i, VoiceGroup::Global});
+          parameter = editBuffer->findParameterByID({ i, VoiceGroup::Global });
         }
       }
     }
@@ -214,6 +213,28 @@ std::pair<bool, bool> PanelUnitPresetMode::trySpecialCaseParameter(const Paramet
     }
   }
   return { false, false };
+}
+
+void PanelUnitPresetMode::setup()
+{
+  PanelUnitParameterEditMode::setup();
+  setupButtonConnection(Buttons::BUTTON_DEFAULT,
+                        [&](Buttons button, ButtonModifiers modifiers, bool state)
+                        {
+                          auto& settings = *Application::get().getSettings();
+                          SettingsUseCases useCases(settings);
+                          auto& famSetting = *settings.getSetting<FocusAndModeSetting>();
+                          auto focusAndMode = famSetting.getState();
+                          if(state)
+                          {
+                            useCases.setFocusAndMode({ focusAndMode.focus, UIMode::Select, UIDetail::InitSound });
+                          }
+                          else if(focusAndMode.detail == UIDetail::InitSound)
+                          {
+                            useCases.setFocusAndMode(famSetting.getOldState());
+                          }
+                          return true;
+                        });
 }
 
 PanelUnitSoundMode::PanelUnitSoundMode()

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitPresetMode.h
@@ -15,6 +15,7 @@ class PanelUnitPresetMode : public PanelUnitParameterEditMode
   PanelUnitPresetMode();
   ~PanelUnitPresetMode() override;
   void bruteForceUpdateLeds() override;
+  void setup() override;
 
  private:
   Throttler m_bruteForceLedThrottler;

--- a/projects/epc/playground/src/use-cases/EditBufferUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/EditBufferUseCases.cpp
@@ -461,3 +461,15 @@ void EditBufferUseCases::copyFX(VoiceGroup from, VoiceGroup to)
     dst->copyFrom(transaction, src);
   }
 }
+
+void EditBufferUseCases::initSoundAs(SoundType type, Defaults defaults)
+{
+  auto name = nltools::string::concat("Init Sound as ", toString(type));
+  auto scope = m_editBuffer.getUndoScope().startTransaction(name);
+  if(type != SoundType::Single)
+    m_editBuffer.undoableConvertToDual(scope->getTransaction(), type, VoiceGroup::I);
+  else
+    m_editBuffer.undoableConvertToSingle(scope->getTransaction(), VoiceGroup::I);
+
+  m_editBuffer.undoableInitSound(scope->getTransaction(), defaults);
+}

--- a/projects/epc/playground/src/use-cases/EditBufferUseCases.h
+++ b/projects/epc/playground/src/use-cases/EditBufferUseCases.h
@@ -35,6 +35,8 @@ class EditBufferUseCases
   void convertToSplit(VoiceGroup currentSelectedVoiceGroup);
   void convertToDual(SoundType type, VoiceGroup group);
 
+  void initSoundAs(SoundType type, Defaults defaults);
+
   void initSound(Defaults defaults);
   void initPart(VoiceGroup part, Defaults defaults);
 


### PR DESCRIPTION
added init-screen, can be opened via holding the default-button from sound and preset-layout, closes #3417