### PR TITLE
WebUI/HWUI: cleanup properties/hashtag displays

### DIFF
--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetPropertyDisplay.cpp
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetPropertyDisplay.cpp
@@ -1,5 +1,6 @@
 #include "PresetPropertyDisplay.h"
 #include "proxies/hwui/controls/Label.h"
+#include <proxies/hwui/Font.h>
 
 PresetPropertyDisplay::PresetPropertyDisplay()
     : ControlWithChildren({ 0, 0, 0, 0 })
@@ -18,12 +19,32 @@ PresetPropertyDisplay::PresetPropertyDisplay()
 void PresetPropertyDisplay::setPosition(const Rect &rect)
 {
   Control::setPosition(rect);
-  auto totalWidth = rect.getWidth() - 5;
-  auto oneQuarter = totalWidth / 4;
-  m_type->setPosition({ 0, 0, oneQuarter, rect.getHeight() });
-  m_unison->setPosition({ 0 + oneQuarter, 0, oneQuarter, rect.getHeight() });
-  m_mono->setPosition({ 0 + oneQuarter * 2, 0, oneQuarter, rect.getHeight() });
-  m_scale->setPosition({ 0 + oneQuarter * 3, 0, oneQuarter, rect.getHeight() });
+  repositionLabels();
+}
+
+void PresetPropertyDisplay::repositionLabels()
+{
+  auto rect = getPosition();
+
+  auto margin = 2;
+
+  auto to_int = [](auto v) { return static_cast<int>(v); };
+
+  auto fontW = to_int(m_type->getFont()->getStringWidth(m_type->getText().text));
+  auto unisonW = to_int(m_unison->getFont()->getStringWidth(m_unison->getText().text));
+  auto monoW = to_int(m_mono->getFont()->getStringWidth(m_mono->getText().text));
+  auto scaleW = to_int(m_scale->getFont()->getStringWidth(m_scale->getText().text));
+
+  int xPos = 0;
+  auto height = rect.getHeight();
+
+  m_type->setPosition({ xPos, 0, fontW, height });
+  xPos += (fontW + margin);
+  m_unison->setPosition({ xPos, 0, unisonW, height });
+  xPos += (unisonW + margin);
+  m_mono->setPosition({ xPos, 0, monoW, height });
+  xPos += (monoW + margin);
+  m_scale->setPosition({ xPos, 0, scaleW, height });
 }
 
 void PresetPropertyDisplay::updateFrom(const Glib::ustring &text)
@@ -61,4 +82,6 @@ void PresetPropertyDisplay::updateFrom(const Glib::ustring &text)
     m_mono->setFontColor(highlightColor);
     m_scale->setFontColor(highlightColor);
   }
+
+  repositionLabels();
 }

--- a/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetPropertyDisplay.h
+++ b/projects/epc/playground/src/proxies/hwui/panel-unit/boled/preset-screens/controls/PresetPropertyDisplay.h
@@ -10,6 +10,7 @@ class PresetPropertyDisplay : public ControlWithChildren
   PresetPropertyDisplay();
   void updateFrom(const Glib::ustring& text);
   void setPosition(const Rect& rect) override;
+  void repositionLabels();
 
  private:
   Label* m_type;

--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/InfoDialog/PresetPropertiesLabels.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/InfoDialog/PresetPropertiesLabels.java
@@ -19,10 +19,6 @@ public class PresetPropertiesLabels {
         panel.add(mono = new Label());
         panel.add(scale = new Label());
 		panel.getElement().addClassName("hashtag-div");
-
-        for (Label label: new Label[]{type, unison, mono, scale}) {
-            label.getElement().addClassName("preset-property-label");
-        }
 	}
 
 	public HTMLPanel getHTML() {

--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
@@ -1973,10 +1973,6 @@ we have to use !important here as the styles get set from within the GWTDialog
   display: flex;
 }
 
-.preset-property-label {
-  /*width: 25%;*/
-}
-
 .preset-property-label-lowlight {
   color: #939393;
 }

--- a/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
+++ b/projects/web/static/nonmaps/src/main/webapp/NonMaps.css
@@ -1974,8 +1974,7 @@ we have to use !important here as the styles get set from within the GWTDialog
 }
 
 .preset-property-label {
-  width: 25%;
-
+  /*width: 25%;*/
 }
 
 .preset-property-label-lowlight {


### PR DESCRIPTION
fixup display of preset-hashtags in webui and hwui -> do not use 25% of the total with but use flex-layout in webUI and margin in HWUI, closes #3733, closes #3710