### PR TITLE
issue 3694 - experimental

### DIFF
--- a/projects/web/static/online-help/src/css/content.css
+++ b/projects/web/static/online-help/src/css/content.css
@@ -12,6 +12,7 @@ body {
     grid-template-rows: auto var(--unit-menu);
     width: 100vw;
     height: 100vh;
+    height: 100svh; /* prefer small viewport height, do not clip headers on mobile? */
     overflow: hidden;
     user-select: none;
 }

--- a/projects/web/static/online-help/src/css/main.css
+++ b/projects/web/static/online-help/src/css/main.css
@@ -486,6 +486,7 @@ svg.image-container a {
     body {
         width: 100vw;
         height: 100vh;
+        height: 100svh; /* prefer small viewport height, do not clip headers on mobile? */
         overflow: hidden;
     }
 


### PR DESCRIPTION
- [x] added [small viewport height](https://caniuse.com/viewport-unit-variants) as preferred height for mobile browser
- [ ] test on mobile device in portrait mode: the current path and hamburger menu should be visible on top
![man-mobile-menu](https://user-images.githubusercontent.com/37212609/228505875-539b5870-aa22-433a-acb0-53a982885803.png)
