### PR TITLE
Yaml rework group elements

### DIFF
--- a/projects/epc/playground/src/parameters/ParameterFactory.cpp
+++ b/projects/epc/playground/src/parameters/ParameterFactory.cpp
@@ -12,22 +12,6 @@
 #include "MacroControlSmoothingParameter.h"
 #include "MacroControlParameter.h"
 
-namespace
-{
-  template <C15::Descriptors::ParameterGroup tGroup> std::vector<int> fromArray()
-  {
-    const auto& elements = C15::ParameterGroupElementList<tGroup>::sElements;
-    const auto& size = C15::ParameterGroupElementList<tGroup>::sSize;
-    std::vector<int> result;
-    result.reserve(size);
-    for(int i = 0; i < size; i++)
-    {
-      result.push_back(elements[i]);
-    }
-    return result;
-  }
-}
-
 std::vector<C15::PID::ParameterID> ParameterFactory::getParameterIDs(const C15::Descriptors::ParameterGroup& group)
 {
   const auto ret = C15::getParameterIds(group);
@@ -36,63 +20,6 @@ std::vector<C15::PID::ParameterID> ParameterFactory::getParameterIDs(const C15::
     return ret;
   // empty results fail
   nltools_detailedAssertAlways(false, ("Unknown parameter group with id: " + group));
-  //  switch(group)
-  //  {
-  //    case C15::Descriptors::ParameterGroup::Mod_HW:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Mod_HW>();
-  //    case C15::Descriptors::ParameterGroup::Mod_HA:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Mod_HA>();
-  //    case C15::Descriptors::ParameterGroup::Macro:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Macro>();
-  //    case C15::Descriptors::ParameterGroup::Split:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Split>();
-  //    case C15::Descriptors::ParameterGroup::Master:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Master>();
-  //    case C15::Descriptors::ParameterGroup::Scale:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Scale>();
-  //    case C15::Descriptors::ParameterGroup::Unison:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Unison>();
-  //    case C15::Descriptors::ParameterGroup::Part:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Part>();
-  //    case C15::Descriptors::ParameterGroup::Mono_Grp:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Mono_Grp>();
-  //    case C15::Descriptors::ParameterGroup::Env_A:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Env_A>();
-  //    case C15::Descriptors::ParameterGroup::Env_B:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Env_B>();
-  //    case C15::Descriptors::ParameterGroup::Env_C:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Env_C>();
-  //    case C15::Descriptors::ParameterGroup::Osc_A:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Osc_A>();
-  //    case C15::Descriptors::ParameterGroup::Shp_A:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Shp_A>();
-  //    case C15::Descriptors::ParameterGroup::Osc_B:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Osc_B>();
-  //    case C15::Descriptors::ParameterGroup::Shp_B:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Shp_B>();
-  //    case C15::Descriptors::ParameterGroup::Comb_Flt:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Comb_Flt>();
-  //    case C15::Descriptors::ParameterGroup::SV_Flt:
-  //      return fromArray<C15::Descriptors::ParameterGroup::SV_Flt>();
-  //    case C15::Descriptors::ParameterGroup::FB_Mix:
-  //      return fromArray<C15::Descriptors::ParameterGroup::FB_Mix>();
-  //    case C15::Descriptors::ParameterGroup::Out_Mix:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Out_Mix>();
-  //    case C15::Descriptors::ParameterGroup::Flanger:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Flanger>();
-  //    case C15::Descriptors::ParameterGroup::Cabinet:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Cabinet>();
-  //    case C15::Descriptors::ParameterGroup::Gap_Flt:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Gap_Flt>();
-  //    case C15::Descriptors::ParameterGroup::Echo:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Echo>();
-  //    case C15::Descriptors::ParameterGroup::Reverb:
-  //      return fromArray<C15::Descriptors::ParameterGroup::Reverb>();
-  //    default:
-  //    case C15::Descriptors::ParameterGroup::Env_G:
-  //    case C15::Descriptors::ParameterGroup::None:
-  //      nltools_detailedAssertAlways(false, ("Unknown parameter group with id: " + group));
-  //  }
 }
 
 bool ParameterFactory::isModulateable(int id)
@@ -143,8 +70,7 @@ std::vector<C15::ParameterGroupDescriptor> ParameterFactory::getParameterGroupsP
   std::vector<C15::ParameterGroupDescriptor> groups;
   for(const auto& group : C15::ParameterGroups)
   {
-    if(group.m_group == C15::Descriptors::ParameterGroup::None
-       || group.m_group == C15::Descriptors::ParameterGroup::Env_G)
+    if(group.m_group == C15::Descriptors::ParameterGroup::None)
       continue;
 
     if(group.m_global_group == false)

--- a/projects/epc/playground/src/parameters/ParameterFactory.cpp
+++ b/projects/epc/playground/src/parameters/ParameterFactory.cpp
@@ -28,65 +28,71 @@ namespace
   }
 }
 
