### PR TITLE
fixup parametercarousel crash

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MiniParameter.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MiniParameter.cpp
@@ -5,11 +5,13 @@
 #include "MiniParameter.h"
 #include "parameters/Parameter.h"
 #include "MiniParameterLabel.h"
+#include "nltools/Assert.h"
 
 MiniParameter::MiniParameter(Parameter *param, const Rect &pos)
     : super(pos)
     , m_param(param)
 {
+  nltools_assertAlways(param != nullptr);
   m_label = addControl(new MiniParameterLabel(param, Rect(0, 0, 56, 9)));
 
   if(param->getID().getNumber() == ScaleGroup::getScaleBaseParameterNumber())

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.cpp
@@ -167,11 +167,14 @@ void ParameterCarousel::antiTurn()
   if(!handled)
   {
     auto idToSelect = lastParameterIDOfCarousel();
-    auto vg = Application::get().getVGManager()->getCurrentVoiceGroup();
-    if(ParameterId::isGlobal(idToSelect))
-      ebUseCases.selectParameter({ idToSelect, VoiceGroup::Global }, true);
-    else
-      ebUseCases.selectParameter({ idToSelect, vg }, true);
+    if(idToSelect.has_value())
+    {
+      auto vg = Application::get().getVGManager()->getCurrentVoiceGroup();
+      if(ParameterId::isGlobal(idToSelect.value()))
+        ebUseCases.selectParameter({ idToSelect.value(), VoiceGroup::Global }, true);
+      else
+        ebUseCases.selectParameter({ idToSelect.value(), vg }, true);
+    }
   }
 }
 
@@ -206,11 +209,14 @@ void ParameterCarousel::turn()
   if(!handled)
   {
     auto idToSelect = firstParameterIDOfCarousel();
-    auto vg = Application::get().getVGManager()->getCurrentVoiceGroup();
-    if(ParameterId::isGlobal(idToSelect))
-      ebUseCases.selectParameter({ idToSelect, VoiceGroup::Global }, true);
-    else
-      ebUseCases.selectParameter({ idToSelect, vg }, true);
+    if(idToSelect.has_value())
+    {
+      auto vg = Application::get().getVGManager()->getCurrentVoiceGroup();
+      if(ParameterId::isGlobal(idToSelect.value()))
+        ebUseCases.selectParameter({ idToSelect.value(), VoiceGroup::Global }, true);
+      else
+        ebUseCases.selectParameter({ idToSelect.value(), vg }, true);
+    }
   }
 }
 
@@ -284,13 +290,17 @@ void ParameterCarousel::setupChildControlsThatDontFit(Parameter* selectedParamet
   }
 }
 
-int ParameterCarousel::firstParameterIDOfCarousel() const
+std::optional<int> ParameterCarousel::firstParameterIDOfCarousel() const
 {
+  if(m_currentCarouselContentIDs.empty())
+    return std::nullopt;
   return m_currentCarouselContentIDs.front();
 }
 
-int ParameterCarousel::lastParameterIDOfCarousel() const
+std::optional<int> ParameterCarousel::lastParameterIDOfCarousel() const
 {
+  if(m_currentCarouselContentIDs.empty())
+    return std::nullopt;
   return m_currentCarouselContentIDs.back();
 }
 

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.h
@@ -4,6 +4,7 @@
 #include "Carousel.h"
 #include "MiniParameter.h"
 #include <nltools/Types.h>
+#include <optional>
 
 class Application;
 class Parameter;

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/ParameterCarousel.h
@@ -36,10 +36,9 @@ class ParameterCarousel : public Carousel
   void setupChildControlsThatFit(Parameter* selectedParameter, const std::list<int>& buttonAssignments);
   void setupChildControlsForParameterWithoutButtonMapping(Parameter *selectedParameter);
   void setupChildControlsThatDontFit(Parameter *selectedParameter, const std::list<int> &buttonAssignments);
-  int firstParameterIDOfCarousel() const;
 
-
-  int lastParameterIDOfCarousel() const;
+  std::optional<int> firstParameterIDOfCarousel() const;
+  std::optional<int> lastParameterIDOfCarousel() const;
 };
 
 


### PR DESCRIPTION
fixup parametercarousel to no longer crash on turn and antiTurn when no other parameters are in the carousel, closes #3495