### PR TITLE
WebUI: don't ask for which FX to load-to-part from single if one FX is unused

### DIFF
--- a/projects/epc/playground/src/parameters/presenter-rules/ParameterPresenterRules.cpp
+++ b/projects/epc/playground/src/parameters/presenter-rules/ParameterPresenterRules.cpp
@@ -1,0 +1,109 @@
+#include "ParameterPresenterRules.h"
+#include "parameter_declarations.h"
+#include "nltools/Types.h"
+#include <presets/Preset.h>
+#include <presets/PresetParameter.h>
+#include <presets/EditBuffer.h>
+#include <parameters/Parameter.h>
+
+bool ParameterPresenterRules::isPresetFXUnused_I(Preset *p)
+{
+  auto out_mix_lvl = p->findParameterByID({ C15::PID::Out_Mix_Lvl, VoiceGroup::I }, true)->getValue();
+  auto out_mix_to_fx = p->findParameterByID({ C15::PID::Out_Mix_To_FX, VoiceGroup::I }, true)->getValue();
+
+  auto master_serial_fx = p->findParameterByID({ C15::PID::Master_Serial_FX, VoiceGroup::Global }, true)->getValue();
+  auto master_fx_mix = p->findParameterByID({ C15::PID::Master_FX_Mix, VoiceGroup::Global }, true)->getValue();
+
+  auto fb_mix_lvl = p->findParameterByID({ C15::PID::FB_Mix_Lvl, VoiceGroup::I }, true)->getValue();
+  auto fb_mix_fx = p->findParameterByID({ C15::PID::FB_Mix_FX, VoiceGroup::I }, true)->getValue();
+  auto fb_mix_fx_src = p->findParameterByID({ C15::PID::FB_Mix_FX_Src, VoiceGroup::I }, true)->getValue();
+
+  auto osc_a_pm_fb = p->findParameterByID({ C15::PID::Osc_A_PM_FB, VoiceGroup::I }, true)->getValue();
+  auto shp_a_fb_mix = p->findParameterByID({ C15::PID::Shp_A_FB_Mix, VoiceGroup::I }, true)->getValue();
+  auto osc_b_pm_fb = p->findParameterByID({ C15::PID::Osc_B_PM_FB, VoiceGroup::I }, true)->getValue();
+  auto shp_b_fb_mix = p->findParameterByID({ C15::PID::Shp_B_FB_Mix, VoiceGroup::I }, true)->getValue();
+
+  const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx < 1;
+  const auto fx_input = out_mix || master_serial_fx < 0;
+  const auto fx_output = master_fx_mix < 1 || master_serial_fx > 0;
+  const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src < 1
+                           && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
+  const auto fx_used = fx_input && (fx_output || fx_feedback);
+  return !fx_used;
+}
+
+bool ParameterPresenterRules::isPresetFXUnused_II(Preset *p)
+{
+  auto out_mix_lvl = p->findParameterByID({ C15::PID::Out_Mix_Lvl, VoiceGroup::I }, true)->getValue();
+  auto out_mix_to_fx = p->findParameterByID({ C15::PID::Out_Mix_To_FX, VoiceGroup::I }, true)->getValue();
+
+  auto master_serial_fx = p->findParameterByID({ C15::PID::Master_Serial_FX, VoiceGroup::Global }, true)->getValue();
+  auto master_fx_mix = p->findParameterByID({ C15::PID::Master_FX_Mix, VoiceGroup::Global }, true)->getValue();
+
+  auto fb_mix_lvl = p->findParameterByID({ C15::PID::FB_Mix_Lvl, VoiceGroup::I }, true)->getValue();
+  auto fb_mix_fx = p->findParameterByID({ C15::PID::FB_Mix_FX, VoiceGroup::I }, true)->getValue();
+  auto fb_mix_fx_src = p->findParameterByID({ C15::PID::FB_Mix_FX_Src, VoiceGroup::I }, true)->getValue();
+
+  auto osc_a_pm_fb = p->findParameterByID({ C15::PID::Osc_A_PM_FB, VoiceGroup::I }, true)->getValue();
+  auto shp_a_fb_mix = p->findParameterByID({ C15::PID::Shp_A_FB_Mix, VoiceGroup::I }, true)->getValue();
+  auto osc_b_pm_fb = p->findParameterByID({ C15::PID::Osc_B_PM_FB, VoiceGroup::I }, true)->getValue();
+  auto shp_b_fb_mix = p->findParameterByID({ C15::PID::Shp_B_FB_Mix, VoiceGroup::I }, true)->getValue();
+
+  const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx > 0;
+  const auto fx_input = out_mix || master_serial_fx > 0;
+  const auto fx_output = master_fx_mix > 0 || master_serial_fx < 0;
+  const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src > 0
+                           && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
+  const auto fx_used = fx_input && (fx_output || fx_feedback);
+  return !fx_used;
+}
+
+bool ParameterPresenterRules::isSingleFXIUnused(EditBuffer &eb)
+{
+  auto out_mix_lvl = eb.findParameterByID({C15::PID::Out_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
+  auto out_mix_to_fx = eb.findParameterByID({C15::PID::Out_Mix_To_FX, VoiceGroup::I})->getControlPositionValue();
+
+  auto master_serial_fx = eb.findParameterByID({C15::PID::Master_Serial_FX, VoiceGroup::Global})->getControlPositionValue();
+  auto master_fx_mix = eb.findParameterByID({C15::PID::Master_FX_Mix, VoiceGroup::Global})->getControlPositionValue();
+
+  auto fb_mix_lvl = eb.findParameterByID({C15::PID::FB_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
+  auto fb_mix_fx = eb.findParameterByID({C15::PID::FB_Mix_FX, VoiceGroup::I})->getControlPositionValue();
+  auto fb_mix_fx_src = eb.findParameterByID({C15::PID::FB_Mix_FX_Src, VoiceGroup::I})->getControlPositionValue();
+
+  auto osc_a_pm_fb = eb.findParameterByID({C15::PID::Osc_A_PM_FB, VoiceGroup::I})->getControlPositionValue();
+  auto shp_a_fb_mix = eb.findParameterByID({C15::PID::Shp_A_FB_Mix, VoiceGroup::I})->getControlPositionValue();
+  auto osc_b_pm_fb = eb.findParameterByID({C15::PID::Osc_B_PM_FB, VoiceGroup::I})->getControlPositionValue();
+  auto shp_b_fb_mix = eb.findParameterByID({C15::PID::Shp_B_FB_Mix, VoiceGroup::I})->getControlPositionValue();
+
+  const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx < 1;
+  const auto fx_input = out_mix || master_serial_fx < 0;
+  const auto fx_output = master_fx_mix < 1 || master_serial_fx > 0;
+  const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src < 1 && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
+  const auto fx_used = fx_input && (fx_output || fx_feedback);
+  return !fx_used;
+}
+
+bool ParameterPresenterRules::isSingleFXIIUnused(EditBuffer &eb)
+{
+  auto out_mix_lvl = eb.findParameterByID({C15::PID::Out_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
+  auto out_mix_to_fx = eb.findParameterByID({C15::PID::Out_Mix_To_FX, VoiceGroup::I})->getControlPositionValue();
+
+  auto master_serial_fx = eb.findParameterByID({C15::PID::Master_Serial_FX, VoiceGroup::Global})->getControlPositionValue();
+  auto master_fx_mix = eb.findParameterByID({C15::PID::Master_FX_Mix, VoiceGroup::Global})->getControlPositionValue();
+
+  auto fb_mix_lvl = eb.findParameterByID({C15::PID::FB_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
+  auto fb_mix_fx = eb.findParameterByID({C15::PID::FB_Mix_FX, VoiceGroup::I})->getControlPositionValue();
+  auto fb_mix_fx_src = eb.findParameterByID({C15::PID::FB_Mix_FX_Src, VoiceGroup::I})->getControlPositionValue();
+
+  auto osc_a_pm_fb = eb.findParameterByID({C15::PID::Osc_A_PM_FB, VoiceGroup::I})->getControlPositionValue();
+  auto shp_a_fb_mix = eb.findParameterByID({C15::PID::Shp_A_FB_Mix, VoiceGroup::I})->getControlPositionValue();
+  auto osc_b_pm_fb = eb.findParameterByID({C15::PID::Osc_B_PM_FB, VoiceGroup::I})->getControlPositionValue();
+  auto shp_b_fb_mix = eb.findParameterByID({C15::PID::Shp_B_FB_Mix, VoiceGroup::I})->getControlPositionValue();
+
+  const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx > 0;
+  const auto fx_input = out_mix || master_serial_fx > 0;
+  const auto fx_output = master_fx_mix > 0 || master_serial_fx < 0;
+  const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src > 0 && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
+  const auto fx_used = fx_input && (fx_output || fx_feedback);
+  return !fx_used;
+}

--- a/projects/epc/playground/src/parameters/presenter-rules/ParameterPresenterRules.h
+++ b/projects/epc/playground/src/parameters/presenter-rules/ParameterPresenterRules.h
@@ -1,0 +1,14 @@
+#pragma once
+
+class Preset;
+class EditBuffer;
+
+class ParameterPresenterRules
+{
+ public:
+  static bool isPresetFXUnused_I(Preset* p);
+  static bool isPresetFXUnused_II(Preset* p);
+
+  static bool isSingleFXIUnused(EditBuffer& eb);
+  static bool isSingleFXIIUnused(EditBuffer& eb);
+};

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/VoiceGroupIndicator.cpp
@@ -3,6 +3,7 @@
 #include <presets/EditBuffer.h>
 #include <proxies/hwui/HWUI.h>
 #include "VoiceGroupIndicator.h"
+#include "parameters/presenter-rules/ParameterPresenterRules.h"
 #include <proxies/hwui/FrameBuffer.h>
 #include <proxies/hwui/controls/SwitchVoiceGroupButton.h>
 #include <groups/MacroControlsGroup.h>
@@ -272,61 +273,8 @@ VoiceGroup VoiceGroupIndicator::getCurrentDisplayedVoiceGroup() const
   return m_selectedVoiceGroup;
 }
 
-namespace {
-
-  bool isSingleFXIUnused(EditBuffer& eb)
-  {
-    auto out_mix_lvl = eb.findParameterByID({C15::PID::Out_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
-    auto out_mix_to_fx = eb.findParameterByID({C15::PID::Out_Mix_To_FX, VoiceGroup::I})->getControlPositionValue();
-
-    auto master_serial_fx = eb.findParameterByID({C15::PID::Master_Serial_FX, VoiceGroup::Global})->getControlPositionValue();
-    auto master_fx_mix = eb.findParameterByID({C15::PID::Master_FX_Mix, VoiceGroup::Global})->getControlPositionValue();
-
-    auto fb_mix_lvl = eb.findParameterByID({C15::PID::FB_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
-    auto fb_mix_fx = eb.findParameterByID({C15::PID::FB_Mix_FX, VoiceGroup::I})->getControlPositionValue();
-    auto fb_mix_fx_src = eb.findParameterByID({C15::PID::FB_Mix_FX_Src, VoiceGroup::I})->getControlPositionValue();
-
-    auto osc_a_pm_fb = eb.findParameterByID({C15::PID::Osc_A_PM_FB, VoiceGroup::I})->getControlPositionValue();
-    auto shp_a_fb_mix = eb.findParameterByID({C15::PID::Shp_A_FB_Mix, VoiceGroup::I})->getControlPositionValue();
-    auto osc_b_pm_fb = eb.findParameterByID({C15::PID::Osc_B_PM_FB, VoiceGroup::I})->getControlPositionValue();
-    auto shp_b_fb_mix = eb.findParameterByID({C15::PID::Shp_B_FB_Mix, VoiceGroup::I})->getControlPositionValue();
-
-    const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx < 1;
-    const auto fx_input = out_mix || master_serial_fx < 0;
-    const auto fx_output = master_fx_mix < 1 || master_serial_fx > 0;
-    const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src < 1 && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
-    const auto fx_used = fx_input && (fx_output || fx_feedback);
-    return !fx_used;
-  }
-
-  bool isSingleFXIIUnused(EditBuffer& eb)
-  {
-    auto out_mix_lvl = eb.findParameterByID({C15::PID::Out_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
-    auto out_mix_to_fx = eb.findParameterByID({C15::PID::Out_Mix_To_FX, VoiceGroup::I})->getControlPositionValue();
-
-    auto master_serial_fx = eb.findParameterByID({C15::PID::Master_Serial_FX, VoiceGroup::Global})->getControlPositionValue();
-    auto master_fx_mix = eb.findParameterByID({C15::PID::Master_FX_Mix, VoiceGroup::Global})->getControlPositionValue();
-
-    auto fb_mix_lvl = eb.findParameterByID({C15::PID::FB_Mix_Lvl, VoiceGroup::I})->getControlPositionValue();
-    auto fb_mix_fx = eb.findParameterByID({C15::PID::FB_Mix_FX, VoiceGroup::I})->getControlPositionValue();
-    auto fb_mix_fx_src = eb.findParameterByID({C15::PID::FB_Mix_FX_Src, VoiceGroup::I})->getControlPositionValue();
-
-    auto osc_a_pm_fb = eb.findParameterByID({C15::PID::Osc_A_PM_FB, VoiceGroup::I})->getControlPositionValue();
-    auto shp_a_fb_mix = eb.findParameterByID({C15::PID::Shp_A_FB_Mix, VoiceGroup::I})->getControlPositionValue();
-    auto osc_b_pm_fb = eb.findParameterByID({C15::PID::Osc_B_PM_FB, VoiceGroup::I})->getControlPositionValue();
-    auto shp_b_fb_mix = eb.findParameterByID({C15::PID::Shp_B_FB_Mix, VoiceGroup::I})->getControlPositionValue();
-
-    const auto out_mix = out_mix_lvl > 0 && out_mix_to_fx > 0;
-    const auto fx_input = out_mix || master_serial_fx > 0;
-    const auto fx_output = master_fx_mix > 0 || master_serial_fx < 0;
-    const auto fx_feedback = fb_mix_lvl > 0 && fb_mix_fx != 0 && fb_mix_fx_src > 0 && (osc_a_pm_fb != 0 || shp_a_fb_mix != 0 || osc_b_pm_fb != 0 || shp_b_fb_mix != 0);
-    const auto fx_used = fx_input && (fx_output || fx_feedback);
-    return !fx_used;
-  }
-}
-
 bool VoiceGroupIndicator::isSingleFXNotActive(VoiceGroup vg) const
 {
   auto& eb = *Application::get().getPresetManager()->getEditBuffer();
-  return vg == VoiceGroup::I ? isSingleFXIUnused(eb) : isSingleFXIIUnused(eb);
+  return vg == VoiceGroup::I ? ParameterPresenterRules::isSingleFXIUnused(eb) : ParameterPresenterRules::isSingleFXIIUnused(eb);
 }

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/ServerProxy.java
@@ -1324,4 +1324,18 @@ public class ServerProxy {
 					}
 				});
 	}
+
+	public void getVoiceGroupsWhereFXIsUnused(Preset p, Consumer<String> cb) {
+		downloadFile("/presets/isFXUnused?uuid=" + URL.encodeQueryString(p.getUUID()),
+		new DownloadHandler() {
+			@Override
+			public void onFileDownloaded(String text) {
+				cb.accept(text);
+			}
+
+			@Override
+			public void onError() {
+			}
+		});
+	}
 }

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/LayerSoundLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/LayerSoundLayout.java
@@ -161,7 +161,20 @@ public class LayerSoundLayout extends SoundLayout {
 			if (dragProxy.getOrigin() instanceof IPreset)
 				if (dragProxy.getOrigin() instanceof Preset) {
 					Preset p = (Preset) dragProxy.getOrigin();
-					choosePresetPart = new ChoosePresetPartDialog(p, group);
+					if(!p.isDual()) {
+						NonMaps.get().getServerProxy().getVoiceGroupsWhereFXIsUnused(p, unused_vg_string -> {
+							if(unused_vg_string == "II") {
+								EditBufferUseCases.get().loadPresetPartIntoPart(p.getUUID(), VoiceGroup.I, group);
+							} else if(unused_vg_string == "I") {
+								EditBufferUseCases.get().loadPresetPartIntoPart(p.getUUID(), VoiceGroup.II, group);
+							} else {
+								choosePresetPart = new ChoosePresetPartDialog(p, group);
+							}
+						});
+					}
+					else {
+						choosePresetPart = new ChoosePresetPartDialog(p, group);
+					}
 				}
 
 			setIsDropTarget(false);

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SplitSoundLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SplitSoundLayout.java
@@ -4,6 +4,7 @@ import com.google.gwt.canvas.dom.client.Context2d;
 import com.nonlinearlabs.client.Millimeter;
 import com.nonlinearlabs.client.NonMaps;
 import com.nonlinearlabs.client.Renameable;
+import com.nonlinearlabs.client.ServerProxy;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel;
 import com.nonlinearlabs.client.dataModel.editBuffer.EditBufferModel.VoiceGroup;
 import com.nonlinearlabs.client.dataModel.editBuffer.ParameterId;
@@ -432,7 +433,20 @@ public class SplitSoundLayout extends SoundLayout {
 			if (dragProxy.getOrigin() instanceof IPreset)
 				if (dragProxy.getOrigin() instanceof Preset) {
 					Preset p = (Preset) dragProxy.getOrigin();
-					choosePresetPart = new ChoosePresetPartDialog(p, group);
+					if(!p.isDual()) {
+						NonMaps.get().getServerProxy().getVoiceGroupsWhereFXIsUnused(p, unused_vg_string -> {
+							if(unused_vg_string == "II") {
+								EditBufferUseCases.get().loadPresetPartIntoPart(p.getUUID(), VoiceGroup.I, group);
+							} else if(unused_vg_string == "I") {
+								EditBufferUseCases.get().loadPresetPartIntoPart(p.getUUID(), VoiceGroup.II, group);
+							} else {
+								choosePresetPart = new ChoosePresetPartDialog(p, group);
+							}
+						});
+					}
+					else {
+						choosePresetPart = new ChoosePresetPartDialog(p, group);
+					}
 				}
 
 			setIsDropTarget(false);


### PR DESCRIPTION
added check for unused fx in single-preset that will be loaded-to-part, if either FX is unused we dont open the dialog to ask which FX to load but load the used FX. Moved rules into new ParameterPresenter class to have all rules in one place, closes #3564