### PR TITLE
What's New 23-26

### DIFF
--- a/projects/shared/version.h
+++ b/projects/shared/version.h
@@ -27,7 +27,7 @@
 //
 //  Final Versions         "YY-WW"   YY-WW : release date (tbd).
 //  Everything else        whatever seems appropriate
-#define C15_VERSION_STRING "23-24"
+#define C15_VERSION_STRING "23-26"
 #pragma message("make sure version string '" C15_VERSION_STRING "' is up-to date when building a release or beta")
 
 // do not change these two strings:

--- a/projects/web/static/online-help/src/_menu.html
+++ b/projects/web/static/online-help/src/_menu.html
@@ -60,9 +60,9 @@
         <!-- info field -->
         <dl class="info">
             <dt>SW Version</dt>
-            <dd><span class="sw-version normal">23-24</span></dd>
+            <dd><span class="sw-version normal">23-26</span></dd>
             <dt>Date</dt>
-            <dd>2023-06-13</dd>
+            <dd>2023-06-22</dd>
         </dl>
     </footer>
 </body>

--- a/projects/web/static/online-help/src/documents/_content.html
+++ b/projects/web/static/online-help/src/documents/_content.html
@@ -47,9 +47,9 @@
                 
                     <ul class="toc child">
 
-                        <li data-pathname="23-24">
+                        <li data-pathname="23-26">
                         
-<a href="./documents/change-log/23-24.html" class="label"><span class="sw-version normal">23-24</span> Spring Update Improvements 3</a>
+<a href="./documents/change-log/23-26.html" class="label"><span class="sw-version normal">23-26</span> Spring Update Improvements 3</a>
                                                     
                         </li>
 

--- a/projects/web/static/online-help/src/documents/change-log/23-26.html
+++ b/projects/web/static/online-help/src/documents/change-log/23-26.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- page title -->
-    <title>Change Log - [23-24] Spring Update Improvements 3</title>
+    <title>Change Log - [23-26] Spring Update Improvements 3</title>
     <!-- noscript fallback -->
     <noscript>
         <meta http-equiv="refresh" content="0;url=../../_noscript.html">
@@ -21,7 +21,7 @@
     <script src="./js/shared.js"></script>
     <script src="./js/main.js" defer></script>
 </head>
-<body class="main-grid" data-path="root/change-log/23-24">
+<body class="main-grid" data-path="root/change-log/23-26">
 <!-- menu: location -->
 <div class="main-grid" id="menu-wrapper">
     <label id="menu-location" class="label reverse">
@@ -29,14 +29,14 @@
         <span>/</span>
         <a href="./documents/change-log/index.html">Change Log</a>
         <span>/</span>
-        <a href="./documents/change-log/23-24.html">Spring Update Improvements 3</a>
+        <a href="./documents/change-log/23-26.html">Spring Update Improvements 3</a>
     </label>
 </div>
 <!-- document content -->
 <div id="content-wrapper">
 <main>
     <section>
-        <h2 class="heading secondary"><span class="sw-version">23-24</span> Spring Update Improvements 3</h2>
+        <h2 class="heading secondary"><span class="sw-version">23-26</span> Spring Update Improvements 3</h2>
         <div data-highlight="note">
             <p>This update provides a few additional bug fixes.</p>
         </div>
@@ -52,6 +52,11 @@
             <li>
                 <header>Flanger - Envelope</header>
                 <p>In <span data-keyword="Single">Sounds</span>, the envelope of the Flanger had inconsistent behavior: only when no keys are priorly pressed, the next pressed key should always start the envelope. The mechanism now reworks reliably for both FX groups. In <span data-keyword="Split">Sounds</span>, pressed keys are counted for each <span data-keyword="Part"></span> individually.</p>
+            </li>
+            <li>
+                <header data-detail="Graphical UI">Midi Settings - change detection</header>
+                <p>In order to avoid hanging notes, changing Midi settings <i>(like Send or Receive channels)</i> require that the system resets all notes internally and also propagates the reset externally when Midi send is used.</p>
+                <p>However, this only worked internally and hanging Midi notes were still possible. With this fix, changing Midi settings will lead to an internal and external reset as soon as any <i>(internal or external)</i> note is active.</p>
             </li>
             <li>
                 <header>Documentation - broken links</header>

--- a/projects/web/static/online-help/src/documents/change-log/index.html
+++ b/projects/web/static/online-help/src/documents/change-log/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="./css/shared.css">
     <link rel="stylesheet" href="./css/main.css">
     <!-- document scripts -->
-    <script src="./js/shared.js" data-redirect="./documents/change-log/23-24.html"></script>
+    <script src="./js/shared.js" data-redirect="./documents/change-log/23-26.html"></script>
     <!-- <script src="./js/main.js" defer></script> -->
 </head>
 <body class="main-grid" data-path="root/change-log">


### PR DESCRIPTION
- [x] combined non-official 23-24 documentation into 23-26
- [x] added midi reset behavior to what's new
- [x] bumped version.h

- todo: cherry-pick documentation commit for after merge (main --> next)

- [x] [Revision 1](https://github.com/nonlinear-labs-dev/C15/files/11834629/Change.Log.-.23-26.-.Revision.1.pdf)
- [ ] ok or Revision 2