### PR TITLE
issue-3474: Fix crash

### DIFF
--- a/projects/shared/nltools/src/nltools/messaging/WebSocketJsonAPI.cpp
+++ b/projects/shared/nltools/src/nltools/messaging/WebSocketJsonAPI.cpp
@@ -149,7 +149,9 @@ namespace nltools
             std::unique_lock<std::recursive_mutex> l(pThis->m_mutex);
             auto it = std::find_if(pThis->m_connections.begin(), pThis->m_connections.end(),
                                    [&](auto &e) { return c == e->connection; });
-            pThis->doSend(c, pThis->m_cb(*it, j));
+
+            if(it != pThis->m_connections.end())
+              pThis->doSend(c, pThis->m_cb(*it, j));
           }
           catch(...)
           {


### PR DESCRIPTION
When a websocket connection is closed between receiveMessage and the according answer, it is still added to the SyncMasters list of subscribers, even though it is not anymore in the list of connections in WebSocketJsonAPI. When SyncMaster later uses its list of weak_ptr<Connection>'s, it will effectively access the WebSocketJsonAPI::m_connections' end iterator and cause UB.