### PR TITLE
WebUI: fixup Fade Indicators can be 'clicked'

### DIFF
--- a/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/FadeIndicator.java
+++ b/projects/web/static/nonmaps/src/main/java/com/nonlinearlabs/client/world/overlay/belt/sound/FadeIndicator.java
@@ -18,4 +18,9 @@ public class FadeIndicator extends SVGImage {
             return true;
         });
     }
+
+    @Override
+    protected boolean hasMouseOver() {
+        return false;
+    }
 }


### PR DESCRIPTION
disabled mouse-over animation states for Fade-Range symbol. closes #3784