### PR TITLE
reintroduced check for send-active-sensing setting, closes #3722

### DIFF
--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -21,7 +21,8 @@ C15Synth::C15Synth(AudioEngineOptions* options)
                                   [this]
                                   {
                                     nltools::msg::Midi::SimpleMessage msg { 0xFE };
-                                    queueExternalMidiOut(msg);
+                                    if(m_midiOptions.shouldSendActiveSensing())
+                                      queueExternalMidiOut(msg);
                                   },
                                   Expiration::Duration(std::chrono::milliseconds(250)) }
 {


### PR DESCRIPTION
closes #3722 