### PR TITLE
Boled: fix animation for sound-edit convert and copy-fx entries

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.cpp
@@ -44,6 +44,25 @@ sigc::connection ConditionRegistry::onChange(const std::function<void()>& cb)
 
 void ConditionRegistry::onConditionChanged()
 {
-  if(Application::get().getSettings()->getSetting<LayoutMode>()->get() != LayoutVersionMode::Old)
-    m_signal.deferedSend();
+  if(!isLocked())
+    if(Application::get().getSettings()->getSetting<LayoutMode>()->get() != LayoutVersionMode::Old)
+      m_signal.deferedSend();
+}
+
+bool ConditionRegistry::isLocked()
+{
+  return locks > 0;
+}
+
+void ConditionRegistry::lock()
+{
+  locks++;
+}
+
+void ConditionRegistry::unlock()
+{
+  locks--;
+  if(locks == 0) {
+    onConditionChanged();
+  }
 }

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.h
@@ -12,11 +12,15 @@ class ConditionRegistry : public sigc::trackable
   tCondition getCondition(const std::string& key);
   static ConditionRegistry& get();
   sigc::connection onChange(const std::function<void()>& cb);
+  void lock();
+  void unlock();
 
  private:
   ConditionRegistry();
   void onConditionChanged();
+  bool isLocked();
 
+  int locks = 0;
   Signal<void> m_signal;
   std::map<std::string, std::unique_ptr<ConditionBase>> m_theConditionMap;
 

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
@@ -6,9 +6,12 @@
 #include <proxies/hwui/controls/Label.h>
 #include <proxies/hwui/Oleds.h>
 
-Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb)
-    : m_animationCB(pcb)
-    , m_animationFinishedCB(fcb)
+#include <utility>
+
+Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb, CatchAllCB cacb)
+    : m_animationCB(std::move(pcb))
+    , m_animationFinishedCB(std::move(fcb))
+    , m_animationCatchAllCB(std::move(cacb))
     , m_animationLength(length)
 {
   m_signal = Application::get().getMainContext()->signal_idle().connect(sigc::mem_fun(this, &Animator::doAnimation));
@@ -16,6 +19,7 @@ Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB 
 
 Animator::~Animator()
 {
+  m_animationCatchAllCB();
   m_signal.disconnect();
 }
 
@@ -59,6 +63,9 @@ void AnimatedGenericItem::startAnimation()
 
           if(m_finish.cb.has_value())
             m_finish.cb.value()();
+        }, [this](){
+          if(m_finally.cb.has_value())
+            m_finally.cb.value()();
         });
 }
 

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
@@ -10,8 +10,9 @@ class Animator
  public:
   using ProgressCB = std::function<void()>;
   using FinishedCB = std::function<void()>;
+  using CatchAllCB = std::function<void()>;
 
-  Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb);
+  Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb, CatchAllCB cacb);
   virtual ~Animator();
   [[nodiscard]] float getAnimationPosition() const;
 
@@ -22,6 +23,7 @@ class Animator
   sigc::connection m_signal;
   ProgressCB m_animationCB;
   FinishedCB m_animationFinishedCB;
+  CatchAllCB m_animationCatchAllCB;
 
   std::chrono::steady_clock::time_point m_animationStartedAt = std::chrono::steady_clock::now();
   std::chrono::milliseconds m_animationLength { 500 };
@@ -31,11 +33,12 @@ class AnimatedGenericItem : public GenericItem
 {
  public:
   template <class tCap>
-  AnimatedGenericItem(tCap caption, const Rect &r, OneShotTypes::StartCB start, OneShotTypes::FinishCB finish)
+  AnimatedGenericItem(tCap caption, const Rect &r, OneShotTypes::StartCB start, OneShotTypes::FinishCB finish, OneShotTypes::CatchAllCB finally = OneShotTypes::CatchAllCB())
       : GenericItem(caption, r, [] {})
   {
-    m_start = start;
-    m_finish = finish;
+    m_start = std::move(start);
+    m_finish = std::move(finish);
+    m_finally = std::move(finally);
   }
 
   void startAnimation();
@@ -48,4 +51,5 @@ class AnimatedGenericItem : public GenericItem
   std::unique_ptr<Animator> m_animator;
   OneShotTypes::StartCB m_start;
   OneShotTypes::FinishCB m_finish;
+  OneShotTypes::CatchAllCB m_finally;
 };

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
@@ -10,10 +10,13 @@
 #include "use-cases/EditBufferUseCases.h"
 #include "proxies/hwui/descriptive-layouts/ConditionRegistry.h"
 
