### PR TITLE
Midi Settings - Reset Hotfix (2)

### DIFF
--- a/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
+++ b/projects/epc/audio-engine/src/synth/c15-audio-engine/dsp_host_dual.h
@@ -38,7 +38,7 @@ inline constexpr bool LOG_INIT = false;
 inline constexpr bool LOG_MIDI_TCD = false;
 inline constexpr bool LOG_MIDI_RAW = false;
 inline constexpr bool LOG_MIDI_DETAIL = false;
-inline constexpr bool LOG_MIDI_OUT = false;
+inline constexpr bool LOG_MIDI_OUT = false; // unused
 inline constexpr bool LOG_DISPATCH = false;
 inline constexpr bool LOG_EDITS = false;
 inline constexpr bool LOG_TIMES = false;
@@ -100,8 +100,13 @@ class DSPInterface
   virtual void resetReturningHWSource(HardwareSource hwui)
   {
   }
-  // areKeysPressed
-  virtual bool areKeysPressed(SoundType _current)
+  // areInternalKeysPressed (local on or off)
+  virtual bool areInternalKeysPressed(SoundType _current)
+  {
+    return true;
+  }
+  // areExternalKeysPressed (midi - primary or secondary)
+  virtual bool areExternalKeysPressed(SoundType _current)
   {
     return true;
   }
@@ -181,7 +186,8 @@ class dsp_host_dual : public DSPInterface
   using SimpleRawMidiMessage = nltools::msg::Midi::SimpleMessage;
   float getReturnValueFor(HardwareSource hwid) override;
   void resetReturningHWSource(HardwareSource hwui) override;
-  bool areKeysPressed(SoundType _current) override;
+  bool areInternalKeysPressed(SoundType _current) override;
+  bool areExternalKeysPressed(SoundType _current) override;
   using MidiOut = std::function<void(const SimpleRawMidiMessage&)>;
   void onHWChanged(HardwareSource id, float value, bool didBehaviourChange) override;
   void onKeyDown(const int note, float velocity, InputEventSource from) override;
@@ -303,13 +309,14 @@ class dsp_host_dual : public DSPInterface
   inline void initSmoothing(const C15::ParameterDescriptor& _desc);
   inline void initSmoothing(const uint32_t& _layer, const C15::ParameterDescriptor& _desc);
 
-  // handles for inconvenient stuff
+  // handles for inconvenient stuff, abstractions
   C15::Properties::HW_Return_Behavior getBehavior(const ReturnMode _mode);
   C15::Properties::HW_Return_Behavior getBehavior(const RibbonReturnMode _mode);
   C15::Parameters::Macro_Controls getMacro(const MacroControls _mc);
   uint32_t getMacroId(const MacroControls _mc);
   C15::Properties::LayerId getLayer(const VoiceGroup _vg);
   uint32_t getLayerId(const VoiceGroup _vg);
+  bool areKeysPressedImpl(SoundType _current, const AssignedKeyCount &_counter);
 
   // key events
   void keyDownTraversal(const AllocatorId _alloc, const uint32_t _note, const float _vel, const AllocatorId _retrigger_mono);

--- a/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
+++ b/projects/epc/audio-engine/src/synth/input/InputEventStage.cpp
@@ -1135,7 +1135,12 @@ bool InputEventStage::didRelevantSectionsChange(const InputEventStage::tMSG &msg
 
 void InputEventStage::onMidiSettingsMessageWasReceived(const tMSG &msg, const tMSG &oldmsg)
 {
-  if(didRelevantSectionsChange(msg, oldmsg) && m_dspHost->areKeysPressed(m_dspHost->getType()))
+  // "broad and lazy" approach: if any internal OR external key is pressed ...
+  const bool internal_keys_are_pressed = m_dspHost->areInternalKeysPressed(m_dspHost->getType());
+  const bool external_keys_are_pressed = m_dspHost->areExternalKeysPressed(m_dspHost->getType());
+  const bool keys_are_pressed = internal_keys_are_pressed || external_keys_are_pressed;
+  // ... an internal (Envelopes, VoiceAllocation) AND external (AllNotesOff) reset occurs
+  if(didRelevantSectionsChange(msg, oldmsg) && keys_are_pressed)
   {
     doInternalReset();
     doExternalReset(msg, oldmsg);


### PR DESCRIPTION
- [x] refactored `areKeysPressed` into internal and external variants
- [x] using both in midi settings change detection
- (documentation follows on separate branch)
closes #3803 