### PR TITLE
FX-Indicator Cross for non-active FX-Parts in Single-Sound

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.h
@@ -21,6 +21,7 @@ class VoiceGroupIndicator : public Control
   bool drawSingle(FrameBuffer& fb);
 
   bool isLayerPartMuted(VoiceGroup vg) const;
+  bool isSingleFXNotActive(VoiceGroup vg) const;
   bool shouldDraw();
 
   VoiceGroup m_selectedVoiceGroup {};
@@ -31,4 +32,6 @@ class VoiceGroupIndicator : public Control
   const Parameter* m_param = nullptr;
   const bool m_allowLoadToPart;
   const bool m_alwaysDraw;
+  void drawCrossForLayer(FrameBuffer& fb, int centerX, int centerY) const;
+  void drawCrossForSingle(FrameBuffer& fb, int centerX, int centerY) const;
 };


### PR DESCRIPTION
implemented cross for 'unused' or 'disabled' FX-Parts for Single-Sounds, closes #3465