### PR TITLE
fixup: access to hashtags now works again

### DIFF
--- a/projects/epc/playground/src/presets/Preset.cpp
+++ b/projects/epc/playground/src/presets/Preset.cpp
@@ -378,7 +378,7 @@ nlohmann::json Preset::serialize() const
            { "part-I-name", getVoiceGroupName(VoiceGroup::I) },
            { "part-II-name", getVoiceGroupName(VoiceGroup::II) },
            { "attributes", AttributesOwner::toJson() },
-           { "Hashtags", getHashtags() } };
+           { "properties", getHashtags() } };
 }
 
 Glib::ustring Preset::getTypeUnicode() const

--- a/projects/web/client/nonmaps-preset-search/search.ts
+++ b/projects/web/client/nonmaps-preset-search/search.ts
@@ -77,7 +77,7 @@ function doesPresetMatch(preset: any, searchOptions: SearchOptions, subquery: St
     if (searchOptions.searchInDeviceName && preset['attributes']['DeviceName'] && preset['attributes']['DeviceName'].toLowerCase().includes(subquery))
         return true;
 
-    if (searchOptions.searchInHashtags && preset['attributes']['Hashtags'] && preset['attributes']['Hashtags'].toLowerCase().includes(subquery))
+    if (searchOptions.searchInHashtags && preset['properties'] && preset['properties'].toLowerCase().includes(subquery))
         return true;
     return false;
 }


### PR DESCRIPTION
feature now works for all preset-managers, as I developed this feature i had the hashtags/properties as part of the attributes for a short while, then i removed that but did not pay attention that my local preset-manager still had those attributes. local testing suggested that the preset-search by hashtags was working, but it was only working for the old preset-manager. closes #3700