### PR TITLE
fix crash

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.cpp
@@ -66,3 +66,8 @@ void ConditionRegistry::unlock()
     onConditionChanged();
   }
 }
+
+std::unique_ptr<ConditionRegistry::ConditionRegistryScopedLock> ConditionRegistry::createLock()
+{
+  return std::make_unique<ConditionRegistryScopedLock>();
+}

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/ConditionRegistry.h
@@ -8,14 +8,26 @@
 class ConditionRegistry : public sigc::trackable
 {
  public:
+  class ConditionRegistryScopedLock {
+   public:
+    ConditionRegistryScopedLock() {
+      ConditionRegistry::get().lock();
+    }
+    ~ConditionRegistryScopedLock() {
+      ConditionRegistry::get().unlock();
+    }
+  };
+
   typedef ConditionBase* tCondition;
   tCondition getCondition(const std::string& key);
   static ConditionRegistry& get();
   sigc::connection onChange(const std::function<void()>& cb);
+  static std::unique_ptr<ConditionRegistryScopedLock> createLock();
+
+ private:
   void lock();
   void unlock();
 
- private:
   ConditionRegistry();
   void onConditionChanged();
   bool isLocked();
@@ -25,4 +37,5 @@ class ConditionRegistry : public sigc::trackable
   std::map<std::string, std::unique_ptr<ConditionBase>> m_theConditionMap;
 
   friend class ConditionBase;
+  friend class ConditionRegistryScopedLock;
 };

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.cpp
@@ -8,10 +8,9 @@
 
 #include <utility>
 
-Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb, CatchAllCB cacb)
+Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb)
     : m_animationCB(std::move(pcb))
     , m_animationFinishedCB(std::move(fcb))
-    , m_animationCatchAllCB(std::move(cacb))
     , m_animationLength(length)
 {
   m_signal = Application::get().getMainContext()->signal_idle().connect(sigc::mem_fun(this, &Animator::doAnimation));
@@ -19,7 +18,6 @@ Animator::Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB 
 
 Animator::~Animator()
 {
-  m_animationCatchAllCB();
   m_signal.disconnect();
 }
 
@@ -63,9 +61,6 @@ void AnimatedGenericItem::startAnimation()
 
           if(m_finish.cb.has_value())
             m_finish.cb.value()();
-        }, [this](){
-          if(m_finally.cb.has_value())
-            m_finally.cb.value()();
         });
 }
 

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h
@@ -10,9 +10,8 @@ class Animator
  public:
   using ProgressCB = std::function<void()>;
   using FinishedCB = std::function<void()>;
-  using CatchAllCB = std::function<void()>;
 
-  Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb, CatchAllCB cacb);
+  Animator(std::chrono::milliseconds length, ProgressCB pcb, FinishedCB fcb);
   virtual ~Animator();
   [[nodiscard]] float getAnimationPosition() const;
 
@@ -23,7 +22,6 @@ class Animator
   sigc::connection m_signal;
   ProgressCB m_animationCB;
   FinishedCB m_animationFinishedCB;
-  CatchAllCB m_animationCatchAllCB;
 
   std::chrono::steady_clock::time_point m_animationStartedAt = std::chrono::steady_clock::now();
   std::chrono::milliseconds m_animationLength { 500 };
@@ -33,12 +31,11 @@ class AnimatedGenericItem : public GenericItem
 {
  public:
   template <class tCap>
-  AnimatedGenericItem(tCap caption, const Rect &r, OneShotTypes::StartCB start, OneShotTypes::FinishCB finish, OneShotTypes::CatchAllCB finally = OneShotTypes::CatchAllCB())
+  AnimatedGenericItem(tCap caption, const Rect &r, OneShotTypes::StartCB start, OneShotTypes::FinishCB finish)
       : GenericItem(caption, r, [] {})
   {
     m_start = std::move(start);
     m_finish = std::move(finish);
-    m_finally = std::move(finally);
   }
 
   void startAnimation();
@@ -51,5 +48,4 @@ class AnimatedGenericItem : public GenericItem
   std::unique_ptr<Animator> m_animator;
   OneShotTypes::StartCB m_start;
   OneShotTypes::FinishCB m_finish;
-  OneShotTypes::CatchAllCB m_finally;
 };

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
@@ -28,7 +28,7 @@ ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toTyp
                           OneShotTypes::StartCB(
                               [=]
                               {
-                                ConditionRegistry::get().lock();
+                                m_lock = ConditionRegistry::createLock();
                                 EditBufferUseCases useCases(*Application::get().getPresetManager()->getEditBuffer());
                                 auto selectedVG = Application::get().getVGManager()->getCurrentVoiceGroup();
 
@@ -54,12 +54,12 @@ ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toTyp
                                 }
                               }),
                           OneShotTypes::FinishCB(
-                              []()
+                              [=]()
                               {
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                              }),
-                          OneShotTypes::CatchAllCB { [] { ConditionRegistry::get().unlock(); } })
+                                m_lock.reset();
+                              }))
 {
 }
 
@@ -69,7 +69,7 @@ ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, Sou
                           OneShotTypes::StartCB(
                               [=]
                               {
-                                ConditionRegistry::get().lock();
+                                m_lock = ConditionRegistry::createLock();
                                 EditBufferUseCases useCases(*Application::get().getPresetManager()->getEditBuffer());
 
                                 switch(convertTo)
@@ -89,11 +89,11 @@ ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, Sou
                                 }
                               }),
                           OneShotTypes::FinishCB(
-                              []
+                              [=]
                               {
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                              }),
-                          OneShotTypes::CatchAllCB { [] { ConditionRegistry::get().unlock(); } })
+                                m_lock.reset();
+                              }))
 {
 }

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.h
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.h
@@ -2,15 +2,20 @@
 
 #include <proxies/hwui/descriptive-layouts/concrete/menu/menu-items/AnimatedGenericItem.h>
 #include <nltools/Types.h>
+#include "proxies/hwui/descriptive-layouts/ConditionRegistry.h"
 
 class ConvertToSoundTypeItem : public AnimatedGenericItem
 {
  public:
   explicit ConvertToSoundTypeItem(const Rect& rect, SoundType toType);
+ private:
+  std::unique_ptr<ConditionRegistry::ConditionRegistryScopedLock> m_lock;
 };
 
 class ConvertToSoundTypeItemWithFX : public AnimatedGenericItem
 {
  public:
   explicit ConvertToSoundTypeItemWithFX(const Rect& rect, SoundType convertTo);
+ private:
+  std::unique_ptr<ConditionRegistry::ConditionRegistryScopedLock> m_lock;
 };


### PR DESCRIPTION
cleanup, remove CatchAllCB, keep lock inside the menu-item, either unlock it after the animation is finished, or latest when the item is destroyed, closes #3566