### PR TITLE
Boled: Sound-Edit-Layout minor fixups of display-texts

### DIFF
--- a/projects/epc/playground/resources/templates/generic-controls/labels/InvertedLabel.json
+++ b/projects/epc/playground/resources/templates/generic-controls/labels/InvertedLabel.json
@@ -61,6 +61,18 @@
         "FontSize": 8,
         "TextAlign": "Center"
       }
+    },
+    "edit-button-sound": {
+      "selector": {
+        "UIFocus": "Sound",
+        "UIMode": "Edit",
+        "PrimitiveClasses": "Text",
+        "ControlClasses": "InvertedLabel",
+        "ControlInstances": "EditTextHeader"
+      },
+      "styles": {
+        "TextAlign": "Right"
+      }
     }
   }
 }

--- a/projects/epc/playground/resources/templates/sound/edit/LayerSoundEditLayout.json
+++ b/projects/epc/playground/resources/templates/sound/edit/LayerSoundEditLayout.json
@@ -24,7 +24,7 @@
           "Class": "InvertedLabel",
           "Position": "192, 0",
           "Init": {
-            "Text[Text]": "Edit"
+            "Text[Text]": "Edit  "
           }
         },
         "Content": {

--- a/projects/epc/playground/resources/templates/sound/edit/SingleSoundEditLayout.json
+++ b/projects/epc/playground/resources/templates/sound/edit/SingleSoundEditLayout.json
@@ -19,13 +19,14 @@
         },
         "VoiceGroupHeader": {
           "Class": "WideInvertedLabel",
-          "Position": "64, 0"
+          "Position": "64, 0",
+          "Events": "CurrentVoiceGroupText => Text[Text]"
         },
         "EditTextHeader": {
           "Class": "InvertedLabel",
           "Position": "192, 0",
           "Init": {
-            "Text[Text]": "Edit"
+            "Text[Text]": "Edit  "
           }
         },
         "Content": {

--- a/projects/epc/playground/resources/templates/sound/edit/SplitSoundEditLayout.json
+++ b/projects/epc/playground/resources/templates/sound/edit/SplitSoundEditLayout.json
@@ -26,7 +26,7 @@
           "Class": "InvertedLabel",
           "Position": "192, 0",
           "Init": {
-            "Text[Text]": "Edit"
+            "Text[Text]": "Edit  "
           }
         },
         "Content": {

--- a/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.cpp
+++ b/projects/epc/playground/src/proxies/hwui/descriptive-layouts/events/event-sources/edit-buffer/EditBufferEvents.cpp
@@ -176,7 +176,7 @@ bool DescriptiveLayouts::UnisonButtonText::isChanged(const EditBuffer *eb)
 
 void DescriptiveLayouts::CurrentVoiceGroupText::onChange(VoiceGroup newSelection)
 {
-  setValue({ toString(newSelection), 0 });
+  setValue({ "Part " + toString(newSelection), 0 });
 }
 
 void DescriptiveLayouts::VGIMuted::onChange(const EditBuffer *eb)


### PR DESCRIPTION
changed text of current-vg indicator in SoundEditLayout to include Part prefix before I or II, change alignment of Edit Label to Right and add some padding, closes #3504

(please note that the crash fix is not yet included, so converting from the WebUI is advised)