### PR TITLE
WebUI: 3657 arrow cleanup

### DIFF
--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/LayerSoundLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/LayerSoundLayout.java
@@ -82,11 +82,12 @@ public class LayerSoundLayout extends SoundLayout {
 			layerToFXArrows4.doLayout(0, 0, layerToFXWidth, h);
 
 			double fxIWidth = fxI.getPictureWidth();
+			double fxIIWidth = fxII.getPictureWidth();
 			fxI.doLayout(layerToFXWidth, 0, fxIWidth, h/2);
-			fxII.doLayout(layerToFXWidth, h/2, fxIWidth, h/2);
-			serial.doLayout(layerToFXWidth, 0, fxIWidth, h);
+			fxII.doLayout(layerToFXWidth, h/2, fxIIWidth, h/2);
+			serial.doLayout(layerToFXWidth, 0, getMaxWidth(fxI, fxII), h);
 
-			double xPos = layerToFXWidth + fxIWidth;
+			double xPos = layerToFXWidth + getMaxWidth(fxI, fxII);
 			double toOutArrowWidth = layerFXToOutArrows.getPictureWidth(); 
 			layerFXToOutArrows.doLayout(xPos, 0, toOutArrowWidth, h);
 		}

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SingleSoundLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SingleSoundLayout.java
@@ -61,9 +61,11 @@ public class SingleSoundLayout extends SoundLayout {
 			//voicegroup indicators
 			double yOffset = Millimeter.toPixels(2);			
 			double vgHeight = vgI.getPictureHeight();
-			double vgWidth = vgI.getPictureWidth();
+			double vgWidth = vgI.getPictureWidth();			
+			double vgHeightII = vgII.getPictureHeight();
+			double vgWidthII = vgII.getPictureWidth();
 			vgI.doLayout(fbWidth, (h / 2) - (vgHeight * 2) + yOffset, vgWidth, vgHeight);
-			vgII.doLayout(fbWidth, (h / 2) + (vgHeight) - yOffset, vgWidth, vgHeight);
+			vgII.doLayout(fbWidth, (h / 2) + (vgHeightII) - yOffset, vgWidthII, vgHeightII);
 
 			//serial arrow
 			double serialArrowHeight = serialArrow.getPictureHeight();

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SplitSoundLayout.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/SplitSoundLayout.java
@@ -88,7 +88,6 @@ public class SplitSoundLayout extends SoundLayout {
 				
 				fb_from_I_Into_I.update(ebp.split_fb_I_into_I);
 				fb_from_I_Into_II.update(ebp.split_fb_I_into_II);
-				
 				ItoOut.update(ebp.splitToOut);
 
 				return true;
@@ -104,23 +103,28 @@ public class SplitSoundLayout extends SoundLayout {
 			double toFXArrowWidth = partIToFXArrows.getPictureWidth();
 			partIToFXArrows.doLayout(w - toFXArrowWidth, margin, toFXArrowWidth, h - 2 * margin);
 		
-			double fx_width = fxI_I.getPictureWidth();
-			double fx_height = fxI_I.getPictureHeight();
-			double fxI_x_pos = w - toFXArrowWidth - fx_width;
+			double fx_width_I = fxI_I.getPictureWidth();
+			double fx_height_I = fxI_I.getPictureHeight();
+			double fx_width_II = fxI_II.getPictureWidth();
+			double fx_height_II = fxI_II.getPictureHeight();
+
+			double fxI_x_pos = w - toFXArrowWidth - fx_width_I;
 			double yPosOffset = h / 6;
 			double yBase = h / 2 - (yPosOffset / 4);
 
-			fxI_I.doLayout(fxI_x_pos, 0 + yPosOffset, fx_width, fx_height);
-			fxI_II.doLayout(fxI_x_pos, yBase + yPosOffset, fx_width, fx_height);
-			serialI.doLayout(fxI_x_pos, 0, fx_width, h);
+			fxI_I.doLayout(fxI_x_pos, 0 + yPosOffset, fx_width_I, fx_height_I);
+			fxI_II.doLayout(fxI_x_pos, yBase + yPosOffset, fx_width_II, fx_height_II);
+			serialI.doLayout(fxI_x_pos, 0, Math.max(fx_width_I, fx_width_II), h);
 
 			double toOutWidth = ItoOut.getPictureWidth();
 			ItoOut.doLayout(fxI_x_pos - toOutWidth, 0, toOutWidth, h);
 
-			double fb_height = fb_from_I_Into_I.getPictureHeight();
+			double fb_height_I = fb_from_I_Into_I.getPictureHeight();
+			double fb_height_II = fb_from_I_Into_II.getPictureHeight();
+
 			double upper_offset = Millimeter.toPixels(0.3);
-			fb_from_I_Into_I.doLayout(w - toFXArrowWidth, yPosOffset - upper_offset, toFXArrowWidth, fb_height);
-			fb_from_I_Into_II.doLayout(w - toFXArrowWidth, h - yPosOffset - fb_height, toFXArrowWidth, fb_height);			
+			fb_from_I_Into_I.doLayout(w - toFXArrowWidth, yPosOffset - upper_offset, toFXArrowWidth, fb_height_I);
+			fb_from_I_Into_II.doLayout(w - toFXArrowWidth, h - yPosOffset - fb_height_II, toFXArrowWidth, fb_height_II);			
 		}
 	}
 
@@ -178,23 +182,27 @@ public class SplitSoundLayout extends SoundLayout {
 			double toFXArrowWidth = partIIToFXArrows.getPictureWidth();
 			partIIToFXArrows.doLayout(0, margin, toFXArrowWidth, h - 2 * margin);
 		
-			double fx_width = fxII_I.getPictureWidth();
-			double fx_height = fxII_I.getPictureHeight();
+			double fx_width_I = fxII_I.getPictureWidth();
+			double fx_height_I = fxII_I.getPictureHeight();
+			double fx_width_II = fxII_II.getPictureWidth();
+			double fx_height_II = fxII_II.getPictureHeight();
+			
 			double fxI_x_pos = 0 + toFXArrowWidth;
 			double yPosOffset = h / 6;
 			double yBase = h / 2 - (yPosOffset / 4);
 
-			fxII_I.doLayout(fxI_x_pos, 0 + yPosOffset, fx_width, fx_height);
-			fxII_II.doLayout(fxI_x_pos, yBase + yPosOffset, fx_width, fx_height);
-			serialII.doLayout(fxI_x_pos, 0, fx_width, h);
+			fxII_I.doLayout(fxI_x_pos, 0 + yPosOffset, fx_width_I, fx_height_I);
+			fxII_II.doLayout(fxI_x_pos, yBase + yPosOffset, fx_width_II, fx_height_II);
+			serialII.doLayout(fxI_x_pos, 0, Math.max(fx_width_I, fx_width_II), h);
 
 			double toOutWidth = IItoOut.getPictureWidth();			
-			IItoOut.doLayout(fxI_x_pos + fx_width, 0, toOutWidth, h);
+			IItoOut.doLayout(fxI_x_pos + Math.max(fx_width_I, fx_width_II), 0, toOutWidth, h);
 
-			double fb_height = fb_from_II_Into_I.getPictureHeight();
+			double fb_height_I = fb_from_II_Into_I.getPictureHeight();
+			double fb_height_II = fb_from_II_Into_II.getPictureHeight();
 			double upper_offset = Millimeter.toPixels(0.3);
-			fb_from_II_Into_I.doLayout(0, yPosOffset - upper_offset, toFXArrowWidth, fb_height);
-			fb_from_II_Into_II.doLayout(0, h - yPosOffset - fb_height, toFXArrowWidth, fb_height);
+			fb_from_II_Into_I.doLayout(0, yPosOffset - upper_offset, toFXArrowWidth, fb_height_I);
+			fb_from_II_Into_II.doLayout(0, h - yPosOffset - fb_height_I, toFXArrowWidth, fb_height_II);
 		}
 	}
 


### PR DESCRIPTION
use separate widths and heights for different controls instead of sibling control widths and heights, closes #3657