### PR TITLE
WebUI: Overwrite with selected empty bank

### DIFF
--- a/projects/epc/playground/src/presets/BankActions.cpp
+++ b/projects/epc/playground/src/presets/BankActions.cpp
@@ -7,6 +7,7 @@
 #include <presets/Bank.h>
 #include <presets/Preset.h>
 #include <presets/PresetManager.h>
+#include <presets/EditBuffer.h>
 
 #include <http/NetworkRequest.h>
 #include <http/HTTPRequest.h>
@@ -106,6 +107,11 @@ BankActions::BankActions(UpdateDocumentContributor* parent, PresetManager& prese
       {
         targetUseCases.overwriteWithEditBuffer(*m_presetManager.getEditBuffer());
       }
+    }
+    else if(auto selBank = m_presetManager.getSelectedBank(); selBank->getNumPresets() == 0)
+    {
+      BankUseCases bankUseCases(selBank, m_presetManager.getEditBuffer()->getSettings());
+      bankUseCases.saveEditBufferIntoBank();
     }
     else
     {

--- a/projects/epc/playground/src/use-cases/BankUseCases.cpp
+++ b/projects/epc/playground/src/use-cases/BankUseCases.cpp
@@ -377,3 +377,16 @@ void BankUseCases::selectFirstOrLastPreset(int inc)
     }
   }
 }
+
+void BankUseCases::saveEditBufferIntoBank()
+{
+  auto presetManager = m_bank->getPresetManager();
+  EditBufferStorePreparation ebsp(*presetManager->getEditBuffer());
+  auto scope = m_bank->getUndoScope().startTransaction("Store Editbuffer into Bank '%0'", m_bank->getName(true));
+  auto transaction = scope->getTransaction();
+  auto preset = m_bank->appendPreset(transaction, std::make_unique<Preset>(m_bank, *presetManager->getEditBuffer()));
+  presetManager->selectBank(transaction, m_bank->getUuid());
+  m_bank->selectPreset(transaction, preset->getUuid());
+  presetManager->getEditBuffer()->undoableLoad(transaction, preset, false);
+  StoreUseCaseHelper::onStore(transaction, *preset, *presetManager, m_settings);
+}

--- a/projects/epc/playground/src/use-cases/BankUseCases.h
+++ b/projects/epc/playground/src/use-cases/BankUseCases.h
@@ -42,6 +42,8 @@ class BankUseCases
   Preset* appendEditBufferAsPresetWithUUID(Uuid uuid);
   Preset* insertEditBufferAsPresetWithUUID(size_t pos, Uuid uuid);
 
+  void saveEditBufferIntoBank();
+
  private:
   [[nodiscard]] bool isDirectLoadActive() const;
   [[nodiscard]] PresetManager* getPresetManager() const;


### PR DESCRIPTION
added new use-case when overwrite is pressed in the webUI while an empty bank is selected, instead of creating a new bank and storing the preset into this bank we will store the editbuffer as a preset into the current (empty) bank, closes #3655