### PR TITLE
Issue 3690 fix

### DIFF
--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -336,8 +336,9 @@ void C15Synth::onHardwareSourceParameterChangedMessage(const nltools::msg::Hardw
   {
     auto element = m_dsp->getParameter(_msg.m_id);
     const auto didBehaviorChange = m_dsp->updateBehaviour(element, _msg.m_returnMode);
-    m_playgroundHwSourceKnownValues[static_cast<int>(latchIndex)][static_cast<int>(HWChangeSource::UI)]
-        = static_cast<float>(_msg.m_controlPosition);
+    auto latchIdx = static_cast<int>(latchIndex);
+    auto src = static_cast<int>(_msg.m_shouldSendMidi ? HWChangeSource::UI : HWChangeSource::UI_MODULATION);
+    m_playgroundHwSourceKnownValues[latchIdx][src] = static_cast<float>(_msg.m_controlPosition);
     m_inputEventStage.onParameterChangedMessage(_msg, didBehaviorChange);
     return;
   }

--- a/projects/epc/audio-engine/src/synth/C15Synth.h
+++ b/projects/epc/audio-engine/src/synth/C15Synth.h
@@ -77,7 +77,8 @@ class C15Synth : public Synth, public sigc::trackable
 
   //Latch-Filters, Queues
   constexpr static auto tNUM_HW = static_cast<int>(C15::Parameters::Hardware_Sources::_LENGTH_);
-  std::array<std::array<float, 3>, tNUM_HW> m_playgroundHwSourceKnownValues {};
+  constexpr static auto tNUM_HW_SOURCES = static_cast<int>(HWChangeSource::LENGTH);
+  std::array<std::array<float, tNUM_HW_SOURCES>, tNUM_HW> m_playgroundHwSourceKnownValues {};
   RingBuffer<nltools::msg::Midi::SimpleMessage> m_externalMidiOutBuffer;
   RingBuffer<MidiChannelModeMessages> m_queuedChannelModeMessages;
 

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -363,14 +363,16 @@ DSPInterface::OutputResetEventSource dsp_host_dual::onPresetMessage(const nltool
   {
     OutputResetEventSource result;
     // glitch suppression: start outputMute fade
-    m_fade.muteAndDo([&] {
-      // global flush
-      m_poly[0].flushDSP();
-      m_poly[1].flushDSP();
-      m_mono[0].flushDSP();
-      m_mono[1].flushDSP();
-      result = recallSingle(_msg);
-    });
+    m_fade.muteAndDo(
+        [&]
+        {
+          // global flush
+          m_poly[0].flushDSP();
+          m_poly[1].flushDSP();
+          m_mono[0].flushDSP();
+          m_mono[1].flushDSP();
+          result = recallSingle(_msg);
+        });
 
     if constexpr(LOG_RECALL)
     {
@@ -395,14 +397,16 @@ DSPInterface::OutputResetEventSource dsp_host_dual::onPresetMessage(const nltool
   {
     OutputResetEventSource result;
     // glitch suppression: start outputMute fade
-    m_fade.muteAndDo([&] {
-      // global flush
-      m_poly[0].flushDSP();
-      m_poly[1].flushDSP();
-      m_mono[0].flushDSP();
-      m_mono[1].flushDSP();
-      result = recallSplit(_msg);
-    });
+    m_fade.muteAndDo(
+        [&]
+        {
+          // global flush
+          m_poly[0].flushDSP();
+          m_poly[1].flushDSP();
+          m_mono[0].flushDSP();
+          m_mono[1].flushDSP();
+          result = recallSplit(_msg);
+        });
 
     if constexpr(LOG_RECALL)
     {
@@ -426,14 +430,16 @@ DSPInterface::OutputResetEventSource dsp_host_dual::onPresetMessage(const nltool
   {
     OutputResetEventSource result;
     // glitch suppression: start outputMute fade
-    m_fade.muteAndDo([&] {
-      // global flush
-      m_poly[0].flushDSP();
-      m_poly[1].flushDSP();
-      m_mono[0].flushDSP();
-      m_mono[1].flushDSP();
-      result = recallLayer(_msg);
-    });
+    m_fade.muteAndDo(
+        [&]
+        {
+          // global flush
+          m_poly[0].flushDSP();
+          m_poly[1].flushDSP();
+          m_mono[0].flushDSP();
+          m_mono[1].flushDSP();
+          result = recallLayer(_msg);
+        });
 
     if constexpr(LOG_RECALL)
     {
@@ -458,8 +464,10 @@ void dsp_host_dual::onParameterChangedMessage(const nltools::msg::HardwareAmount
 
 void dsp_host_dual::onParameterChangedMessage(const nltools::msg::MacroControlParameterChangedMessage &_msg)
 {
+
   const auto &descriptor = getParameter(_msg.m_id);
   auto &param = m_parameters.m_global.m_macroControls[descriptor.m_param.m_index];
+  nltools::Log::error("onMacroControlParameterChangedMessage!", _msg.m_id, "value", _msg.m_controlPosition);
   if(param.update_position((float) _msg.m_controlPosition))
   {
     if constexpr(LOG_EDITS)
@@ -695,27 +703,29 @@ inline DSPInterface::OutputResetEventSource dsp_host_dual::onUnisonVoicesChanged
   const OutputResetEventSource outputEvent
       = determineOutputEventSource(areKeysPressed(fromType(m_layer_mode)), m_layer_mode);
   // application now via fade point
-  m_fade.muteAndDo([&] {
-    // apply (preloaded) unison change
-    m_alloc.setUnison(_layer, _pos, m_layer_mode, m_layer_mode);
-    // apply reset to affected poly compoments
-    m_poly[_layer].resetEnvelopes();
-    m_poly[_layer].m_uVoice = m_alloc.m_unison - 1;
-    m_poly[_layer].m_key_active = 0;
-    if(m_layer_mode != LayerMode::Split)
-    {
-      m_alloc.m_internal_keys.m_global = 0;
-      // apply reset to other poly components (when not in split mode)
-      const uint32_t layer = 1 - _layer;
-      m_poly[layer].resetEnvelopes();
-      m_poly[layer].m_uVoice = m_alloc.m_unison - 1;
-      m_poly[layer].m_key_active = 0;
-    }
-    else
-    {
-      m_alloc.m_internal_keys.m_local[_layer] = 0;
-    }
-  });
+  m_fade.muteAndDo(
+      [&]
+      {
+        // apply (preloaded) unison change
+        m_alloc.setUnison(_layer, _pos, m_layer_mode, m_layer_mode);
+        // apply reset to affected poly compoments
+        m_poly[_layer].resetEnvelopes();
+        m_poly[_layer].m_uVoice = m_alloc.m_unison - 1;
+        m_poly[_layer].m_key_active = 0;
+        if(m_layer_mode != LayerMode::Split)
+        {
+          m_alloc.m_internal_keys.m_global = 0;
+          // apply reset to other poly components (when not in split mode)
+          const uint32_t layer = 1 - _layer;
+          m_poly[layer].resetEnvelopes();
+          m_poly[layer].m_uVoice = m_alloc.m_unison - 1;
+          m_poly[layer].m_key_active = 0;
+        }
+        else
+        {
+          m_alloc.m_internal_keys.m_local[_layer] = 0;
+        }
+      });
   // return detected reset event
   if(m_layer_mode != LayerMode::Split)
   {
@@ -744,25 +754,27 @@ inline DSPInterface::OutputResetEventSource dsp_host_dual::onMonoEnableChanged(c
   const OutputResetEventSource outputEvent
       = determineOutputEventSource(areKeysPressed(fromType(m_layer_mode)), m_layer_mode);
   // application now via fade point
-  m_fade.muteAndDo([&] {
-    // apply (preloaded) mono change
-    m_alloc.setMonoEnable(_layer, _pos, m_layer_mode);
-    // apply reset to affected poly compoments
-    m_poly[_layer].resetEnvelopes();
-    m_poly[_layer].m_key_active = 0;
-    if(m_layer_mode != LayerMode::Split)
-    {
-      m_alloc.m_internal_keys.m_global = 0;
-      // apply reset to other poly components (when not in split mode)
-      const uint32_t lId = 1 - _layer;
-      m_poly[lId].resetEnvelopes();
-      m_poly[lId].m_key_active = 0;
-    }
-    else
-    {
-      m_alloc.m_internal_keys.m_local[_layer] = 0;
-    }
-  });
+  m_fade.muteAndDo(
+      [&]
+      {
+        // apply (preloaded) mono change
+        m_alloc.setMonoEnable(_layer, _pos, m_layer_mode);
+        // apply reset to affected poly compoments
+        m_poly[_layer].resetEnvelopes();
+        m_poly[_layer].m_key_active = 0;
+        if(m_layer_mode != LayerMode::Split)
+        {
+          m_alloc.m_internal_keys.m_global = 0;
+          // apply reset to other poly components (when not in split mode)
+          const uint32_t lId = 1 - _layer;
+          m_poly[lId].resetEnvelopes();
+          m_poly[lId].m_key_active = 0;
+        }
+        else
+        {
+          m_alloc.m_internal_keys.m_local[_layer] = 0;
+        }
+      });
   // return detected reset event
   if(m_layer_mode != LayerMode::Split)
   {
@@ -990,21 +1002,23 @@ void dsp_host_dual::render()
 
 void dsp_host_dual::reset()
 {
-  m_fade.muteAndDo([&] {
-    for(uint32_t layerId = 0; layerId < C15::Properties::num_of_VoiceGroups; layerId++)
-    {
-      m_z_layers[layerId].reset();
-      m_poly[layerId].resetDSP();
-      m_mono[layerId].resetDSP();
-    }
-    m_alloc.reset();
-    m_global.resetDSP();
-    m_mainOut_L = m_mainOut_R = 0.0f;
-    if constexpr(LOG_RESET)
-    {
-      nltools::Log::info("DSP has been reset.");
-    }
-  });
+  m_fade.muteAndDo(
+      [&]
+      {
+        for(uint32_t layerId = 0; layerId < C15::Properties::num_of_VoiceGroups; layerId++)
+        {
+          m_z_layers[layerId].reset();
+          m_poly[layerId].resetDSP();
+          m_mono[layerId].resetDSP();
+        }
+        m_alloc.reset();
+        m_global.resetDSP();
+        m_mainOut_L = m_mainOut_R = 0.0f;
+        if constexpr(LOG_RESET)
+        {
+          nltools::Log::info("DSP has been reset.");
+        }
+      });
 }
 
 dsp_host_dual::HWSourceValues dsp_host_dual::getHWSourceValues() const
@@ -2251,14 +2265,16 @@ void dsp_host_dual::onKeyUpSplit(const int note, float velocity, VoiceGroup part
 
 void dsp_host_dual::fadeOutResetVoiceAllocAndEnvelopes()
 {
-  m_fade.muteAndDo([&] {
-    m_alloc.reset();
-    for(auto &layerId : m_poly)
-    {
-      layerId.resetEnvelopes();
-      layerId.m_key_active = 0;
-    }
-  });
+  m_fade.muteAndDo(
+      [&]
+      {
+        m_alloc.reset();
+        for(auto &layerId : m_poly)
+        {
+          layerId.resetEnvelopes();
+          layerId.m_key_active = 0;
+        }
+      });
 }
 
 bool dsp_host_dual::updateBehaviour(C15::ParameterDescriptor &element, ReturnMode mode)

--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.cpp
@@ -464,10 +464,8 @@ void dsp_host_dual::onParameterChangedMessage(const nltools::msg::HardwareAmount
 
 void dsp_host_dual::onParameterChangedMessage(const nltools::msg::MacroControlParameterChangedMessage &_msg)
 {
-
   const auto &descriptor = getParameter(_msg.m_id);
   auto &param = m_parameters.m_global.m_macroControls[descriptor.m_param.m_index];
-  nltools::Log::error("onMacroControlParameterChangedMessage!", _msg.m_id, "value", _msg.m_controlPosition);
   if(param.update_position((float) _msg.m_controlPosition))
   {
     if constexpr(LOG_EDITS)

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -869,6 +869,12 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
     m_localDisabledPositions[static_cast<unsigned int>(hwID)] = { pedalPos, source };
     m_hwChangedCB();
   }
+  else if(source == HWChangeSource::UI_MODULATION)
+  {
+    m_dspHost->setHardwareSourceLastChangeSource(hwID, source);
+    m_localDisabledPositions[static_cast<unsigned int>(hwID)] = { pos, source };
+    m_hwChangedCB();
+  }
 
   if(source != HWChangeSource::MIDI)
   {

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -871,7 +871,6 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
   }
   else if(source == HWChangeSource::UI_MODULATION)
   {
-    m_dspHost->setHardwareSourceLastChangeSource(hwID, source);
     m_localDisabledPositions[static_cast<unsigned int>(hwID)] = { pos, source };
     m_hwChangedCB();
   }

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -253,6 +253,8 @@ void InputEventStage::onMIDIEvent()
         onMIDIHWChanged(decoder);
       break;
 
+    case DecoderEventType::PollStart:
+    case DecoderEventType::PollStop:
     case DecoderEventType::UNKNOWN:
       nltools_detailedAssertAlways(false, "Decoded Event should not have UNKNOWN Type");
   }
@@ -271,6 +273,8 @@ void InputEventStage::convertToAndSendMIDI(TCDDecoder *pDecoder, const VoiceGrou
     case DecoderEventType::HardwareChange:
       sendHardwareChangeAsMidi(pDecoder->getHardwareSource(), pDecoder->getValue());
       break;
+    case DecoderEventType::PollStart:
+    case DecoderEventType::PollStop:
     case DecoderEventType::UNKNOWN:
       nltools_assertNotReached();
   }
@@ -755,7 +759,8 @@ void InputEventStage::onParameterChangedMessage(const nltools::msg::HardwareSour
   if(hwID != HardwareSource::NONE)
   {
     auto cp = static_cast<float>(message.m_controlPosition);
-    onHWChanged(hwID, cp, HWChangeSource::UI, false, false, didBehaviourChange);
+    onHWChanged(hwID, cp, message.m_shouldSendMidi ? HWChangeSource::UI : HWChangeSource::UI_MODULATION, false, false,
+                didBehaviourChange);
   }
 }
 
@@ -823,7 +828,8 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
 
   auto routingIndex = hwidToRoutingIndex(hwID);
 
-  auto sendToDSP = [&](auto source, auto hwID, auto wasPrim, auto wasSplit) {
+  auto sendToDSP = [&](auto source, auto hwID, auto wasPrim, auto wasSplit)
+  {
     switch(source)
     {
       case HWChangeSource::MIDI:
@@ -836,6 +842,8 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
       }
       case HWChangeSource::TCD:
         return m_options->shouldAllowLocal(routingIndex);
+      case HWChangeSource::UI_MODULATION:
+        return false;
       case HWChangeSource::UI:
         return true;
       default:
@@ -850,7 +858,7 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
     m_localDisabledPositions[static_cast<unsigned int>(hwID)] = { pos, source };
     m_hwChangedCB();
   }
-  else if(source != HWChangeSource::MIDI)
+  else if(source != HWChangeSource::MIDI && source != HWChangeSource::UI_MODULATION)
   {
     auto pedalPos = pos;
     const auto isPedal = hwID >= HardwareSource::PEDAL1 && hwID <= HardwareSource::PEDAL4;
@@ -873,7 +881,14 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
     if(source == HWChangeSource::UI)
     {
       if(m_options->isLocalEnabled(hwID))
+      {
         sendHardwareChangeAsMidi(hwID, pos);
+      }
+    }
+    if(source == HWChangeSource::UI_MODULATION)
+    {
+      nltools::Log::info("we do not send the hw-source (" + toString(source)
+                         + ") as midi as the hw-change-source is ui_modulation");
     }
     else
     {

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -891,12 +891,7 @@ void InputEventStage::onHWChanged(HardwareSource hwID, float pos, HWChangeSource
         sendHardwareChangeAsMidi(hwID, pos);
       }
     }
-    if(source == HWChangeSource::UI_MODULATION)
-    {
-      nltools::Log::info("we do not send the hw-source (" + toString(source)
-                         + ") as midi as the hw-change-source is ui_modulation");
-    }
-    else
+    else if(source != HWChangeSource::UI_MODULATION)
     {
       sendHardwareChangeAsMidi(hwID, pos);
     }

--- a/projects/epc/playground/src/parameters/MacroControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/MacroControlParameter.cpp
@@ -202,10 +202,12 @@ void MacroControlParameter::undoableSetGivenName(UNDO::Transaction *transaction,
   if(m_givenName != newName)
   {
     auto swapData = UNDO::createSwapData(newName);
-    transaction->addSimpleCommand([=](UNDO::Command::State) mutable {
-      swapData->swapWith(m_givenName);
-      invalidate();
-    });
+    transaction->addSimpleCommand(
+        [=](UNDO::Command::State) mutable
+        {
+          swapData->swapWith(m_givenName);
+          invalidate();
+        });
   }
 }
 
@@ -215,10 +217,12 @@ void MacroControlParameter::undoableSetInfo(UNDO::Transaction *transaction, cons
   {
     auto swapData = UNDO::createSwapData(info);
 
-    transaction->addSimpleCommand([=](UNDO::Command::State) mutable {
-      swapData->swapWith(m_info);
-      invalidate();
-    });
+    transaction->addSimpleCommand(
+        [=](UNDO::Command::State) mutable
+        {
+          swapData->swapWith(m_info);
+          invalidate();
+        });
   }
 }
 
@@ -276,7 +280,8 @@ Glib::ustring MacroControlParameter::getLongName() const
 
   auto replace = [](auto s, auto p, auto r) { return StringTools::replaceAll(s, p, r); };
 
-  auto invertLabel = [replace](auto str) {
+  auto invertLabel = [replace](auto str)
+  {
     auto mcA = replace(str, "\uE000", "\uE400");
     auto mcB = replace(mcA, "\uE001", "\uE401");
     auto mcC = replace(mcB, "\uE002", "\uE402");

--- a/projects/epc/playground/src/parameters/Parameter.h
+++ b/projects/epc/playground/src/parameters/Parameter.h
@@ -146,12 +146,12 @@ class Parameter : public UpdateDocumentContributor,
   [[nodiscard]] C15::Descriptors::ParameterType getType() const;
   bool isMonophonic() const;
   bool isPolyphonic() const;
-  void sendParameterMessage() const;
+  void sendParameterMessage(bool sendAsMidi = true) const;
 
   bool isScale() const;
 
  protected:
-  virtual void sendToAudioEngine() const;
+  virtual void sendToAudioEngine(bool sendAsMidi = true) const;
   virtual void setCpValue(UNDO::Transaction *transaction, Initiator initiator, tControlPositionValue value,
                           bool notifyAudioEngine);
   virtual void writeDocProperties(Writer &writer, tUpdateID knownRevision) const;

--- a/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
+++ b/projects/epc/playground/src/parameters/PhysicalControlParameter.cpp
@@ -48,9 +48,13 @@ ReturnMode PhysicalControlParameter::getLastReturnModeBeforePresetLoad() const
 void PhysicalControlParameter::onChangeFromExternalSource(tControlPositionValue newValue, HWChangeSource source)
 {
   if(source == HWChangeSource::MIDI)
+  {
     getValue().setRawValue(Initiator::EXPLICIT_MIDI, getValue().getFineQuantizedClippedValue(newValue));
+  }
   else
+  {
     getValue().setRawValue(Initiator::EXPLICIT_PLAYCONTROLLER, getValue().getFineQuantizedClippedValue(newValue));
+  }
 }
 
 void PhysicalControlParameter::setCPFromHwui(UNDO::Transaction *transaction, const tControlPositionValue &cpValue)
@@ -133,7 +137,8 @@ size_t PhysicalControlParameter::getHash() const
 Glib::ustring PhysicalControlParameter::generateName() const
 {
   auto it = std::max_element(m_targets.begin(), m_targets.end(),
-                             [](const ModulationRoutingParameter *a, const ModulationRoutingParameter *b) {
+                             [](const ModulationRoutingParameter *a, const ModulationRoutingParameter *b)
+                             {
                                auto fa = fabs(a->getControlPositionValue());
                                auto fb = fabs(b->getControlPositionValue());
 
@@ -285,7 +290,8 @@ bool PhysicalControlParameter::lockingEnabled() const
 
 HardwareSourceSendParameter *PhysicalControlParameter::getSendParameter() const
 {
-  auto idToSendID = [](auto id) {
+  auto idToSendID = [](auto id)
+  {
     switch(id.getNumber())
     {
       case C15::PID::Pedal_1:

--- a/projects/epc/playground/src/parameters/RibbonParameter.cpp
+++ b/projects/epc/playground/src/parameters/RibbonParameter.cpp
@@ -37,10 +37,12 @@ void RibbonParameter::undoableSetRibbonTouchBehaviour(UNDO::Transaction *transac
   {
     auto swapData = UNDO::createSwapData(mode);
 
-    transaction->addSimpleCommand([=](UNDO::Command::State) mutable {
-      swapData->swapWith(m_touchBehaviour);
-      setupScalingAndDefaultValue(false);
-    });
+    transaction->addSimpleCommand(
+        [=](UNDO::Command::State) mutable
+        {
+          swapData->swapWith(m_touchBehaviour);
+          setupScalingAndDefaultValue(false);
+        });
   }
   else
   {
@@ -142,25 +144,27 @@ void RibbonParameter::undoableSetRibbonReturnMode(UNDO::Transaction *transaction
 
     undoableSetHWAmountsForReturnToCenterMode(transaction, mode);
 
-    transaction->addSimpleCommand([=](UNDO::Command::State) mutable {
-      auto oldMode = m_returnMode;
-      swapData->swapWith(m_returnMode);
-      auto oldPos = getControlPositionValue();
-      setupScalingAndDefaultValue(initiator == Initiator::EXPLICIT_USECASE
-                                  && getRibbonReturnMode() == RibbonReturnMode::RETURN);
-      if(initiator == Initiator::EXPLICIT_USECASE && oldMode == RibbonReturnMode::RETURN
-         && getRibbonReturnMode() == RibbonReturnMode::STAY)
-      {
-        auto newPos = (oldPos * 0.5) + 0.5;
-        getValue().setRawValue(initiator, newPos);
-      }
-      else if(initiator == Initiator::EXPLICIT_LOAD && oldMode == RibbonReturnMode::STAY
-              && getRibbonReturnMode() == RibbonReturnMode::RETURN)
-      {
-        setupScalingAndDefaultValue(true);
-      }
-      onChange();
-    });
+    transaction->addSimpleCommand(
+        [=](UNDO::Command::State) mutable
+        {
+          auto oldMode = m_returnMode;
+          swapData->swapWith(m_returnMode);
+          auto oldPos = getControlPositionValue();
+          setupScalingAndDefaultValue(initiator == Initiator::EXPLICIT_USECASE
+                                      && getRibbonReturnMode() == RibbonReturnMode::RETURN);
+          if(initiator == Initiator::EXPLICIT_USECASE && oldMode == RibbonReturnMode::RETURN
+             && getRibbonReturnMode() == RibbonReturnMode::STAY)
+          {
+            auto newPos = (oldPos * 0.5) + 0.5;
+            getValue().setRawValue(initiator, newPos);
+          }
+          else if(initiator == Initiator::EXPLICIT_LOAD && oldMode == RibbonReturnMode::STAY
+                  && getRibbonReturnMode() == RibbonReturnMode::RETURN)
+          {
+            setupScalingAndDefaultValue(true);
+          }
+          onChange();
+        });
   }
   else
   {
@@ -284,10 +288,13 @@ void RibbonParameter::copyTo(UNDO::Transaction *transaction, PresetParameter *ot
 
 void RibbonParameter::boundToMacroControl(tControlPositionValue v)
 {
-  getValue().setRawValue(Initiator::INDIRECT, v);
-  onChange();
-  invalidate();
-  sendToAudioEngine();
+  if(getValue().getFineQuantizedClippedValue(v) != getValue().getQuantizedClippedValue(true))
+  {
+    getValue().setRawValue(Initiator::INDIRECT, v);
+    onChange();
+    invalidate();
+    sendToAudioEngine(false);
+  }
 }
 
 RoutingSettings::tRoutingIndex indexFromID(const ParameterId &id)
@@ -373,9 +380,9 @@ size_t RibbonParameter::getHash() const
   return hash;
 }
 
-void RibbonParameter::sendToAudioEngine() const
+void RibbonParameter::sendToAudioEngine(bool shouldSendMidi) const
 {
-  PhysicalControlParameter::sendToAudioEngine();
+  PhysicalControlParameter::sendToAudioEngine(shouldSendMidi);
 
   auto proxy = Application::get().getPlaycontrollerProxy();
   const auto id = getID().getNumber();

--- a/projects/epc/playground/src/parameters/RibbonParameter.cpp
+++ b/projects/epc/playground/src/parameters/RibbonParameter.cpp
@@ -288,13 +288,10 @@ void RibbonParameter::copyTo(UNDO::Transaction *transaction, PresetParameter *ot
 
 void RibbonParameter::boundToMacroControl(tControlPositionValue v)
 {
-  if(getValue().getFineQuantizedClippedValue(v) != getValue().getQuantizedClippedValue(true))
-  {
-    getValue().setRawValue(Initiator::INDIRECT, v);
-    onChange();
-    invalidate();
-    sendToAudioEngine(false);
-  }
+  getValue().setRawValue(Initiator::INDIRECT, v);
+  onChange();
+  invalidate();
+  sendToAudioEngine(false);
 }
 
 RoutingSettings::tRoutingIndex indexFromID(const ParameterId &id)

--- a/projects/epc/playground/src/parameters/RibbonParameter.h
+++ b/projects/epc/playground/src/parameters/RibbonParameter.h
@@ -50,7 +50,7 @@ class RibbonParameter : public PhysicalControlParameter
   Glib::ustring getCurrentBehavior() const override;
   void undoableStepBehavior(UNDO::Transaction *transaction, int direction) override;
   size_t getHash() const override;
-  void sendToAudioEngine() const override;
+  void sendToAudioEngine(bool shouldSendMidi = true) const override;
 
  private:
   void ensureExclusiveRoutingIfNeeded(UNDO::Transaction *transaction);

--- a/projects/epc/playground/src/parameters/messaging/ParameterMessageFactory.h
+++ b/projects/epc/playground/src/parameters/messaging/ParameterMessageFactory.h
@@ -9,19 +9,19 @@
 namespace ParameterMessageFactory
 {
 
-  template <C15::Descriptors::ParameterType, typename T> auto createParameterChangedMessage(const T *);
-
+  template <C15::Descriptors::ParameterType, typename T> auto createParameterChangedMessage(const T *, bool sendAsMidi);
 };
 
 template <>
 inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Hardware_Source>(
-    const PhysicalControlParameter *param)
+    const PhysicalControlParameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::HardwareSourceParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
   ret.m_controlPosition = param->getControlPositionValue();
   ret.m_returnMode = param->getReturnMode();
   ret.m_isLocalEnabled = param->isLocalEnabled();
+  ret.m_shouldSendMidi = sendAsMidi;
   // safety proposal: id pointing to non hw-source descriptor will fail
   nltools_assertAlways(ret.validateParameterType());
   return ret;
@@ -29,7 +29,7 @@ inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descript
 
 template <>
 inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Display_Parameter>(
-    const HardwareSourceSendParameter *param)
+    const HardwareSourceSendParameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::HardwareSourceSendParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -44,7 +44,7 @@ inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descript
 
 template <>
 inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Hardware_Amount>(
-    const ModulationRoutingParameter *param)
+    const ModulationRoutingParameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::HardwareAmountParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -56,7 +56,7 @@ inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descript
 
 template <>
 inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Macro_Control>(
-    const MacroControlParameter *param)
+    const MacroControlParameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::MacroControlParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -68,7 +68,7 @@ inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descript
 
 template <>
 inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Macro_Time>(
-    const Parameter *param)
+    const Parameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::MacroTimeParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -81,7 +81,7 @@ inline auto ParameterMessageFactory::createParameterChangedMessage<C15::Descript
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Global_Modulateable>(
-        const ModulateableParameter *param)
+        const ModulateableParameter *param, bool sendAsMidi)
 {
   const auto range = param->getModulationRange(false);
   auto ret = nltools::msg::GlobalModulateableParameterChangedMessage {};
@@ -100,7 +100,7 @@ inline auto
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Global_Unmodulateable>(
-        const Parameter *param)
+        const Parameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::GlobalUnmodulateableParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -114,7 +114,7 @@ inline auto
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Polyphonic_Modulateable>(
-        const ModulateableParameter *param)
+        const ModulateableParameter *param, bool sendAsMidi)
 {
   const auto range = param->getModulationRange(false);
   auto ret = nltools::msg::PolyphonicModulateableParameterChangedMessage {};
@@ -133,7 +133,7 @@ inline auto
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Polyphonic_Unmodulateable>(
-        const Parameter *param)
+        const Parameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::PolyphonicUnmodulateableParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();
@@ -147,7 +147,7 @@ inline auto
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Monophonic_Modulateable>(
-        const ModulateableParameter *param)
+        const ModulateableParameter *param, bool sendAsMidi)
 {
   const auto range = param->getModulationRange(false);
   auto ret = nltools::msg::MonophonicModulateableParameterChangedMessage {};
@@ -166,7 +166,7 @@ inline auto
 template <>
 inline auto
     ParameterMessageFactory::createParameterChangedMessage<C15::Descriptors::ParameterType::Monophonic_Unmodulateable>(
-        const Parameter *param)
+        const Parameter *param, bool sendAsMidi)
 {
   auto ret = nltools::msg::MonophonicUnmodulateableParameterChangedMessage {};
   ret.m_id = (C15::PID::ParameterID) param->getID().getNumber();

--- a/projects/shared/nltools-2/include/ParameterMessages.h
+++ b/projects/shared/nltools-2/include/ParameterMessages.h
@@ -54,6 +54,7 @@ namespace nltools
           public controls::HardwareSourceParameter
     {
       bool m_isLocalEnabled = {};
+      bool m_shouldSendMidi = true;
     };
 
     struct HardwareSourceSendParameterChangedMessage

--- a/projects/shared/nltools/include/nltools/Types.h
+++ b/projects/shared/nltools/include/nltools/Types.h
@@ -62,7 +62,7 @@ ENUM(AftertouchCurves, int8_t, AFTERTOUCH_CURVE_SOFT = 0, AFTERTOUCH_CURVE_NORMA
 ENUM(VelocityCurves, int8_t, VELOCITY_CURVE_VERY_SOFT = 0, VELOCITY_CURVE_SOFT = 1, VELOCITY_CURVE_NORMAL = 2,
      VELOCITY_CURVE_HARD = 3, VELOCITY_CURVE_VERY_HARD = 4)
 
-ENUM(HWChangeSource, int8_t, TCD = 0, MIDI = 1, UI = 2)
+ENUM(HWChangeSource, int8_t, TCD = 0, MIDI = 1, UI = 2, UI_MODULATION = 3, LENGTH = 4)
 
 ENUM(MidiHWChangeSpecialCases, uint16_t, ChannelPitchbend, Aftertouch, PitchbendUp, PitchbendDown, CC)
 


### PR DESCRIPTION
added argument to sendParameterMessage to indicate wether or not the
event should be send via midi. this argument is always true except for the case where a ribbon is changed via the bound macro-control. then we dont want to send the value, but we have to update the latched values (but I have not yet understood why)