### PR TITLE
Mirror-Oleds: map all soled pixels to white

### DIFF
--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/oleds/Oleds.ui.xml
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/html/oleds/Oleds.ui.xml
@@ -7,7 +7,7 @@
 				<foreignObject x="2" y="2" width="256" height="64">
 					<canvas id="boled" width="256" height="64"></canvas>
 				</foreignObject>
-				<foreignObject x="66" y="68" width="256" height="32">
+				<foreignObject x="66" y="68" width="128" height="32">
 					<canvas id="soled" width="128" height="32"></canvas>
 				</foreignObject>
 			</svg>

--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.js.in
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.js.in
@@ -142,6 +142,16 @@ function showOleds() {
     map.set(0x0B, [219, 219, 219, 255]);
     map.set(0x0F, [255, 255, 255, 255]);
 
+    var soledMap = new Map();
+    soledMap.set(0x10, [0, 0, 0, 255]);
+    soledMap.set(0x00, [0, 0, 0, 255]);
+    soledMap.set(0x02, [255, 255, 255, 255]);
+    soledMap.set(0x05, [255, 255, 255, 255]);
+    soledMap.set(0x06, [255, 255, 255, 255]);
+    soledMap.set(0x0A, [255, 255, 255, 255]);
+    soledMap.set(0x0B, [255, 255, 255, 255]);
+    soledMap.set(0x0F, [255, 255, 255, 255]);
+
     socket = new WebSocket("ws://" + hostName + ":" + @PLAYGROUND_OLED_WEBSOCKET_PORT@);
     socket.onopen = (event) => { socket.send("{}"); };
     socket.onerror = (event) => { refresh(); };
@@ -151,6 +161,7 @@ function showOleds() {
       reader.onload = () => {
         var oledsRaw = JSON.parse(reader.result);
         var oledsPix = new Uint8ClampedArray(oledsRaw.length * 4);
+        var soledPix = new Uint8ClampedArray(oledsRaw.length * 4);
 
         for (var i = 0; i < oledsRaw.length; i++) {
           var idx = i * 4;
@@ -159,10 +170,16 @@ function showOleds() {
           oledsPix[idx + 1] = mapped[1];
           oledsPix[idx + 2] = mapped[2];
           oledsPix[idx + 3] = mapped[3];
+
+          var mappedSoled = soledMap.get(oledsRaw[i]);
+          soledPix[idx + 0] = mappedSoled[0];
+          soledPix[idx + 1] = mappedSoled[1];
+          soledPix[idx + 2] = mappedSoled[2];
+          soledPix[idx + 3] = mappedSoled[3];
         }
 
         drawBoled(oledsPix.slice(0, 4 * 256 * 64));
-        drawSoled(oledsPix.slice(4 * 256 * 64, 4 * 256 * 64 + 4 * 256 * 32));
+        drawSoled(soledPix.slice(4 * 256 * 64, 4 * 256 * 64 + 4 * 256 * 32));
       }
       reader.readAsText(event.data);
     };

--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.js.in
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.js.in
@@ -160,26 +160,34 @@ function showOleds() {
       var reader = new FileReader()
       reader.onload = () => {
         var oledsRaw = JSON.parse(reader.result);
-        var oledsPix = new Uint8ClampedArray(oledsRaw.length * 4);
-        var soledPix = new Uint8ClampedArray(oledsRaw.length * 4);
 
-        for (var i = 0; i < oledsRaw.length; i++) {
+        var boledArraySize = 256 * 64;
+        var soledArraySize = 256 * 32;
+
+        var boledsPix = new Uint8ClampedArray(boledArraySize * 4);
+        var soledPix = new Uint8ClampedArray(soledArraySize * 4);
+
+        for(var i = 0; i < boledArraySize; i++) {
           var idx = i * 4;
           var mapped = map.get(oledsRaw[i]);
-          oledsPix[idx + 0] = mapped[0];
-          oledsPix[idx + 1] = mapped[1];
-          oledsPix[idx + 2] = mapped[2];
-          oledsPix[idx + 3] = mapped[3];
-
-          var mappedSoled = soledMap.get(oledsRaw[i]);
-          soledPix[idx + 0] = mappedSoled[0];
-          soledPix[idx + 1] = mappedSoled[1];
-          soledPix[idx + 2] = mappedSoled[2];
-          soledPix[idx + 3] = mappedSoled[3];
+          boledsPix[idx + 0] = mapped[0];
+          boledsPix[idx + 1] = mapped[1];
+          boledsPix[idx + 2] = mapped[2];
+          boledsPix[idx + 3] = mapped[3];
         }
 
-        drawBoled(oledsPix.slice(0, 4 * 256 * 64));
-        drawSoled(soledPix.slice(4 * 256 * 64, 4 * 256 * 64 + 4 * 256 * 32));
+        for(var i = 0; i < soledArraySize; i++) {
+          var idx = i * 4;
+          var offset = boledArraySize;
+          var mapped = soledMap.get(oledsRaw[offset + i]);
+          soledPix[idx + 0] = mapped[0];
+          soledPix[idx + 1] = mapped[1];
+          soledPix[idx + 2] = mapped[2];
+          soledPix[idx + 3] = mapped[3];
+        }
+
+        drawBoled(boledsPix);
+        drawSoled(soledPix);
       }
       reader.readAsText(event.data);
     };


### PR DESCRIPTION
added new mapping for soled, map all set pixels to white to increase readability on the mirror-oled display, closes #3629