### PR TITLE
fixup SignalFlowIndication #3490

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
@@ -36,6 +36,9 @@ PanelUnitParameterEditMode::PanelUnitParameterEditMode()
 
   Application::get().getPresetManager()->getEditBuffer()->onPresetLoaded(
       sigc::mem_fun(this, &PanelUnitParameterEditMode::bruteForceUpdateLeds));
+
+  Application::get().getPresetManager()->getEditBuffer()->onChange(
+      sigc::mem_fun(this, &PanelUnitParameterEditMode::bruteForceUpdateLeds));
 }
 
 PanelUnitParameterEditMode::~PanelUnitParameterEditMode()

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
@@ -34,9 +34,6 @@ PanelUnitParameterEditMode::PanelUnitParameterEditMode()
   Application::get().getSettings()->getSetting<SignalFlowIndicationSetting>()->onChange(
       sigc::hide(sigc::mem_fun(this, &PanelUnitParameterEditMode::bruteForceUpdateLeds)));
 
-  Application::get().getPresetManager()->getEditBuffer()->onPresetLoaded(
-      sigc::mem_fun(this, &PanelUnitParameterEditMode::bruteForceUpdateLeds));
-
   Application::get().getPresetManager()->getEditBuffer()->onChange(
       sigc::mem_fun(this, &PanelUnitParameterEditMode::bruteForceUpdateLeds));
 }


### PR DESCRIPTION
connected bruteForceLED update of ParameterEditMode (SignalFlowIndication) to EditBuffer::onChange to update when a parameter is changed via for example: modulation, closes #3490