-std::vector<int> ParameterFactory::getParameterIDs(const C15::Descriptors::ParameterGroup& group)
+std::vector<C15::PID::ParameterID> ParameterFactory::getParameterIDs(const C15::Descriptors::ParameterGroup& group)
 {
-  switch(group)
-  {
-    case C15::Descriptors::ParameterGroup::Mod_HW:
-      return fromArray<C15::Descriptors::ParameterGroup::Mod_HW>();
-    case C15::Descriptors::ParameterGroup::Mod_HA:
-      return fromArray<C15::Descriptors::ParameterGroup::Mod_HA>();
-    case C15::Descriptors::ParameterGroup::Macro:
-      return fromArray<C15::Descriptors::ParameterGroup::Macro>();
-    case C15::Descriptors::ParameterGroup::Split:
-      return fromArray<C15::Descriptors::ParameterGroup::Split>();
-    case C15::Descriptors::ParameterGroup::Master:
-      return fromArray<C15::Descriptors::ParameterGroup::Master>();
-    case C15::Descriptors::ParameterGroup::Scale:
-      return fromArray<C15::Descriptors::ParameterGroup::Scale>();
-    case C15::Descriptors::ParameterGroup::Unison:
-      return fromArray<C15::Descriptors::ParameterGroup::Unison>();
-    case C15::Descriptors::ParameterGroup::Part:
-      return fromArray<C15::Descriptors::ParameterGroup::Part>();
-    case C15::Descriptors::ParameterGroup::Mono_Grp:
-      return fromArray<C15::Descriptors::ParameterGroup::Mono_Grp>();
-    case C15::Descriptors::ParameterGroup::Env_A:
-      return fromArray<C15::Descriptors::ParameterGroup::Env_A>();
-    case C15::Descriptors::ParameterGroup::Env_B:
-      return fromArray<C15::Descriptors::ParameterGroup::Env_B>();
-    case C15::Descriptors::ParameterGroup::Env_C:
-      return fromArray<C15::Descriptors::ParameterGroup::Env_C>();
-    case C15::Descriptors::ParameterGroup::Osc_A:
-      return fromArray<C15::Descriptors::ParameterGroup::Osc_A>();
-    case C15::Descriptors::ParameterGroup::Shp_A:
-      return fromArray<C15::Descriptors::ParameterGroup::Shp_A>();
-    case C15::Descriptors::ParameterGroup::Osc_B:
-      return fromArray<C15::Descriptors::ParameterGroup::Osc_B>();
-    case C15::Descriptors::ParameterGroup::Shp_B:
-      return fromArray<C15::Descriptors::ParameterGroup::Shp_B>();
-    case C15::Descriptors::ParameterGroup::Comb_Flt:
-      return fromArray<C15::Descriptors::ParameterGroup::Comb_Flt>();
-    case C15::Descriptors::ParameterGroup::SV_Flt:
-      return fromArray<C15::Descriptors::ParameterGroup::SV_Flt>();
-    case C15::Descriptors::ParameterGroup::FB_Mix:
-      return fromArray<C15::Descriptors::ParameterGroup::FB_Mix>();
-    case C15::Descriptors::ParameterGroup::Out_Mix:
-      return fromArray<C15::Descriptors::ParameterGroup::Out_Mix>();
-    case C15::Descriptors::ParameterGroup::Flanger:
-      return fromArray<C15::Descriptors::ParameterGroup::Flanger>();
-    case C15::Descriptors::ParameterGroup::Cabinet:
-      return fromArray<C15::Descriptors::ParameterGroup::Cabinet>();
-    case C15::Descriptors::ParameterGroup::Gap_Flt:
-      return fromArray<C15::Descriptors::ParameterGroup::Gap_Flt>();
-    case C15::Descriptors::ParameterGroup::Echo:
-      return fromArray<C15::Descriptors::ParameterGroup::Echo>();
-    case C15::Descriptors::ParameterGroup::Reverb:
-      return fromArray<C15::Descriptors::ParameterGroup::Reverb>();
-    default:
-    case C15::Descriptors::ParameterGroup::Env_G:
-    case C15::Descriptors::ParameterGroup::None:
-      nltools_detailedAssertAlways(false, ("Unknown parameter group with id: " + group));
-  }
+  const auto ret = C15::getParameterIds(group);
+  // non-empty results are valid
+  if(ret.size() > 0)
+    return ret;
+  // empty results fail
+  nltools_detailedAssertAlways(false, ("Unknown parameter group with id: " + group));
+  //  switch(group)
+  //  {
+  //    case C15::Descriptors::ParameterGroup::Mod_HW:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Mod_HW>();
+  //    case C15::Descriptors::ParameterGroup::Mod_HA:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Mod_HA>();
+  //    case C15::Descriptors::ParameterGroup::Macro:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Macro>();
+  //    case C15::Descriptors::ParameterGroup::Split:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Split>();
+  //    case C15::Descriptors::ParameterGroup::Master:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Master>();
+  //    case C15::Descriptors::ParameterGroup::Scale:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Scale>();
+  //    case C15::Descriptors::ParameterGroup::Unison:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Unison>();
+  //    case C15::Descriptors::ParameterGroup::Part:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Part>();
+  //    case C15::Descriptors::ParameterGroup::Mono_Grp:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Mono_Grp>();
+  //    case C15::Descriptors::ParameterGroup::Env_A:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Env_A>();
+  //    case C15::Descriptors::ParameterGroup::Env_B:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Env_B>();
+  //    case C15::Descriptors::ParameterGroup::Env_C:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Env_C>();
+  //    case C15::Descriptors::ParameterGroup::Osc_A:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Osc_A>();
+  //    case C15::Descriptors::ParameterGroup::Shp_A:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Shp_A>();
+  //    case C15::Descriptors::ParameterGroup::Osc_B:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Osc_B>();
+  //    case C15::Descriptors::ParameterGroup::Shp_B:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Shp_B>();
+  //    case C15::Descriptors::ParameterGroup::Comb_Flt:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Comb_Flt>();
+  //    case C15::Descriptors::ParameterGroup::SV_Flt:
+  //      return fromArray<C15::Descriptors::ParameterGroup::SV_Flt>();
+  //    case C15::Descriptors::ParameterGroup::FB_Mix:
+  //      return fromArray<C15::Descriptors::ParameterGroup::FB_Mix>();
+  //    case C15::Descriptors::ParameterGroup::Out_Mix:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Out_Mix>();
+  //    case C15::Descriptors::ParameterGroup::Flanger:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Flanger>();
+  //    case C15::Descriptors::ParameterGroup::Cabinet:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Cabinet>();
+  //    case C15::Descriptors::ParameterGroup::Gap_Flt:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Gap_Flt>();
+  //    case C15::Descriptors::ParameterGroup::Echo:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Echo>();
+  //    case C15::Descriptors::ParameterGroup::Reverb:
+  //      return fromArray<C15::Descriptors::ParameterGroup::Reverb>();
+  //    default:
+  //    case C15::Descriptors::ParameterGroup::Env_G:
+  //    case C15::Descriptors::ParameterGroup::None:
+  //      nltools_detailedAssertAlways(false, ("Unknown parameter group with id: " + group));
+  //  }
 }
 
 bool ParameterFactory::isModulateable(int id)

