### PR TITLE
prevent buffer underruns

### DIFF
--- a/projects/bbb/scripts/c15-unit-check.sh
+++ b/projects/bbb/scripts/c15-unit-check.sh
@@ -5,7 +5,7 @@ SSH_OPTIONS="-o LogLevel=quiet -o ServerAliveInterval=1 -o ConnectTimeout=1 -o S
 EPC_IP="192.168.10.10"
 LOG_FILE=""
 
-function executeAsRoot() {
+executeAsRoot() {
     if echo "sscl" | sshpass -p 'sscl' ssh ${SSH_OPTIONS} sscl@$EPC_IP "sudo -S /bin/bash -c '$2'" &> /dev/null; then
         echo "$1 Yes!" | tee -a $LOG_FILE
         return 0
@@ -15,47 +15,48 @@ function executeAsRoot() {
     return 1
 }
 
-function getInfoAsRoot() {
+getInfoAsRoot() {
     echo "sscl" | sshpass -p 'sscl' ssh ${SSH_OPTIONS} sscl@$EPC_IP "sudo -S /bin/bash -c '$1'"
 }
 
-function check_userland_exists() {
+check_userland_exists() {
     executeAsRoot \
         "Userland exists?" \
         "ls /usr/local/ | grep C15"
 }
 
-function check_soundcard_driver_param() {
+check_soundcard_driver_param() {
     executeAsRoot \
         "Soundcard driver parameter fix applied?" \
         "cat /etc/modprobe.d/snd_hda_intel.conf | grep 'snd_hda_intel bdl_pos_adj=1,1,1'"
+    printf "\n" | tee -a $LOG_FILE
 }
 
-function check_epc_network_exists() {
+check_epc_network_exists() {
     executeAsRoot \
         "EPC Accesspoint is configured?" \
         "test -e /etc/NetworkManager/system-connections/C15.nmconnection'"
 }
 
-function check_isolcpus() {
+check_isolcpus() {
     executeAsRoot \
         "EPC has isolated CPUS for realtime processes?" \
         "cat /proc/cmdline | grep isolcpus"
 }
 
-function check_mitigations() {
+check_mitigations() {
     executeAsRoot \
         "EPC has mitigations switched off?" \
         "cat /proc/cmdline | grep mitigations"
 }
 
-function check_overlay() {
+check_overlay() {
     executeAsRoot \
         "OverlayFS order is correct?" \
         "mount | grep overlay | grep /nloverlay/os-overlay:/lroot"
 }
 
-function check_usb_stick() {
+check_usb_stick() {
     while ! mount | grep /mnt/usb-stick > /dev/null; do
         echo "Please connect a USB stick to the BBB!"
         sleep 2
@@ -84,10 +85,10 @@ function check_usb_stick() {
    executeAsRoot \
         "Read from usb stick on EPC?" \
         "[ \"\$(cat /mnt/usb-stick/test-file)\" = '2' ]"
-
+    printf "\n" | tee -a $LOG_FILE
 }
 
-function check_BBB_AP() {
+check_BBB_AP() {
     if executeAsRoot "Is EPC1?" "cat /proc/cpuinfo | grep -e \"i3-5010\" -e \"i3-7100\""; then
         if iw wlan0 info | grep ssid | grep -v "_BBB" > /dev/null; then
             echo "BBB Accesspoint is active and is correctly missing the _BBB suffix? Yes!"
@@ -108,7 +109,7 @@ function check_BBB_AP() {
 
 }
 
-function check_EPC_AP() {
+check_EPC_AP() {
     if ! executeAsRoot "Is EPC1?" "cat /proc/cpuinfo | grep -e \"i3-5010\" -e \"i3-7100\""; then
         if executeAsRoot "Has Wifi device?" "ip a | grep wlan"; then
             if executeAsRoot "Is AP active on epc?" "nmcli con show --active | grep C15"; then
@@ -121,7 +122,7 @@ function check_EPC_AP() {
     fi
 }
 
-function check_iface_names() {
+check_iface_names() {
     executeAsRoot \
         "Ethernet device is named eth0?" \
         "ip a | grep eth0"
@@ -131,53 +132,49 @@ function check_iface_names() {
         "ip a | grep wlan0"
 }
 
-function check_ping_timeout() {
+check_ping_timeout() {
     executeAsRoot \
         "Ping timeout workaround is installed in initramfs?" \
         "mkdir -p /mnt/sda1; mount /dev/sda1 /mnt/sda1; zstdcat /mnt/sda1/initramfs-linux-rt.img | grep ping_bbb"
 }
 
-function check_date() {
+get_date() {
     printf "\nePC - date: $(getInfoAsRoot 'date "+%F %T"')\n" | tee -a $LOG_FILE \
         && printf "BBB - date: $(date "+%F %T")\n" | tee -a $LOG_FILE
-    printf "\n" | tee -a $LOG_FILE
 }
 
-function check_ro_mnts() {
-    printf "ePC - RO mounts:\n$(getInfoAsRoot 'mount | grep "(ro"')\n" | tee -a $LOG_FILE \
-        && printf "BBB - RO mounts:\n$(mount | grep "(ro")\n" | tee -a $LOG_FILE
-    printf "\n" | tee -a $LOG_FILE
+get_ro_mnts() {
+    printf "\nePC - RO mounts:\n$(getInfoAsRoot 'mount | grep "(ro"')\n" | tee -a $LOG_FILE \
+        && printf "\nBBB - RO mounts:\n$(mount | grep "(ro")\n" | tee -a $LOG_FILE
 }
 
-function get_journal_dmesg() {
-    rm /tmp/journal_epc.log /tmp/dmesg_epc.log /tmp/journal_bbb.log /tmp/dmesg_bbb.log
+get_journal_dmesg() {
+    rm /tmp/epc_journal.log /tmp/epc_dmesg.log /tmp/bbb_journal.log /tmp/bbb_dmesg.log > /dev/null
 
-    getInfoAsRoot 'journalctl -b -p "emerg".."warning"' >> /tmp/journal_epc.log \
-    && getInfoAsRoot 'dmesg --level=err,warn' >> /tmp/dmesg_epc.log \
-    && printf "Got journal and dmesg from ePC: Yes!\n" | tee -a $LOG_FILE \
-    || printf "Got journal and dmesg from ePC: No!\n" | tee -a $LOG_FILE
+    getInfoAsRoot 'journalctl -b -p "emerg".."warning"' >> /tmp/epc_journal.log \
+        && getInfoAsRoot 'dmesg --level=err,warn' >> /tmp/epc_dmesg.log \
+        && printf "\nGot journal and dmesg from ePC: Yes!\n" | tee -a $LOG_FILE \
+        || printf "\nGot journal and dmesg from ePC: No!\n" | tee -a $LOG_FILE
 
-    journalctl -b -p "emerg".."warning" >> /tmp/journal_bbb.log \
-    && dmesg --level=err,warn >> /tmp/dmesg_bbb.log \
-    && printf "Got journal and dmesg from BBB: Yes!\n" | tee -a $LOG_FILE \
-    || printf "Got journal and dmesg from BBB: No!\n" | tee -a $LOG_FILE
+    journalctl -b -p "emerg".."warning" >> /tmp/bbb_journal.log \
+        && dmesg --level=err,warn >> /tmp/bbb_dmesg.log \
+        && printf "Got journal and dmesg from BBB: Yes!\n" | tee -a $LOG_FILE \
+        || printf "Got journal and dmesg from BBB: No!\n" | tee -a $LOG_FILE
 
-    printf "\n" | tee -a $LOG_FILE
     return 0
 }
 
-function get_partition_info() {
-    printf "ePC - lsblk:\n$(getInfoAsRoot 'lsblk')\n" | tee -a $LOG_FILE \
-    && printf "ePC - mount:\n$(getInfoAsRoot 'mount | grep /dev/sda')\n" | tee -a $LOG_FILE
+get_partition_info() {
+    printf "\nePC - lsblk:\n$(getInfoAsRoot 'lsblk')\n" | tee -a $LOG_FILE \
+        && printf "\nePC - mount:\n$(getInfoAsRoot 'mount | grep /dev/sda')\n" | tee -a $LOG_FILE
 
-    printf "BBB - lsblk:\n$(lsblk)\n" | tee -a $LOG_FILE \
-    && printf "BBB - mount:\n$(mount | grep /dev/mmc)\n" | tee -a $LOG_FILE
-
-    printf "\n" | tee -a $LOG_FILE
+    printf "\nBBB - lsblk:\n$(lsblk)\n" | tee -a $LOG_FILE \
+        && printf "\nBBB - mount:\n$(mount | grep /dev/mmc)\n" | tee -a $LOG_FILE
     return 0
 }
 
-function check_persistent_files() {
+check_persistent_files() {
+    printf "\n" | tee -a $LOG_FILE
     executeAsRoot \
         "Calibration files?" \
         "ls /persistent/calibration/*.cal"
@@ -194,27 +191,24 @@ function check_persistent_files() {
     printf "\n" | tee -a $LOG_FILE
 }
 
-function check_alsa_settings() {
+check_alsa_settings() {
     executeAsRoot \
         "Alsamixer set to 100%?" \
         "amixer -D hw:PCH sget 'Master' | grep 100%"
     printf "\n" | tee -a $LOG_FILE
 }
 
-function get_network_settings_bbb() {
-    cat /etc/network/interfaces | tee -a $LOG_FILE \
-    && printf "\n" | tee -a $LOG_FILE \
-    && cat /etc/hostapd.conf | tee -a $LOG_FILE
-    printf "\n" | tee -a $LOG_FILE
+get_network_settings_bbb() {
+    cat /etc/network/interfaces | tee -a $LOG_FILE
+    cat /etc/hostapd.conf | tee -a $LOG_FILE
 }
 
-function get_update_script_vers() {
+get_update_script_vers() {
     VERS=$(cat /usr/C15/scripts/install-update.sh | grep version)
-    printf "Update script ${VERS} \n" | tee -a $LOG_FILE
-    printf "\n" | tee -a $LOG_FILE
+    printf "\nUpdate script ${VERS}\n\n" | tee -a $LOG_FILE
 }
 
-function check_for_present_tools() {
+check_for_present_tools() {
     for i in sshpass rsync socat thttpd playcontroller mke2fs; do
         if command -V "$i" &> /dev/null; then
             printf "$i installed: Yes\n" | tee -a $LOG_FILE
@@ -239,26 +233,28 @@ function check_for_present_tools() {
     return 0
 }
 
-function check_lpc() {
-    systemctl stop bbbb \
-    && lpc reset && printf "LPC reset: Yes\n" | tee -a $LOG_FILE \
-    || printf "LPC reset: No\n" | tee -a $LOG_FILE
+check_lpc() {
+    systemctl stop bbbb
+    lpc reset && printf "LPC reset: Yes\n" | tee -a $LOG_FILE \
+        || printf "LPC reset: No\n" | tee -a $LOG_FILE
 
     printf "LPC version: $(lpc req sw-version; lpc-read +q -h) \n" | tee -a $LOG_FILE \
-    || printf "Can not get LPC version!\n" | tee -a $LOG_FILE
+        || printf "Can not get LPC version!\n" | tee -a $LOG_FILE
 
-    printf "\n" | tee -a $LOG_FILE
+    printf "HW ID: $(lpc req uhid64; lpc-read +q -h) \n" | tee -a $LOG_FILE \
+        || printf "Can not get HW ID!\n" | tee -a $LOG_FILE
+
     systemctl restart bbbb
     return 0
 }
 
-function run_epc_stress_test() {
+run_epc_stress_test() {
 
     while ( ! getInfoAsRoot 'grep "/dev/sdb " /proc/mounts' ); do
         executeAsRoot "Created /tmp/usb?" "mkdir /tmp/usb"
         executeAsRoot "Unmounted USB Stick?" "umount /dev/sdb"
         executeAsRoot "Mounted USB Stick?" "mount /dev/sdb /tmp/usb" \
-        || read -p "Can not find USB stick! Try again!"
+            || read -p "Can not find USB stick! Try again!"
     done
 
     if ( ! getInfoAsRoot "[ -x /tmp/usb/Diagnosis_Tools/Benchmarks/Prime95_Linux_19/mprime ]" ); then
@@ -290,7 +286,7 @@ function run_epc_stress_test() {
     return 0
 }
 
-function check_buffer_underruns() {
+check_buffer_underruns() {
     TEST_DURATION=$1
     CHECK_FREQ=$2
 
@@ -305,14 +301,14 @@ function check_buffer_underruns() {
     for COUNTER in $(seq 0 $CHECK_FREQ $TEST_DURATION); do
         if ( $(getInfoAsRoot "journalctl -u audio-engine -S \"${DATE}\" | grep -q x-run") ); then
             printf "Bufferunderun detected! " | tee -a $LOG_FILE \
-            && getInfoAsRoot 'date "+%y-%m-%d %T"' | tee -a $LOG_FILE && return 1
+                && getInfoAsRoot 'date "+%y-%m-%d %T"' | tee -a $LOG_FILE && return 1
         fi
         sleep $CHECK_FREQ;
     done
     return 0
 }
 
-function usage() {
+usage() {
     echo "Runs a system check. I'd advise to select a singular option!"
     echo
     echo "Syntax: ./foo.sh [ -h ] [ -b DURATION,FACTOR ] [ -s DURATION,FACTOR] [ -g ]"
@@ -326,8 +322,8 @@ function usage() {
     echo
 }
 
-function general_check() {
-        printf "Will run general C15 check on ePC and BBB\n" | tee -a $LOG_FILE
+general_check() {
+        printf "Will run general C15 check on ePC and BBB\n\n" | tee -a $LOG_FILE
         check_userland_exists
         check_iface_names
         check_overlay
@@ -339,8 +335,8 @@ function general_check() {
         check_mitigations
         check_ping_timeout
 
-        check_date
-        check_ro_mnts
+        get_date
+        get_ro_mnts
         get_journal_dmesg
         get_partition_info
 
@@ -360,18 +356,18 @@ while getopts ":hgbs" option; do
             [ -z "${NUMARR[0]}" ] && DURATION=14400 || DURATION="${NUMARR[0]}"
             [ -z "${NUMARR[1]}" ] && FACTOR=60 || FACTOR="${NUMARR[1]}"
             LOG_FILE="/tmp/buffer_test.log"
-            rm $LOG_FILE; touch $LOG_FILE
+            rm $LOG_FILE > /dev/null; touch $LOG_FILE
             check_buffer_underruns ${DURATION} ${FACTOR};;
         s)
             set -f; OLDIFS=$IFS; IFS=','; NUMARR=($2); set +f; IFS=$OLDIFS;
             LOG_FILE="/tmp/stress_test.log"
-            rm $LOG_FILE; touch $LOG_FILE
+            rm $LOG_FILE > /dev/null; touch $LOG_FILE
             [ -z "${NUMARR[0]}" ] && DURATION=1200 || DURATION="${NUMARR[0]}"
             [ -z "${NUMARR[1]}" ] && FACTOR=60 || FACTOR="${NUMARR[1]}"
             run_epc_stress_test ${DURATION} ${FACTOR};;
         g)
             LOG_FILE="/tmp/general_check.log"
-            rm $LOG_FILE; touch $LOG_FILE
+            rm $LOG_FILE > /dev/null; touch $LOG_FILE
             general_check;;
         h | \?)
             usage

--- a/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
+++ b/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
@@ -79,6 +79,7 @@ void AlsaAudioOutput::open(const std::string& deviceName)
   nltools::Log::info("Alsa ringbuffer size:", ringBufferSize);
 
   m_numFramesPerPeriod = framesPerPeriod;
+  m_numPeriods = periods;
 
   m_writer = AudioWriterBase::create(m_handle, format, channels);
 }
@@ -100,30 +101,44 @@ void AlsaAudioOutput::stop()
 void AlsaAudioOutput::doBackgroundWork()
 {
   pthread_setname_np(pthread_self(), "AudioOut");
-  const auto framesPerCallback = m_numFramesPerPeriod;
+  const auto bufferSize = m_numFramesPerPeriod * m_numPeriods;
 
   snd_pcm_prepare(m_handle);
 
-  SampleFrame prefillAudio[framesPerCallback];
-  std::fill(prefillAudio, prefillAudio + framesPerCallback, SampleFrame {});
+  SampleFrame audio[bufferSize];
+  std::fill(audio, audio + bufferSize, SampleFrame {});
+  playback(audio, bufferSize);
 
   snd_pcm_start(m_handle);
-  playback(prefillAudio, framesPerCallback);
 
-  SampleFrame audio[framesPerCallback];
-  std::fill(audio, audio + framesPerCallback, SampleFrame {});
+  int numPollFDs = snd_pcm_poll_descriptors_count(m_handle);
+  pollfd pollFileDescriptors[numPollFDs];
+  numPollFDs = snd_pcm_poll_descriptors(m_handle, pollFileDescriptors, numPollFDs);
 
-  auto microsPerBuffer = std::micro::den * framesPerCallback / m_options->getSampleRate();
+  const auto recSR = 1.0 / m_options->getSampleRate();
 
   while(m_run)
   {
-    auto startDSP = g_get_monotonic_time();
-    m_cb(audio, framesPerCallback);
-    auto endDSP = g_get_monotonic_time();
-    playback(audio, framesPerCallback);
+    auto avail = snd_pcm_avail(m_handle);
 
-    auto diff = endDSP - startDSP;
-    reportPerformanceRatio(1.0 * diff / microsPerBuffer);
+    if(avail == 0)
+    {
+      poll(pollFileDescriptors, numPollFDs, 10);
+    }
+    else if(avail < 0)
+    {
+      handleWriteError(avail);
+    }
+    else
+    {
+      auto startDSP = g_get_monotonic_time();
+      m_cb(audio, avail);
+      auto endDSP = g_get_monotonic_time();
+      playback(audio, avail);
+      auto diff = endDSP - startDSP;
+
+      reportPerformanceRatio(1.0 * m_options->getSampleRate() * diff / (std::micro::den * avail));
+    }
   }
 }
 

--- a/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
+++ b/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.cpp
@@ -71,9 +71,7 @@ void AlsaAudioOutput::open(const std::string& deviceName)
   snd_pcm_uframes_t ringBufferSize = static_cast<snd_pcm_uframes_t>(m_options->getAlsaRingBufferSize());
   checkAlsa(snd_pcm_hw_params_set_buffer_size_near(m_handle, hwparams, &ringBufferSize));
   checkAlsa(snd_pcm_hw_params(m_handle, hwparams));
-  checkAlsa(snd_pcm_sw_params_current(m_handle, swparams));
-  checkAlsa(snd_pcm_sw_params(m_handle, swparams));
-
+  
   nltools::Log::info("Alsa periods:", periods);
   nltools::Log::info("Alsa frames per period:", framesPerPeriod);
   nltools::Log::info("Alsa ringbuffer size:", ringBufferSize);
@@ -123,7 +121,7 @@ void AlsaAudioOutput::doBackgroundWork()
 
     if(avail == 0)
     {
-      poll(pollFileDescriptors, numPollFDs, 10);
+      poll(pollFileDescriptors, numPollFDs, 1);
     }
     else if(avail < 0)
     {

--- a/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.h
+++ b/projects/epc/audio-engine/src/io/audio/AlsaAudioOutput.h
@@ -39,6 +39,7 @@ class AlsaAudioOutput : public AudioOutput
 
   snd_pcm_uframes_t m_framesProcessed = 0;
   snd_pcm_uframes_t m_numFramesPerPeriod = 0;
+  uint m_numPeriods = 0;
 
   std::unique_ptr<AudioWriterBase> m_writer;
   const AudioEngineOptions *m_options;

--- a/projects/epc/audio-engine/system/audio-engine.service.in
+++ b/projects/epc/audio-engine/system/audio-engine.service.in
@@ -13,12 +13,8 @@ ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/EMPHASE/id ]; do sleep 
 # WAIT FOR AUDIO DEVICE
 ExecStartPre=/usr/bin/bash -c "while [ ! -f /proc/asound/PCH/id ]; do sleep 0.1; done"
 
-# SETUP FRAME SIZE DEPENDENT ON CPU
-ExecStartPre=/usr/bin/bash -c "/usr/bin/systemctl set-environment FRAMES_PER_PERIOD=49"
-ExecStartPre=/usr/bin/bash -c "if cat /proc/cpuinfo | grep \"model name\" | grep \"5010\" > /dev/null; then /usr/bin/systemctl set-environment FRAMES_PER_PERIOD=64; fi"
-
 # START THE ENGINE
-ExecStart=@C15_INSTALL_PATH@/audio-engine/audio-engine -t hw:EMPHASE -a hw:PCH -n 3 -s ${FRAMES_PER_PERIOD} -r 48000 --playground-host=localhost --heartbeat=hw:EMPHASE
+ExecStart=@C15_INSTALL_PATH@/audio-engine/audio-engine -t hw:EMPHASE -a hw:PCH -n 8 -s 16 -r 48000 --playground-host=localhost --heartbeat=hw:EMPHASE
 
 Restart=on-failure
 RestartSec=1

--- a/projects/shared/version.h
+++ b/projects/shared/version.h
@@ -27,7 +27,7 @@
 //
 //  Final Versions         "YY-WW"   YY-WW : release date (tbd).
 //  Everything else        whatever seems appropriate
-#define C15_VERSION_STRING "23-03"
+#define C15_VERSION_STRING "23-04"
 #pragma message("make sure version string '" C15_VERSION_STRING "' is up-to date when building a release or beta")
 
 // do not change these two strings:

--- a/projects/shared/version.h
+++ b/projects/shared/version.h
@@ -27,7 +27,7 @@
 //
 //  Final Versions         "YY-WW"   YY-WW : release date (tbd).
 //  Everything else        whatever seems appropriate
-#define C15_VERSION_STRING "22-49"
+#define C15_VERSION_STRING "23-03"
 #pragma message("make sure version string '" C15_VERSION_STRING "' is up-to date when building a release or beta")
 
 // do not change these two strings:


### PR DESCRIPTION
when experimenting with different approaches of
using alsa, we found out that we can use a polling audio loop to drive 8 buffers of 16 frames without ever experiencing underruns on 5i3 and 11i3.