### PR TITLE
Recorder: fixup Download as Flac Disabled state

### DIFF
--- a/projects/web/static/recorder/ui.ts
+++ b/projects/web/static/recorder/ui.ts
@@ -120,6 +120,7 @@ class UI {
             }
 
             wave.disabled = tooLargeForWave;
+            flac.disabled = false;
 
             name.oninput = () => {
                 wave.disabled = name.value.length == 0;


### PR DESCRIPTION
added missing reset of disabled state for download as flac button, when the name has been deleted before, closes #3513