### PR TITLE
MIDI: only send active-sensing after midi message from PG got received

### DIFF
--- a/projects/epc/audio-engine/src/synth/C15Synth.cpp
+++ b/projects/epc/audio-engine/src/synth/C15Synth.cpp
@@ -20,9 +20,11 @@ C15Synth::C15Synth(AudioEngineOptions* options)
     , m_activeSensingExpiration { Glib::MainContext::get_default(),
                                   [this]
                                   {
-                                    nltools::msg::Midi::SimpleMessage msg { 0xFE };
-                                    if(m_midiOptions.shouldSendActiveSensing())
+                                    if(m_midiOptions.shouldSendActiveSensing() && m_didReceiveMidiSettings)
+                                    {
+                                      nltools::msg::Midi::SimpleMessage msg { 0xFE };
                                       queueExternalMidiOut(msg);
+                                    }
                                   },
                                   Expiration::Duration(std::chrono::milliseconds(250)) }
 {
@@ -431,6 +433,7 @@ void C15Synth::onMidiSettingsMessage(const nltools::msg::Setting::MidiSettingsMe
   auto oldMsg = m_midiOptions.getLastReceivedMessage();
   m_midiOptions.update(msg);
   m_inputEventStage.onMidiSettingsMessageWasReceived(msg, oldMsg);
+  m_didReceiveMidiSettings = true;
 }
 
 void C15Synth::onPanicNotificationReceived(const nltools::msg::PanicAudioEngine&)

--- a/projects/epc/audio-engine/src/synth/C15Synth.h
+++ b/projects/epc/audio-engine/src/synth/C15Synth.h
@@ -91,4 +91,5 @@ class C15Synth : public Synth, public sigc::trackable
   std::atomic<bool> m_quit { false };
   std::future<void> m_syncExternalsTask;
   Expiration m_activeSensingExpiration;
+  bool m_didReceiveMidiSettings = false;
 };


### PR DESCRIPTION
added boolean flag that will be set when midi-settings are received, and if we did not receive the settings from the playground yet we do not send active-sensing, closes #3728