### PR TITLE
HWUI: fixup signal flow indication for ENV_C

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.cpp
@@ -487,10 +487,10 @@ void PanelUnitParameterEditMode::letTargetsBlink(Parameter *selParam, tLedStates
   }
   else if(groupName == "Env C")
   {
-    letOtherTargetsBlink({ Osc_A_Pitch_Env_C, Osc_A_Fluct_Env_C, Osc_A_PM_FB_Env_C, Shp_A_FB_Env_C, Osc_B_Pitch_Env_C,
-                           Osc_B_Fluct_Env_C, Osc_B_PM_FB_Env_C, Shp_B_FB_Env_C, Comb_Flt_Pitch_Env_C,
-                           Comb_Flt_AP_Env_C, Comb_Flt_LP_Env_C, SV_Flt_Cut_Env_C, SV_Flt_Res_Env_C },
-                         states);
+    letEnvCTargetsBlink({ Osc_A_Pitch_Env_C, Osc_A_Fluct_Env_C, Osc_A_PM_FB_Env_C, Shp_A_FB_Env_C, Osc_B_Pitch_Env_C,
+                          Osc_B_Fluct_Env_C, Osc_B_PM_FB_Env_C, Shp_B_FB_Env_C, Comb_Flt_Pitch_Env_C, Comb_Flt_AP_Env_C,
+                          Comb_Flt_LP_Env_C, SV_Flt_Cut_Env_C, SV_Flt_Res_Env_C },
+                        states);
   }
   else if(groupName == "Osc A" || groupName == "Sh A")
   {
@@ -671,6 +671,30 @@ void PanelUnitParameterEditMode::letOscAShaperABlink(const std::vector<int> &tar
         break;
       case C15::PID::SV_Flt_FM:
         if(isSignalFlowingThrough(currentParam) && stateVariableFilterFMAB->getControlPositionValue() < 1)
+          states[static_cast<size_t>(button)] = TwoStateLED::BLINK;
+        break;
+      default:
+        if(isSignalFlowingThrough(currentParam))
+          states[static_cast<size_t>(button)] = TwoStateLED::BLINK;
+        break;
+    }
+  }
+}
+
+void PanelUnitParameterEditMode::letEnvCTargetsBlink(const std::vector<int> &targets, tLedStates &states)
+{
+  auto vg = Application::get().getVGManager()->getCurrentVoiceGroup();
+  auto editBuffer = Application::get().getPresetManager()->getEditBuffer();
+
+  for(auto targetID : targets)
+  {
+    auto currentParam = editBuffer->findParameterByID({ targetID, vg });
+    auto button = m_mappings.findButton(currentParam->getID().getNumber());
+    switch(targetID)
+    {
+      case C15::PID::Shp_A_FB_Env_C:
+      case C15::PID::Shp_B_FB_Env_C:
+        if(currentParam->getControlPositionValue() > 0)
           states[static_cast<size_t>(button)] = TwoStateLED::BLINK;
         break;
       default:

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/PanelUnitParameterEditMode.h
@@ -59,6 +59,7 @@ class PanelUnitParameterEditMode : public UsageMode
   void letTargetsBlink(Parameter *selParam, tLedStates &states);
   void letMacroControlTargetsBlink(tLedStates &states);
   void letOscAShaperABlink(const std::vector<int> &targets, tLedStates &states);
+  void letEnvCTargetsBlink(const std::vector<int> &targets, tLedStates &states);
   void letOscBShaperBBlink(const std::vector<int> &targets, tLedStates &states);
   void letOtherTargetsBlink(const std::vector<int> &targets, tLedStates &states);
   void letReverbBlink(const std::vector<int> &targets, tLedStates &states);


### PR DESCRIPTION
added explicit check for SHP_A/B FB_ENV_C to not indicate when the position is negative, as then the env-c is not active, closes #3656