### PR TITLE
Preset-Search: preserve white-spaces for long preset-names

### DIFF
--- a/projects/web/client/nonmaps-preset-search/search.less
+++ b/projects/web/client/nonmaps-preset-search/search.less
@@ -599,7 +599,7 @@ body {
 
                 .name-first {
                     display: inline-block;
-                    white-space: break-spaces;
+                    white-space: pre;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     vertical-align: middle;
@@ -607,6 +607,7 @@ body {
 
                 .name-second {
                     display: inline-block;
+                    white-space: pre;
                     vertical-align: middle;
                     max-width: 10em;
                 }

--- a/projects/web/client/nonmaps-preset-search/search.less
+++ b/projects/web/client/nonmaps-preset-search/search.less
@@ -599,7 +599,7 @@ body {
 
                 .name-first {
                     display: inline-block;
-                    white-space: nowrap;
+                    white-space: break-spaces;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     vertical-align: middle;


### PR DESCRIPTION
changed white-space to break-spaces to preserve space between first and second preset part of preset-name lengths over 10 characters. closes #3589