### PR TITLE
Issue 3663 (2)

### DIFF
--- a/projects/epc/playground/src/device-settings/AlsaFramesPerPeriod.cpp
+++ b/projects/epc/playground/src/device-settings/AlsaFramesPerPeriod.cpp
@@ -37,7 +37,7 @@ Glib::ustring AlsaFramesPerPeriod::save() const
 
 void AlsaFramesPerPeriod::set(int fpp)
 {
-  fpp = std::clamp(fpp, 0, 512);
+  fpp = std::clamp(fpp, 1, 512);
 
   if(std::exchange(m_framesPerPeriod, fpp) != fpp)
     notify();

--- a/projects/epc/playground/src/device-settings/AlsaFramesPerPeriod.h
+++ b/projects/epc/playground/src/device-settings/AlsaFramesPerPeriod.h
@@ -22,6 +22,6 @@ class AlsaFramesPerPeriod : public Setting
  private:
   void loadDefaultValue(C15::Settings::SettingDescriptor::ValueType val) override;
 
-  constexpr static int c_defaultFramesPerPeriod = 0;
+  constexpr static int c_defaultFramesPerPeriod = 16;
   int m_framesPerPeriod = c_defaultFramesPerPeriod;
 };

--- a/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
+++ b/projects/epc/playground/src/device-settings/midi/RoutingSettings.cpp
@@ -38,7 +38,7 @@ void RoutingSettings::load(const Glib::ustring& text, Initiator initiator)
       {
         try
         {
-          m_data.at(idx).at(settingIdx) = map.at(settingIdx) == "1";
+          setState(static_cast<tRoutingIndex>(idx), static_cast<tAspectIndex>(settingIdx), map.at(settingIdx) == "1");
         }
         catch(...)
         {
@@ -52,7 +52,7 @@ void RoutingSettings::load(const Glib::ustring& text, Initiator initiator)
     }
   }
 
-  if(initiator == Initiator::EXPLICIT_LOAD)
+  if(initiator == Initiator::EXPLICIT_LOAD || initiator == Initiator::EXPLICIT_USECASE)
   {
     sanitizeReceiveHWSourcesAndPC();
   }

--- a/projects/shared/configuration/src/settings.yaml
+++ b/projects/shared/configuration/src/settings.yaml
@@ -71,7 +71,7 @@ BenderCurve:
     default: BenderCurves::Normal
 
 EditSmoothingTime:
-    default: 0.0
+    default: 0.1
     display: { scale: LINEAR_200_MS, coarse: 100, fine: 1000 }
 
 Passphrase:
@@ -172,19 +172,24 @@ AutoStartRecorder:
     default: BooleanSettings::BOOLEAN_SETTING_TRUE
 
 RoutingSettings:
+    # Program Changes and HW Sources can exclusively either receive primary or secondary (but not both)
+    # comma-and line-separated table of values
+        # column structure: Send_Primary, Receive_Primary, Send_Secondary, Receive_Secondary, Local
+        # row structure: Pedal1, Pedal2, Pedal3, Pedal4, Bender, Aftertouch, Ribbon1, Ribbon2, ProgramChange, Notes, Ribbon3, Ribbon4
+        # values: 0 - off, 1 - on
     default: |
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
+        1,1,1,0,1,
         1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1,
-        1,1,1,1,1
+        1,1,1,0,1,
+        1,1,1,0,1
 
 GlobalLocalEnable:
     default: BooleanSettings::BOOLEAN_SETTING_TRUE

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/settings/AlsaFramesPerPeriod.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/maps/settings/AlsaFramesPerPeriod.java
@@ -14,7 +14,7 @@ class AlsaFramesPerPeriod extends Setting {
 
 	@Override
 	public Control onValueButtonMouseDown(Position eventPoint) {
-		String v = Window.prompt("Frames per Period (0 = default, 1...512)", "0");
+		String v = Window.prompt("Frames per Period (16 = default, 1...512)", "16");
 		getNonMaps().getServerProxy().setSetting("AlsaFramesPerPeriod", v);
 		return this;
 	}


### PR DESCRIPTION
Most of the Settings appear to be reliably defaultable now, but unfortunately there are some issues remaining _(proposed default values are marked __bold__)_:

Setup: Device Settings
- [x] Edit Smoothing Time has wrong default (0ms ... __20ms__ .. 200ms, default should be 0.1f)

Setup: GUI Settings (Web UI only) are missing
- Selection Auto Scroll? (Off, Parameter, Preset, Parameter and Preset)
- Edit Parameter? (Always, If Selected, Never)
- Show Context Menus, Preset Drag and Drop? (BooleanSettings: __On__, Off)
- Display Scaling Factor? (50%, 75%, __100%__, 125%, 150%)
- Stripe Brightness (Off, 10%, 25%, 50%)
- BitmapCache, Show Developer Options (BooleanSettings: __On__, Off)

Setup: MIDI Settings
- [x] Routings
  - display problem: set all routings off, load factory defaults and observe that nothing seems to have changed, then click on a checkbox and observe that now all checkboxes are in actual default state (see below)
  - [x] actual default is: all on except Prog. Change and HW Sources with exclusive Receive (either __Primary Receive On, Secondary Receive Off__ or Primary Receive Off, Secondary Receive On) _(and Prog. Change is `n.a.` for Local and can be considered permanently Local On)_
:question: The now correct default leads to a slightly different update-problem, now taking two clicks before the other checkboxes update.

Developer Options
- Alsa Frames per Period
  - doesn't show a value unless clicking on `set`, opening an input dialog (raw text input with no validation: only playground stdout reports an error when entering non-numerical text)
    - [x] the text says `Frames per Period (0 = default, 1...512)`, which is wrong (16 is new default, and zero is not considered a valid value)
    - there are better input types to consider, like `number` or `range` (with min/max attributes and some validation out of the box)
    - the setting is declared as `persistent: TRUE`, but no value persists (the text input always shows `0` after clicking set, no matter what was entered before)

closes #3663