### PR TITLE
HWUI: reset returning HW-Sources on Focus-Change if last changed from HWUI

### DIFF
--- a/projects/epc/playground/src/presets/EditBuffer.cpp
+++ b/projects/epc/playground/src/presets/EditBuffer.cpp
@@ -61,6 +61,30 @@ void EditBuffer::init(Settings *settings)
 {
   ParameterGroupSet::init(settings);
   m_recallSet.init();
+  connectToFocusAndMode();
+}
+
+void EditBuffer::connectToFocusAndMode()
+{
+  m_settings.getSetting<FocusAndModeSetting>()->onChange(
+      sigc::mem_fun(this, &EditBuffer::resetReturningParametersOnFocusAndModeChange));
+}
+
+void EditBuffer::resetReturningParametersOnFocusAndModeChange(const Setting *s)
+{
+  if(auto famSetting = dynamic_cast<const FocusAndModeSetting *>(s))
+  {
+    auto state = famSetting->getState();
+    if(state.focus != UIFocus::Parameters)
+    {
+      getParameterGroupByID({ "CS", VoiceGroup::Global })->forEachParameter([](auto parameter) {
+        if(auto hw = dynamic_cast<PhysicalControlParameter *>(parameter))
+        {
+          hw->resetChangedFromHWUIPosition();
+        }
+      });
+    }
+  }
 }
 
 EditBuffer::~EditBuffer()

--- a/projects/epc/playground/src/presets/EditBuffer.h
+++ b/projects/epc/playground/src/presets/EditBuffer.h
@@ -19,6 +19,7 @@ class SplitPointParameter;
 class LoadedPresetLog;
 class Settings;
 class AudioEngineProxy;
+class Setting;
 
 class EditBuffer : public ParameterGroupSet, public SyncedItem
 {
@@ -202,6 +203,9 @@ class EditBuffer : public ParameterGroupSet, public SyncedItem
   void setHWSourcesToLoadRulePositionsAndModulate(UNDO::Transaction *transaction);
 
   void sendPresetLoadSignal();
+
+  void connectToFocusAndMode();
+  void resetReturningParametersOnFocusAndModeChange(const Setting *s);
 
   Signal<void, Parameter *, Parameter *> m_signalSelectedParameter;
   Signal<void, Parameter *> m_signalReselectParameter;


### PR DESCRIPTION
added reset of changed from HWUI sources if we select any other focus but parameters (this will leave the changed value intact for parameter-edit or -info)

closes #3500