### PR TITLE
added/fixup single-sound compare

### DIFF
--- a/projects/epc/playground/src/presets/PresetDualParameterGroups.cpp
+++ b/projects/epc/playground/src/presets/PresetDualParameterGroups.cpp
@@ -146,10 +146,17 @@ void PresetDualParameterGroups::writeGroups(Writer &writer, const Preset *other,
 
   static std::vector<std::string> parameterGroupsThatAreTreatedAsGlobalForLayerSounds = { "Unison", "Mono" };
 
-  auto isParameterGroupPresentInVGII = [&](GroupId id) {
+  auto isParameterGroupPresentInVGII = [&](const GroupId& id) {
     auto &v = parameterGroupsThatAreTreatedAsGlobalForLayerSounds;
     auto it = std::find(v.begin(), v.end(), id.getName());
     return it != v.end();
+  };
+
+  auto isPolyphonicGroup = [](const GroupId& id)
+  {
+    if(auto group = Application::get().getPresetManager()->getEditBuffer()->getParameterGroupByID(id))
+      return group->isPolyphonic();
+    return false;
   };
 
   for(auto &g : m_parameterGroups[static_cast<size_t>(vgOfThis)])
@@ -157,7 +164,8 @@ void PresetDualParameterGroups::writeGroups(Writer &writer, const Preset *other,
     PresetParameterGroup *myGroup = nullptr;
     PresetParameterGroup *otherGroup = nullptr;
 
-    if(getType() == SoundType::Layer && isParameterGroupPresentInVGII(g.first))
+    if((getType() == SoundType::Layer && isParameterGroupPresentInVGII(g.first))
+       || (getType() == SoundType::Single && isPolyphonicGroup(g.first)))
     {
       myGroup = findParameterGroup({ g.first.getName(), VoiceGroup::I });
     }
@@ -166,7 +174,8 @@ void PresetDualParameterGroups::writeGroups(Writer &writer, const Preset *other,
       myGroup = g.second.get();
     }
 
-    if(other->getType() == SoundType::Layer && isParameterGroupPresentInVGII(g.first))
+    if((other->getType() == SoundType::Layer && isParameterGroupPresentInVGII(g.first))
+       || (other->getType() == SoundType::Single && isPolyphonicGroup(g.first)))
     {
       otherGroup = other->findParameterGroup({ g.first.getName(), VoiceGroup::I });
     }

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/CompareDialog.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/CompareDialog.java
@@ -497,14 +497,8 @@ public class CompareDialog extends GWTDialog {
 			refresh();
 		});
 
-		boolean aActive = (presetA != null && presetA.isDual()) || (presetA == null);
-		boolean bActive = (presetB != null && presetB.isDual()) || (presetB == null);
-		selectVGA.setVisible(aActive);
-		selectVGB.setVisible(bActive);
-		if(!aActive)
-			selectVGA.setHeight("0px");
-		if(!bActive)
-			selectVGB.setHeight("0px");
+		selectVGA.setVisible(true);
+		selectVGB.setVisible(true);
 	}
 
 	private boolean hideParameter(int id, SoundType type) {

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/CompareDialog.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/CompareDialog.java
@@ -23,7 +23,6 @@ import com.nonlinearlabs.client.ServerProxy.DownloadHandler;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.SoundType;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.VoiceGroup;
-import com.nonlinearlabs.client.presenters.EditBufferPresenterProvider;
 import com.nonlinearlabs.client.world.maps.parameters.PhysicalControlParameter.ReturnMode;
 import com.nonlinearlabs.client.world.maps.parameters.PlayControls.MacroControls.Macros.MacroControls;
 import com.nonlinearlabs.client.world.maps.presets.bank.preset.Preset;
@@ -475,17 +474,8 @@ public class CompareDialog extends GWTDialog {
 		selectVGA.addItem("Part I");
 		selectVGB.addItem("Part I");
 
-		SoundType ebType = EditBufferPresenterProvider.getPresenter().soundType;
-
-		if (presetA != null && presetA.getType() != SoundType.Single)
-			selectVGA.addItem("Part II");
-		if (presetA == null && ebType != SoundType.Single)
-			selectVGA.addItem("Part II");
-
-		if (presetB != null && presetB.getType() != SoundType.Single)
-			selectVGB.addItem("Part II");
-		if (presetB == null && ebType != SoundType.Single)
-			selectVGB.addItem("Part II");
+		selectVGA.addItem("Part II");
+		selectVGB.addItem("Part II");
 
 		if (selectVGA.getItemCount() > selA)
 			selectVGA.setSelectedIndex(selA);
@@ -507,8 +497,8 @@ public class CompareDialog extends GWTDialog {
 			refresh();
 		});
 
-		boolean aActive = (presetA != null && presetA.isDual()) || (presetA == null && ebType != SoundType.Single);
-		boolean bActive = (presetB != null && presetB.isDual()) || (presetB == null && ebType != SoundType.Single);
+		boolean aActive = (presetA != null && presetA.isDual()) || (presetA == null);
+		boolean bActive = (presetB != null && presetB.isDual()) || (presetB == null);
 		selectVGA.setVisible(aActive);
 		selectVGB.setVisible(bActive);
 		if(!aActive)


### PR DESCRIPTION
poly-parametergroups will always show part I for single-presets and single-edibuffers, even when part-II is selected in the dropdown, which will now always be displayed, the monophonic parameters are displayed for each part individually, closes #3516