### PR TITLE
fixup parameter and bank comments heights

### DIFF
--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/BankInfoDialog.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/BankInfoDialog.java
@@ -15,6 +15,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.ui.FlexTable;
@@ -170,6 +171,10 @@ public class BankInfoDialog extends GWTDialog {
 			}
 		});
 
+		comment.addKeyUpHandler(event -> {
+			updateCommentFieldHeight();
+		});
+
 		position.addKeyPressHandler(new KeyPressHandler() {
 
 			@Override
@@ -243,6 +248,15 @@ public class BankInfoDialog extends GWTDialog {
 
 		setWidget(panel);
 		setFocus(panel);
+
+		//for some reason we can't properly initialize the height of the comment section on the first open so we have to recalculate it here after some time
+		Timer t = new Timer() {
+			@Override
+			public void run() {
+				updateCommentFieldHeight();
+			}
+		};
+		t.schedule(15);
 	}
 
 	@Override
@@ -271,6 +285,14 @@ public class BankInfoDialog extends GWTDialog {
 			theDialog.updateInfo(bank);
 	}
 
+	private void updateCommentFieldHeight()	{
+		if (comment.getElement().getScrollHeight() > 0) {
+			comment.setHeight("1em");
+			int height = comment.getElement().getScrollHeight() + 10;
+			comment.setHeight(height + "px");
+		}
+	}
+
 	private void updateInfo(Bank bank) {
 		if (bank != null) {
 			String bankName = bank.getCurrentName();
@@ -280,12 +302,7 @@ public class BankInfoDialog extends GWTDialog {
 			if (haveFocus != comment) {
 				if (!commentText.equals(comment.getText())) {
 					comment.setText(commentText);
-
-					if (comment.getElement().getScrollHeight() > 0) {
-						comment.setHeight("1em");
-						int height = comment.getElement().getScrollHeight() + 5;
-						comment.setHeight(height + "px");
-					}
+					updateCommentFieldHeight();
 				}
 			}
 

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/InfoDialog/PresetInfoWidget.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/InfoDialog/PresetInfoWidget.java
@@ -2,9 +2,11 @@ package com.nonlinearlabs.client.world.overlay.InfoDialog;
 
 import java.util.Date;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.DateTimeFormat.PredefinedFormat;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.FlexTable;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -75,12 +77,7 @@ public class PresetInfoWidget {
 
 			if (force || haveFocus != comment) {
 				comment.setText(commentText);
-
-				if (comment.getElement().getScrollHeight() > 0) {
-					comment.setHeight("1em");
-					int height = comment.getElement().getScrollHeight() + 5;
-					comment.setHeight(height + "px");
-				}
+				updateCommentFieldHeight();
 			}
 
 			if (force || haveFocus != name) {
@@ -133,6 +130,10 @@ public class PresetInfoWidget {
 							comment.getText());
 				}
 			}
+		});
+
+		comment.addKeyUpHandler(event -> {
+			updateCommentFieldHeight();
 		});
 
 		name.addFocusHandler(event -> haveFocus = name);
@@ -197,6 +198,16 @@ public class PresetInfoWidget {
 		this.panel = panel;
 
 		updateInfo(NonMaps.get().getNonLinearWorld().getPresetManager().getSelectedPreset(), false);
+
+
+		//for some reason we can't properly initialize the height of the comment section on the first open so we have to recalculate it here after some time
+		Timer t = new Timer() {
+			@Override
+			public void run() {
+				updateCommentFieldHeight();
+			}
+		};
+		t.schedule(15);
 	}
 
 	private void addRow(FlexTable panel, String name, Widget content) {
@@ -208,6 +219,14 @@ public class PresetInfoWidget {
 	private void saveContent() {
 		if (haveFocus != null && m_currentShownPreset != null) {
 			haveFocus.setFocus(false);
+		}
+	}
+
+	private void updateCommentFieldHeight()	{
+		if (comment.getElement().getScrollHeight() > 0) {
+			comment.setHeight("1em");
+			int height = comment.getElement().getScrollHeight() + 10;
+			comment.setHeight(height + "px");
 		}
 	}
 }

--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
@@ -1608,7 +1608,7 @@ select[disabled='disabled'] {
 
 .dialogContent textarea.editable {
   min-height: 4em;
-  max-height: 10em;
+  max-height: 50vh;
   color: white;
   font-size: 14px;
 }


### PR DESCRIPTION
added updateHeight to onKeyUpHandlers for Comment-Fields, cant use onKeyown as the content has not changed (atleast after pressing return) and inital size setting won't work so we just reschedule a new calculation 15ms in the future, closes #3597