-namespace {
-  std::string getSuffix(SoundType convertTo) {
+namespace
+{
+  std::string getSuffix(SoundType convertTo)
+  {
     auto currentType = Application::get().getPresetManager()->getEditBuffer()->getType();
-    if((currentType != SoundType::Single && convertTo == SoundType::Single) || (currentType == SoundType::Single && convertTo != SoundType::Single))
+    if((currentType != SoundType::Single && convertTo == SoundType::Single)
+       || (currentType == SoundType::Single && convertTo != SoundType::Single))
       return " (both FX)";
     else
       return "";
@@ -60,13 +63,13 @@ ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toTyp
 {
 }
 
-
 ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, SoundType convertTo)
 
     : AnimatedGenericItem(nltools::string::concat("Convert to ", toString(convertTo), " (FX I only)"), rect,
                           OneShotTypes::StartCB(
                               [=]
                               {
+                                ConditionRegistry::get().lock();
                                 EditBufferUseCases useCases(*Application::get().getPresetManager()->getEditBuffer());
 
                                 switch(convertTo)
@@ -84,11 +87,13 @@ ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, Sou
                                   default:
                                     break;
                                 }
-
+                              }),
+                          OneShotTypes::FinishCB(
+                              []()
+                              {
+                                ConditionRegistry::get().unlock();
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                              }),
-                          OneShotTypes::FinishCB([]() {}))
+                              }))
 {
 }
-

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
@@ -58,8 +58,8 @@ ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toTyp
                               {
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                                ConditionRegistry::get().unlock();
-                              }))
+                              }),
+                          OneShotTypes::CatchAllCB { [] { ConditionRegistry::get().unlock(); } })
 {
 }
 
@@ -89,11 +89,11 @@ ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, Sou
                                 }
                               }),
                           OneShotTypes::FinishCB(
-                              []()
+                              []
                               {
-                                ConditionRegistry::get().unlock();
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                              }))
+                              }),
+                          OneShotTypes::CatchAllCB { [] { ConditionRegistry::get().unlock(); } })
 {
 }

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/CopyFX.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/CopyFX.h
@@ -1,26 +1,33 @@
 #pragma once
-#include "proxies/hwui/descriptive-layouts/concrete/menu/menu-items/GenericItem.h"
 #include "nltools/Types.h"
 #include "use-cases/SettingsUseCases.h"
+#include "proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h"
 #include <use-cases/EditBufferUseCases.h>
 #include <Application.h>
 #include <presets/PresetManager.h>
 #include <presets/EditBuffer.h>
 
-
-template<VoiceGroup from, VoiceGroup to>
-class CopyFX : public GenericItem
+template <VoiceGroup from, VoiceGroup to> class CopyFX : public AnimatedGenericItem
 {
  public:
   explicit CopyFX(Rect fullWidth);
 };
 
-template <VoiceGroup from, VoiceGroup to> CopyFX<from, to>::CopyFX(Rect fullWidth) : GenericItem(nltools::string::concat("Copy FX ", toString(from), " to ", toString(to)), fullWidth, [](){
-      auto eb = Application::get().getPresetManager()->getEditBuffer();
-      EditBufferUseCases ebUseCases(*eb);
-      ebUseCases.copyFX(from, to);
-      SettingsUseCases sUseCases(eb->getSettings());
-      sUseCases.setFocusAndMode({UIFocus::Sound, UIMode::Select, UIDetail::Init});
-    })
+template <VoiceGroup from, VoiceGroup to>
+CopyFX<from, to>::CopyFX(Rect fullWidth)
+    : AnimatedGenericItem(
+        nltools::string::concat("Copy FX ", toString(from), " to ", toString(to)), fullWidth,
+        OneShotTypes::StartCB{[]()
+        {
+          auto eb = Application::get().getPresetManager()->getEditBuffer();
+          EditBufferUseCases ebUseCases(*eb);
+          ebUseCases.copyFX(from, to);
+        }},
+        OneShotTypes::FinishCB{[]()
+        {
+          auto eb = Application::get().getPresetManager()->getEditBuffer();
+          SettingsUseCases sUseCases(eb->getSettings());
+          sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
+        }})
 {
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/OneShotEntryTypes.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/setup/OneShotEntryTypes.h
@@ -28,4 +28,16 @@ namespace OneShotTypes
     }
     std::optional<CB> cb;
   };
+
+  struct CatchAllCB
+  {
+    CatchAllCB() {
+      cb = std::nullopt;
+    }
+
+    CatchAllCB(const CB& c) {
+      cb = c;
+    }
+    std::optional<CB> cb;
+  };
 }


### PR DESCRIPTION
fixup all current animated sound-edit-menu items to show the animation before closing/changing the screen, added return symbol at the end of the lines of copy FX I/II items, closes #3544