### PR TITLE
WebUI: Font-Styling

### DIFF
--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
@@ -1029,7 +1029,6 @@ select {
 .gwt-TextArea {
   padding: 5px 7px;
   margin: 3px;
-  font-size: 100%;
   font-family: SSP-LW25, Arial Unicode MS, Arial, sans-serif;
 }
 
@@ -1610,6 +1609,8 @@ select[disabled='disabled'] {
 .dialogContent textarea.editable {
   min-height: 4em;
   max-height: 10em;
+  color: white;
+  font-size: 14px;
 }
 
 .dialogContent textarea.editable.txt-oneline {

--- a/projects/web/static/nonmaps/src/main/webapp/style.css
+++ b/projects/web/static/nonmaps/src/main/webapp/style.css
@@ -729,12 +729,13 @@ textarea {
 	border: 0px solid #000;
 	border-radius: 5px;
 	width: auto;
-	font-family: 'SSP-LW00';
+	font-family: 'SSP-LW25';
 	font-size: 95%;
 	font-weight: 300;
 	padding: 0.4em 0.6em;
 	resize: none;
 	outline: none;
+	color: #c2c2c2;
 	background-color: #141414;
 	border: 1px solid #575757;
 }
@@ -762,7 +763,7 @@ textarea {
 	padding: 0.3em 0.6em;
 	margin: 0;
 	font-family: SSP-LW25, Arial Unicode MS, Arial, sans-serif;
-	color: #c2c2c2;
+	color: #bbb;
 }
 
 input[type="text"]+button.reset {


### PR DESCRIPTION
changed preset and bank comment texts to have the same size and color as the title and position counterparts, closes #3580

tested on linux Firefox and Chromium