### PR TITLE
fix mc assignment shortcut for VG-II focus in Single-Sounds

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnit.cpp
@@ -58,8 +58,13 @@ PanelUnit::PanelUnit(Settings &settings, Oleds &oleds, LayoutFolderMonitor *mon)
         auto selParam = editBuffer->getSelected(Application::get().getVGManager()->getCurrentVoiceGroup());
         auto mc = MacroControlsGroup::paramIDToModSrc(selParam->getID());
 
+        //select other parameter as we could be on MacroControl but VG II focus, we only want to assign to non-monophonics in part II
         auto targetId = m_macroControlAssignmentStateMachine.getCurrentModulateableParameter();
         auto target = editBuffer->findParameterByID(targetId);
+        if(editBuffer->getType() == SoundType::Single && target && target->isPolyphonic())
+          targetId = ParameterId(targetId.getNumber(), VoiceGroup::I);
+
+        target = editBuffer->findParameterByID(targetId);
 
         if(auto modParam = dynamic_cast<ModulateableParameter *>(target))
         {


### PR DESCRIPTION
fix parameter assignment when mc is held down and some parameter button is pressed. In single sounds we tried to assign the mc to a parameter in VG-II even the monophonics, this lead to leds showing up but no assignment visisble. closes #3523