### PR TITLE
HWUI: Preset-Info last line for Multi-Line Comment does no longer get cut-off

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/info/MultiLineInfoContent.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/info/MultiLineInfoContent.cpp
@@ -8,6 +8,11 @@ MultiLineInfoContent::MultiLineInfoContent()
 void MultiLineInfoContent::setPosition(const Rect& rect)
 {
   auto re = rect;
-  re.moveBy(0, 2);
+  re.moveBy(0, getBottomPadding());
   MultiLineLabel::setPosition(re);
+}
+
+int MultiLineInfoContent::getBottomPadding()
+{
+  return 2;
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/info/MultiLineInfoContent.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/info/MultiLineInfoContent.h
@@ -7,4 +7,5 @@ class MultiLineInfoContent : public MultiLineLabel
  public:
   MultiLineInfoContent();
   void setPosition(const Rect& rect) override;
+  int getBottomPadding() override;
 };

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.cpp
@@ -86,20 +86,15 @@ void MultiLineLabel::updateLines()
 
   TextSplitter s(font, r.getWidth(), m_text);
   auto lineHeight = font->getHeight() + 3;
-  auto lastLineHeight = lineHeight + 2;
   int y = 0;
 
-  const auto lines = s.getLines();
-  int currentLine = 0;
-  for(const auto &line : lines)
+  for(const auto &line : s.getLines())
   {
-    auto currentLineHeight = currentLine == lines.size() - 1 ? lastLineHeight : lineHeight;
-    addControl(new DETAIL::ChildLabel(line, m_color, font, Rect(0, y, r.getWidth(), currentLineHeight)));
-    y += currentLineHeight;
-    currentLine++;
+    addControl(new DETAIL::ChildLabel(line, m_color, font, Rect(0, y, r.getWidth(), lineHeight)));
+    y += lineHeight;
   }
 
-  super::setPosition(Rect(r.getLeft(), r.getTop(), r.getWidth(), y));
+  super::setPosition(Rect(r.getLeft(), r.getTop(), r.getWidth(), y + getBottomPadding()));
 }
 
 void MultiLineLabel::drawBackground(FrameBuffer &fb)
@@ -120,4 +115,9 @@ bool MultiLineLabel::redraw(FrameBuffer &fb)
 const Glib::ustring &MultiLineLabel::getText() const
 {
   return m_text;
+}
+
+int MultiLineLabel::getBottomPadding()
+{
+  return 0;
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.cpp
@@ -85,13 +85,18 @@ void MultiLineLabel::updateLines()
   auto font = getFont();
 
   TextSplitter s(font, r.getWidth(), m_text);
-  int lineHeight = font->getHeight() + 3;
+  auto lineHeight = font->getHeight() + 3;
+  auto lastLineHeight = lineHeight + 2;
   int y = 0;
 
-  for(const auto &line : s.getLines())
+  const auto lines = s.getLines();
+  int currentLine = 0;
+  for(const auto &line : lines)
   {
-    addControl(new DETAIL::ChildLabel(line, m_color, font, Rect(0, y, r.getWidth(), lineHeight)));
-    y += lineHeight;
+    auto currentLineHeight = currentLine == lines.size() - 1 ? lastLineHeight : lineHeight;
+    addControl(new DETAIL::ChildLabel(line, m_color, font, Rect(0, y, r.getWidth(), currentLineHeight)));
+    y += currentLineHeight;
+    currentLine++;
   }
 
   super::setPosition(Rect(r.getLeft(), r.getTop(), r.getWidth(), y));

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/controls/MultiLineLabel.h
@@ -19,6 +19,7 @@ class MultiLineLabel : public ControlWithChildren
   void drawBackground(FrameBuffer &fb) override;
   bool redraw(FrameBuffer &fb) override;
   void setPosition(const Rect &rect) override;
+  virtual int getBottomPadding();
 
  protected:
   virtual std::shared_ptr<Font> getFont();


### PR DESCRIPTION
gave characters more space at the last line to not cut-off the pixels below, as the MultiLineInfoContent is moved by 2 pixels downwards. this showed on lowercase y or g etc.., closes #3515