--- a/projects/epc/playground/src/parameters/ParameterFactory.h
+++ b/projects/epc/playground/src/parameters/ParameterFactory.h
@@ -12,7 +12,7 @@ class ParameterFactory
 {
  public:
   static std::vector<C15::ParameterGroupDescriptor> getParameterGroupsPerVoiceGroup();
-  static std::vector<int> getParameterIDs(const C15::Descriptors::ParameterGroup& group);
+  static std::vector<C15::PID::ParameterID> getParameterIDs(const C15::Descriptors::ParameterGroup& group);
 
   static bool isModulateable(int id);
   static Parameter* createParameterByType(ParameterGroup* parent, const ParameterId& id);

--- a/projects/shared/configuration/lib/tasks/declarations.ts
+++ b/projects/shared/configuration/lib/tasks/declarations.ts
@@ -90,7 +90,11 @@ export const DeclarationsParser = new Parser<DeclarationsType>(
                 parameter_unit: Object.keys(declarations.parameter_unit).join(",\n"),
                 parameter_rounding: Object.keys(declarations.parameter_rounding).join(",\n"),
                 parameter_infinity: Object.keys(declarations.parameter_infinity).join(",\n"),
-                parameter_group: Object.keys(declarations.parameter_group).join(",\n"),
+                parameter_group: Object.entries(declarations.parameter_group).reduce((out, [key, props]) => {
+                    if((key === "None") || (props !== null))
+                        out.push(key);
+                    return out;
+                }, []).join(",\n"),
                 smoother_section: Object.keys(declarations.smoother_section).join(",\n"),
                 smoother_clock: Object.keys(declarations.smoother_clock).join(",\n"),
                 smoother_scale: Object.keys(declarations.smoother_scale).join(",\n"),

--- a/projects/shared/configuration/src/parameter_group.h.in
+++ b/projects/shared/configuration/src/parameter_group.h.in
@@ -18,11 +18,6 @@ namespace C15
     constexpr ParameterGroupDescriptor ParameterGroups[] = {
         ${parameter_groups}
     };
-    // elements of individual parameter groups - todo: remove
-    template<Descriptors::ParameterGroup G>
-    struct ParameterGroupElementList;
-    // template specializations - todo: remove
-    ${group_map}
     // elements of individual parameter groups
     ${get_parameter_ids}
 } // namespace C15

--- a/projects/shared/configuration/src/parameter_group.h.in
+++ b/projects/shared/configuration/src/parameter_group.h.in
@@ -10,6 +10,7 @@
 *******************************************************************************/
 
 #include "parameter_descriptor.h"
+#include <vector>
 
 namespace C15
 {
@@ -17,9 +18,11 @@ namespace C15
     constexpr ParameterGroupDescriptor ParameterGroups[] = {
         ${parameter_groups}
     };
-    // elements of individual parameter groups
+    // elements of individual parameter groups - todo: remove
     template<Descriptors::ParameterGroup G>
     struct ParameterGroupElementList;
-    // template specializations
+    // template specializations - todo: remove
     ${group_map}
+    // elements of individual parameter groups
+    ${get_parameter_ids}
 } // namespace C15


### PR DESCRIPTION
- [x] provide std::vector&lt;C15::PID::ParameterID&gt; for retrieving elements of ParameterGroups instead of template specializations
- [x] no more invalid ParameterGroups (except None)

---

- [x] playground-test
~~~
test cases:   228 |   227 passed | 1 failed as expected
assertions: 26266 | 26265 passed | 1 failed as expected
~~~

- [x] Preview of generated `parameter_group.h`:
~~~ c++
// elements of individual parameter groups
inline std::vector<PID::ParameterID> getParameterIds(const Descriptors::ParameterGroup &_group) {
    switch(_group) {
    case Descriptors::ParameterGroups::None:
        return {};
    case Descriptors::ParameterGroup::Mod_HW:
        return {
            PID::Pedal_1,
            PID::Pedal_1_Send,
            // ...
        };
    case Descriptors::ParameterGroup::Mod_HA:
        return {
            PID::Pedal_1_to_MC_A,
            PID::Pedal_1_to_MC_B,
            // ..
        };
    // ...
    }
    // no default necessary because every ParameterGroup entry is covered
    return {}; // prevent warning
}
~~~

- [x] cleanup

---

`ParameterFactory::getParameterIDs` will assert when receiving an empty vector (for `ParameterGroup::None`). If this assertion is necessary can be subject of discussion.

closes #3652