### PR TITLE
Unit-Tests add [slow] tag

### DIFF
--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue2905.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue2905.cpp
@@ -3,7 +3,7 @@
 #include "CompileTimeOptions.h"
 #include <iostream>
 
-TEST_CASE_METHOD(TestHelper::ApplicationFixture, "Sort Bank Numbers deletes Banks!", "[2905]")
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "Sort Bank Numbers deletes Banks!", "[2905][slow]")
 {
   Application::get().stopWatchDog();
 

--- a/projects/epc/playground/src/testing/unit-tests/issues/Issue3343.cpp
+++ b/projects/epc/playground/src/testing/unit-tests/issues/Issue3343.cpp
@@ -19,7 +19,7 @@ TEST_CASE("File in Stream")
   CHECK(StringTools::hasEnding("", ".zip") == false);
 }
 
-TEST_CASE_METHOD(TestHelper::ApplicationFixture, "3343 - Can't Load Backup")
+TEST_CASE_METHOD(TestHelper::ApplicationFixture, "3343 - Can't Load Backup", "[slow]")
 {
   const auto backupFileNotBroken
       = getSourceDir() + "/projects/epc/playground/test-resources/2022-10-04-15-30-nonlinear-c15-banks.xml.tar.gz";


### PR DESCRIPTION
added [slow] tag to tests which take way over 20 seconds to run, when invoking the test-application we can pass this argument now: `~[slow]`  to exclude those tests from the test-run 