### PR TITLE
Issue 3310, reset HW-Source, which was changed from HWUI, before Storing a Preset

### DIFF
--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
@@ -188,7 +188,11 @@ void PhysicalControlParameter::onSelected()
 void PhysicalControlParameter::onUnselected()
 {
   Parameter::onUnselected();
+  resetChangedFromHWUIPosition();
+}
 
+void PhysicalControlParameter::resetChangedFromHWUIPosition()
+{
   if(m_lastChangedFromHWUI && getReturnMode() != ReturnMode::None)
   {
     m_lastChangedFromHWUI = false;

--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.h
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.h
@@ -57,6 +57,7 @@ class PhysicalControlParameter : public Parameter
   virtual void onLocalEnableChanged(bool b) = 0;
 
   MacroControlParameter* getMCAssignedToThisHW() const;
+  void resetChangedFromHWUIPosition();
 
  protected:
   void onValueChanged(Initiator initiator, tControlPositionValue oldValue, tControlPositionValue newValue) override;

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue3035/PresetRecallTests.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue3035/PresetRecallTests.cpp
@@ -49,7 +49,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Issue 3035, Loading Preset with
 
   WHEN("Bender is -1")
   {
-    benderUseCase.setControlPosition(-1.);
+    benderUseCase.changeFromAudioEngine(-1., HWChangeSource::TCD);
     TestHelper::doMainLoopIteration();
     CHECK(bender->getControlPositionValue() == -1);
     CHECK(mcA->getControlPositionValue() == 0);
@@ -58,7 +58,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Issue 3035, Loading Preset with
 
   WHEN("Bender is 1")
   {
-    benderUseCase.setControlPosition(1.);
+    benderUseCase.changeFromAudioEngine(1., HWChangeSource::TCD);
     TestHelper::doMainLoopIteration();
     CHECK(bender->getControlPositionValue() == 1);
     CHECK(mcA->getControlPositionValue() == 1);
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(TestHelper::ApplicationFixture,"Issue 3035, Loading Preset with
 
   WHEN("Bender is 1 and Held while saving")
   {
-    benderUseCase.setControlPosition(1.);
+    benderUseCase.changeFromAudioEngine(1., HWChangeSource::TCD);
     TestHelper::doMainLoopIteration();
 
     auto bank = pmUseCases.createBankAndStoreEditBuffer();

--- a/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
+++ b/projects/epc/playground/src/use-cases/EditBufferStorePreparation.cpp
@@ -7,6 +7,16 @@ EditBufferStorePreparation::EditBufferStorePreparation(EditBuffer& eb) : m_eb{eb
 {
   auto scope = UNDO::Scope::startTrashTransaction();
   auto transaction = scope->getTransaction();
+
+  using namespace C15::PID;
+  for(auto id: { Pedal_1, Pedal_2, Pedal_3, Pedal_4, Ribbon_1, Ribbon_2, Ribbon_3, Ribbon_4, Bender, Aftertouch })
+  {
+    if(auto hw_param = eb.findAndCastParameterByID<PhysicalControlParameter>({id, VoiceGroup::Global}))
+    {
+      hw_param->resetChangedFromHWUIPosition();
+    }
+  }
+
   m_eb.getAudioEngineProxy().freezeParameterMessages();
   m_eb.getAudioEngineProxy().freezePresetMessages();
   m_oldPositions = m_eb.setHWSourcesToDefaultValues(transaction);


### PR DESCRIPTION
The 'reset' of the HW-Source, which was changed via HWUI, happens only when a new Parameter is Selected. So storing a preset without first selecting MC or any other parameter can lead to a bug where the returning-hw-source is not reset before saving.

I introduced an explicit reset, of those from-hwui-changes, before the storing the preset. 

With that change i can no longer reproduce the issue @davidm2894 explained in the ticket

closes #3310 