### PR TITLE
BOLED: fix crash on convert actions

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/concrete/sound/menus/items/ConvertToSoundTypeItem.cpp
@@ -56,9 +56,9 @@ ConvertToSoundTypeItem::ConvertToSoundTypeItem(const Rect& rect, SoundType toTyp
                           OneShotTypes::FinishCB(
                               [=]()
                               {
+                                m_lock.reset();
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                                m_lock.reset();
                               }))
 {
 }
@@ -91,9 +91,9 @@ ConvertToSoundTypeItemWithFX::ConvertToSoundTypeItemWithFX(const Rect& rect, Sou
                           OneShotTypes::FinishCB(
                               [=]
                               {
+                                m_lock.reset();
                                 SettingsUseCases sUseCases(*Application::get().getSettings());
                                 sUseCases.setFocusAndMode({ UIFocus::Sound, UIMode::Select, UIDetail::Init });
-                                m_lock.reset();
                               }))
 {
 }


### PR DESCRIPTION
unlock first as we send the focusAndMode signal directly -> means the layout will get reset, therefore the animated item does not exist anymore when we resume the closure, leading to the crash