### PR TITLE
PNGControls -> less noise in Playground Output

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/controls/PNGControl.cpp
+++ b/projects/epc/playground/src/proxies/hwui/controls/PNGControl.cpp
@@ -71,6 +71,9 @@ void PNGControl::loadImage(const std::string& l)
   if(l.empty())
   {
     m_imagePath = "";
+    m_image = png::image<png::rgba_pixel>();
+    recalculatePixels();
+    return;
   }
 
   try


### PR DESCRIPTION
fixup noisy logs when loading an empty image -> when DynamicLayouts want to display an Empty Phase for example when no Feedback is active in the Sound-Layouts. Now no error is reported that the desired file is a directory. As we create an empty image object and return early. closes #3570