### PR TITLE
Split Point Rounding - cleanup

### DIFF
--- a/projects/shared/nltools-2/include/SplitPointRounding.h
+++ b/projects/shared/nltools-2/include/SplitPointRounding.h
@@ -9,20 +9,19 @@ namespace SplitPointRounding
 
   static constexpr float range = (float) C15::ParameterList[C15::PID::Split_Split_Point].m_pg.m_coarse_cp;
 
-  static signed round(const float &_value)
+  inline signed round(const float &_value)
   {
     return (signed) std::ceil(range * _value);
   }
 
-  static float quantize(const float &_value, const unsigned &_steps)
+  inline float quantize(const float &_value, const unsigned &_steps)
   {
     if(_steps == 0)
       return _value;
-    const float normal = 1.0f / (float) _steps;
     return std::clamp(std::floor(_value * (float) (1 + _steps)) / (float) _steps, 0.0f, 1.0f);
   }
 
-  static float getModulation(const float &_mod, const float &_modAmount)
+  inline float getModulation(const float &_mod, const float &_modAmount)
   {
     return (float) _modAmount * quantize(_mod, round(std::abs(_modAmount)));
   }


### PR DESCRIPTION
https://github.com/nonlinear-labs-dev/C15/pull/3469#discussion_r1062593723
> nitpick: we could remove the static keyword from all functions inside this namespace

Merely removing the `static` keyword causes compilation errors, as the functions' symbols are redefined in test-cases. I made them `inline` instead.

I also found a redundant division which I removed, so this PR is in fact benefitial.