### PR TITLE
HWUI: Recall-Screen value formatting

### DIFF
--- a/projects/epc/playground/src/parameters/ModulationRoutingParameter.cpp
+++ b/projects/epc/playground/src/parameters/ModulationRoutingParameter.cpp
@@ -99,11 +99,11 @@ bool ModulationRoutingParameter::routes(const PhysicalControlParameter *p) const
   return m_srcParameter == p;
 }
 
-Glib::ustring ModulationRoutingParameter::getDisplayString() const
+Glib::ustring ModulationRoutingParameter::getDisplayString(tControlPositionValue val) const
 {
   if(getSourceParameter()->getReturnMode() == ReturnMode::None)
   {
-    if(getValue().getDisplayValue() != 0.0)
+    if(val != 0.0)
     {
       return "On";
     }
@@ -113,7 +113,12 @@ Glib::ustring ModulationRoutingParameter::getDisplayString() const
     }
   }
 
-  return super::getDisplayString();
+  return super::getDisplayString(val);
+}
+
+Glib::ustring ModulationRoutingParameter::getDisplayString() const
+{
+  return getDisplayString(getControlPositionValue());
 }
 
 tControlPositionValue ModulationRoutingParameter::getControlPositionValue() const

--- a/projects/epc/playground/src/parameters/ModulationRoutingParameter.h
+++ b/projects/epc/playground/src/parameters/ModulationRoutingParameter.h
@@ -30,6 +30,7 @@ class ModulationRoutingParameter : public Parameter, public IntrusiveListItem<Mo
 
   bool routes(const PhysicalControlParameter *p) const;
   Glib::ustring getDisplayString() const override;
+  Glib::ustring getDisplayString(tControlPositionValue val) const override;
   tControlPositionValue getControlPositionValue() const override;
   Layout *createLayout(FocusAndMode focusAndMode) const override;
 

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/parameter-screens/ParameterLayout.cpp
@@ -355,11 +355,12 @@ ParameterRecallLayout2::ParameterRecallLayout2()
         break;
     }
 
-    m_leftValue = addControl(new Label(StringAndSuffix { p->getDisplayString() }, Rect(67, 35, 58, 11)));
+    auto currentValue = p->getControlPositionValue();
+    auto leftText = p->getDisplayString(currentValue);
+    m_leftValue = addControl(new Label(StringAndSuffix { leftText }, Rect(67, 35, 58, 11)));
 
-    auto displayString = p->getDisplayString(originalValue);
-
-    m_rightValue = addControl(new Label(StringAndSuffix { displayString }, Rect(131, 35, 58, 11)));
+    auto rightText = p->getDisplayString(originalValue);
+    m_rightValue = addControl(new Label(StringAndSuffix { rightText }, Rect(131, 35, 58, 11)));
   }
 
   m_recallValue = getCurrentParameter()->getControlPositionValue();
@@ -478,10 +479,11 @@ void ParameterRecallLayout2::updateUI(bool paramLikeInPreset)
     {
       auto originalParam = p->getOriginalParameter();
       auto originalValue = originalParam ? originalParam->getRecallValue() : p->getDefaultValue();
-      auto displayString = p->getDisplayString(originalValue);
+      auto displayStringRecall = p->getDisplayString(originalValue);
+      auto currentDisplayString = p->getDisplayString(p->getControlPositionValue());
 
-      m_leftValue->setText(StringAndSuffix { displayString });
-      m_rightValue->setText(StringAndSuffix { p->getDisplayString() });
+      m_leftValue->setText(StringAndSuffix { displayStringRecall });
+      m_rightValue->setText(StringAndSuffix { currentDisplayString });
       m_slider->setValue(m_recallValue, p->isBiPolar());
       m_leftValue->setHighlight(false);
       m_rightValue->setHighlight(true);


### PR DESCRIPTION
added overwrite of getDisplayString(double) to allow RecallParameterLayout of Mod-Routers to display the values with the same formatting

closes #3643 

now:
![Boled-Tue-Feb-21-15:58:16-2023
](https://user-images.githubusercontent.com/15381257/220380852-03476065-d787-413f-8c20-b97aaffbe279.png)
