### PR TITLE
fix ribbon leds not set to 100% upon shutdown

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/FourStateLED.h
+++ b/projects/epc/playground/src/proxies/hwui/FourStateLED.h
@@ -18,9 +18,9 @@ class FourStateLED : public LED
     Bright = 3
   };
 
-  void setState(State state);
+  void setState(State state, bool throttle = true);
   [[nodiscard]] State getState() const;
-  void syncHWUI();
+  void syncHWUI(bool throttle = true);
 
  private:
   Throttler m_syncThrottler;


### PR DESCRIPTION
add option to send the led state non-throttled -> only do that when we are shutting down, as the throttler would be destroyed before it has a chance to send its state, closes #3705