### PR TITLE
Hotfix: undo deleting of bank/preset

### DIFF
--- a/projects/epc/playground/src/presets/UndoableVector.h
+++ b/projects/epc/playground/src/presets/UndoableVector.h
@@ -182,7 +182,8 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
     pos = std::min(pos, size());
 
     transaction->addSimpleCommand(
-        [=](auto) {
+        [=](auto)
+        {
           Checker checker(this);
           auto it = std::next(m_elements.begin(), pos);
           swapData->template get<0>()->resume();
@@ -191,7 +192,8 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
 
           invalidateAllChildren();
         },
-        [=](auto) {
+        [=](auto)
+        {
           Checker checker(this);
           auto it = std::next(m_elements.begin(), pos);
           swapData->swapWith(*it);
@@ -232,7 +234,8 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
       auto swapData = UNDO::createSwapData(ElementPtr(nullptr));
 
       transaction->addSimpleCommand(
-          [=](auto) {
+          [=](auto)
+          {
             Checker checker(this);
             auto it = std::next(m_elements.begin(), pos);
             ElementPtr e = std::move(*it);
@@ -245,11 +248,12 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
             swapData->template get<0>()->suspend();
             invalidateAllChildren();
           },
-          [=](auto) {
+          [=](auto)
+          {
             Checker checker(this);
             ElementPtr e;
-            swapData->swapWith(e);
             swapData->template get<0>()->resume();
+            swapData->swapWith(e);
             auto it = std::next(m_elements.begin(), pos);
             m_elements.insert(it, std::move(e));
             invalidateAllChildren();
@@ -305,13 +309,15 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
       }
 
       transaction->addSimpleCommand(
-          [=](auto) {
+          [=](auto)
+          {
             auto it = std::next(m_elements.begin(), pos);
             auto ptr = it->release();
             m_elements.erase(it);
             invalidateAllChildren();
           },
-          [=](auto) {
+          [=](auto)
+          {
             auto it = std::next(m_elements.begin(), pos);
             m_elements.insert(it, ElementPtr(theElement));
             invalidateAllChildren();
@@ -328,12 +334,14 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
     pos = std::min(pos, size());
 
     transaction->addSimpleCommand(
-        [=](auto) {
+        [=](auto)
+        {
           auto it = std::next(m_elements.begin(), pos);
           m_elements.insert(it, ElementPtr(p));
           invalidateAllChildren();
         },
-        [=](auto) {
+        [=](auto)
+        {
           auto it = std::next(m_elements.begin(), pos);
           it->release();
           m_elements.erase(it);
@@ -357,20 +365,22 @@ template <typename Owner, typename Element> class UndoableVector : private Undoa
 
     auto swap = UNDO::createSwapData(order);
 
-    transaction->addSimpleCommand([=](auto) {
-      std::vector<Element *> newOrder;
-      std::transform(m_elements.begin(), m_elements.end(), std::back_inserter(newOrder),
-                     [&](auto &e) { return e.get(); });
-      swap->swapWith(newOrder);
+    transaction->addSimpleCommand(
+        [=](auto)
+        {
+          std::vector<Element *> newOrder;
+          std::transform(m_elements.begin(), m_elements.end(), std::back_inserter(newOrder),
+                         [&](auto &e) { return e.get(); });
+          swap->swapWith(newOrder);
 
-      for(size_t i = 0; i < newOrder.size(); i++)
-      {
-        m_elements[i].release();
-        m_elements[i].reset(newOrder[i]);
-      }
+          for(size_t i = 0; i < newOrder.size(); i++)
+          {
+            m_elements[i].release();
+            m_elements[i].reset(newOrder[i]);
+          }
 
-      invalidateAllChildren();
-    });
+          invalidateAllChildren();
+        });
   }
 
   const std::vector<ElementPtr> &getElements() const

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue3681.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue3681.cpp
@@ -1,0 +1,30 @@
+#include <testing/TestHelper.h>
+#include "testing/unit-tests/mock/MockPresetStorage.h"
+#include <presets/Preset.h>
+#include <http/UndoScope.h>
+
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "delete preset and undo does not lead to crash")
+{
+  MockPresetStorage presets;
+  auto singlePreset = presets.getSinglePreset();
+
+  BankUseCases bankUseCases(static_cast<Bank*>(singlePreset->getParent()), *app->getSettings());
+  bankUseCases.deletePreset(singlePreset);
+
+  app->getUndoScope()->undo();
+  app->getUndoScope()->redo();
+  app->getUndoScope()->undo();
+}
+
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "delete bank and undo does not lead to crash")
+{
+  MockPresetStorage presets;
+  auto singlePreset = presets.getSinglePreset();
+
+  PresetManagerUseCases pmUseCases(*app->getPresetManager(), *app->getSettings());
+  pmUseCases.deleteBank(static_cast<Bank*>(singlePreset->getParent()));
+
+  app->getUndoScope()->undo();
+  app->getUndoScope()->redo();
+  app->getUndoScope()->undo();
+}


### PR DESCRIPTION
hotfix crash by calling resume on a tElement which was pointing to invalid memory in UndoableVector, right after swap. fixes #3681